### PR TITLE
fix: production hardening pass

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,17 @@ export const config = {
 		ttlSeconds: 604800, // 1 week
 	},
 
+	rateLimit: {
+		read: {
+			maxRequests: 120,
+			windowSeconds: 60,
+		},
+		write: {
+			maxRequests: 10,
+			windowSeconds: 60,
+		},
+	},
+
 	matching: {
 		durationTolerance: 2, // ±2 seconds for duration matching
 	},

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export const config = {
 	},
 
 	http: {
-		maxBodyBytes: 6 * 1024 * 1024,
+		maxBodyBytes: 8 * 1024 * 1024,
 	},
 
 	rateLimit: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,10 @@ export const config = {
 		ttlSeconds: 604800, // 1 week
 	},
 
+	http: {
+		maxBodyBytes: 6 * 1024 * 1024,
+	},
+
 	rateLimit: {
 		read: {
 			maxRequests: 120,

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -91,6 +91,7 @@ function createEnv(db: MockDB, cache: MockCache): Env {
 		DB: db as unknown as Env["DB"],
 		CACHE: cache as unknown as Env["CACHE"],
 		RATE_LIMITER: {} as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
 		CACHE_TTL_SECONDS: "300",
 	}
 }

--- a/src/db/votes.test.ts
+++ b/src/db/votes.test.ts
@@ -103,6 +103,7 @@ function createEnv(db: MockDB, cache: MockCache): Env {
 		DB: db as unknown as Env["DB"],
 		CACHE: cache as unknown as Env["CACHE"],
 		RATE_LIMITER: {} as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
 		CACHE_TTL_SECONDS: "300",
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Elysia } from "elysia"
 import { node } from "@elysiajs/node"
 import { cors } from "@elysiajs/cors"
 import { cron } from "@elysiajs/cron"
+import { config } from "@/config"
 import { createEnv } from "@/infra/env"
 import { closePool } from "@/infra/database"
 import { closeRedis } from "@/infra/cache"
@@ -27,6 +28,13 @@ const app = new Elysia({ adapter: node() })
 			maxAge: 86400,
 		})
 	)
+	.onParse(({ request, set }) => {
+		const len = request.headers.get("content-length")
+		if (len && Number(len) > config.http.maxBodyBytes) {
+			set.status = 413
+			return { success: false, error: "Payload too large" }
+		}
+	})
 	.use(
 		cron({
 			name: "score-updater",

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,9 @@ backfillTextSearch(env)
 	.catch((err) => log.error("text search backfill failed", { error: (err as Error).message }))
 
 process.on("unhandledRejection", (reason) => {
-	log.error("unhandled rejection", { error: String(reason) })
+	const err = reason instanceof Error ? reason : new Error(String(reason))
+	log.error("unhandled rejection", { error: err.message, stack: err.stack })
+	flushLogs().finally(() => process.exit(1))
 })
 
 process.on("uncaughtException", (err) => {

--- a/src/infra/cache.test.ts
+++ b/src/infra/cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest"
+import { KVCompat } from "./cache"
+
+function mockRedis() {
+	const store = new Map<string, string>()
+	return {
+		set: vi.fn(async (key: string, value: string, ...args: unknown[]) => {
+			const nx = args.includes("NX")
+			if (nx && store.has(key)) return null
+			store.set(key, value)
+			return "OK"
+		}),
+		get: vi.fn(async (key: string) => store.get(key) ?? null),
+		setex: vi.fn(),
+		del: vi.fn(),
+	}
+}
+
+describe("KVCompat.setNX", () => {
+	it("returns true when key is new", async () => {
+		const kv = new KVCompat(mockRedis() as never)
+		expect(await kv.setNX("k", "v", 60)).toBe(true)
+	})
+
+	it("returns false when key already exists", async () => {
+		const redis = mockRedis()
+		const kv = new KVCompat(redis as never)
+		await kv.setNX("k", "v", 60)
+		expect(await kv.setNX("k", "v", 60)).toBe(false)
+	})
+})

--- a/src/infra/cache.test.ts
+++ b/src/infra/cache.test.ts
@@ -29,3 +29,31 @@ describe("KVCompat.setNX", () => {
 		expect(await kv.setNX("k", "v", 60)).toBe(false)
 	})
 })
+
+describe("KVCompat resilience", () => {
+	const broken = (method: string) => ({
+		[method]: vi.fn(async () => {
+			throw new Error("ECONNRESET")
+		}),
+	})
+
+	it("get returns null when redis throws", async () => {
+		const kv = new KVCompat(broken("get") as never)
+		expect(await kv.get("k")).toBeNull()
+	})
+
+	it("put swallows errors", async () => {
+		const kv = new KVCompat(broken("setex") as never)
+		await expect(kv.put("k", "v", { expirationTtl: 60 })).resolves.toBeUndefined()
+	})
+
+	it("delete swallows errors", async () => {
+		const kv = new KVCompat(broken("del") as never)
+		await expect(kv.delete("k")).resolves.toBeUndefined()
+	})
+
+	it("setNX returns true (fail-open) when redis throws", async () => {
+		const kv = new KVCompat(broken("set") as never)
+		expect(await kv.setNX("k", "v", 60)).toBe(true)
+	})
+})

--- a/src/infra/cache.ts
+++ b/src/infra/cache.ts
@@ -1,4 +1,7 @@
 import Redis from "ioredis"
+import { Logger } from "./logger"
+
+const log = new Logger("cache")
 
 let redis: Redis | null = null
 
@@ -27,23 +30,46 @@ export class KVCompat {
 	}
 
 	async get(key: string): Promise<string | null> {
-		return this.redis.get(key)
+		try {
+			return await this.redis.get(key)
+		} catch (err) {
+			log.warn("cache get failed", { key, error: (err as Error).message })
+			return null
+		}
 	}
 
 	async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
-		if (opts?.expirationTtl) {
-			await this.redis.setex(key, opts.expirationTtl, value)
-		} else {
-			await this.redis.set(key, value)
+		try {
+			if (opts?.expirationTtl) {
+				await this.redis.setex(key, opts.expirationTtl, value)
+			} else {
+				await this.redis.set(key, value)
+			}
+		} catch (err) {
+			log.warn("cache put failed", { key, error: (err as Error).message })
 		}
 	}
 
 	async delete(key: string): Promise<void> {
-		await this.redis.del(key)
+		try {
+			await this.redis.del(key)
+		} catch (err) {
+			log.warn("cache delete failed", { key, error: (err as Error).message })
+		}
 	}
 
+	// Fail-open: brief Redis outages disable nonce replay protection,
+	// but the ±5min timestamp window in isTimestampFresh is the secondary defense.
 	async setNX(key: string, value: string, ttlSeconds: number): Promise<boolean> {
-		const result = await this.redis.set(key, value, "EX", ttlSeconds, "NX")
-		return result === "OK"
+		try {
+			const result = await this.redis.set(key, value, "EX", ttlSeconds, "NX")
+			return result === "OK"
+		} catch (err) {
+			log.warn("cache setNX failed, allowing request", {
+				key,
+				error: (err as Error).message,
+			})
+			return true
+		}
 	}
 }

--- a/src/infra/cache.ts
+++ b/src/infra/cache.ts
@@ -41,4 +41,9 @@ export class KVCompat {
 	async delete(key: string): Promise<void> {
 		await this.redis.del(key)
 	}
+
+	async setNX(key: string, value: string, ttlSeconds: number): Promise<boolean> {
+		const result = await this.redis.set(key, value, "EX", ttlSeconds, "NX")
+		return result === "OK"
+	}
 }

--- a/src/infra/database.ts
+++ b/src/infra/database.ts
@@ -8,7 +8,7 @@ export function getPool(databaseUrl: string): pg.Pool {
 	if (!pool) {
 		pool = new Pool({
 			connectionString: databaseUrl,
-			max: 10,
+			max: 30,
 			idleTimeoutMillis: 30_000,
 			connectionTimeoutMillis: 5_000,
 			allowExitOnIdle: true,

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -1,3 +1,4 @@
+import { config } from "@/config"
 import type { Env } from "@/types"
 import { D1Compat, getPool } from "./database"
 import { KVCompat, getRedis } from "./cache"
@@ -16,7 +17,16 @@ export function createEnv(): Env {
 	return {
 		DB: new D1Compat(pool),
 		CACHE: new KVCompat(redis),
-		RATE_LIMITER: new RedisRateLimiter(redis),
+		RATE_LIMITER: new RedisRateLimiter(
+			redis,
+			config.rateLimit.write.maxRequests,
+			config.rateLimit.write.windowSeconds
+		),
+		READ_RATE_LIMITER: new RedisRateLimiter(
+			redis,
+			config.rateLimit.read.maxRequests,
+			config.rateLimit.read.windowSeconds
+		),
 		CACHE_TTL_SECONDS: process.env.CACHE_TTL_SECONDS || "604800",
 	}
 }

--- a/src/infra/rate-limiter.test.ts
+++ b/src/infra/rate-limiter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest"
+import { RedisRateLimiter } from "./rate-limiter"
+
+describe("RedisRateLimiter", () => {
+	it("fails open when redis throws", async () => {
+		const broken = {
+			incr: vi.fn(async () => {
+				throw new Error("ECONNRESET")
+			}),
+			expire: vi.fn(),
+		}
+		const rl = new RedisRateLimiter(broken as never, 10, 60)
+		expect(await rl.limit({ key: "k" })).toEqual({ success: true })
+	})
+
+	it("allows requests under the limit", async () => {
+		const counter = { n: 0 }
+		const ok = {
+			incr: vi.fn(async () => ++counter.n),
+			expire: vi.fn(),
+		}
+		const rl = new RedisRateLimiter(ok as never, 3, 60)
+		expect((await rl.limit({ key: "k" })).success).toBe(true)
+		expect((await rl.limit({ key: "k" })).success).toBe(true)
+		expect((await rl.limit({ key: "k" })).success).toBe(true)
+		expect((await rl.limit({ key: "k" })).success).toBe(false)
+	})
+})

--- a/src/infra/rate-limiter.ts
+++ b/src/infra/rate-limiter.ts
@@ -1,4 +1,7 @@
 import type Redis from "ioredis"
+import { Logger } from "./logger"
+
+const log = new Logger("cache")
 
 export class RedisRateLimiter {
 	private redis: Redis
@@ -13,10 +16,18 @@ export class RedisRateLimiter {
 
 	async limit(opts: { key: string }): Promise<{ success: boolean }> {
 		const redisKey = `rl:${opts.key}`
-		const count = await this.redis.incr(redisKey)
-		if (count === 1) {
-			await this.redis.expire(redisKey, this.windowSeconds)
+		try {
+			const count = await this.redis.incr(redisKey)
+			if (count === 1) {
+				await this.redis.expire(redisKey, this.windowSeconds)
+			}
+			return { success: count <= this.maxRequests }
+		} catch (err) {
+			log.warn("rate-limit check failed, allowing request", {
+				key: opts.key,
+				error: (err as Error).message,
+			})
+			return { success: true }
 		}
-		return { success: count <= this.maxRequests }
 	}
 }

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -1,6 +1,7 @@
+import type { Env } from "@/types"
 import { describe, expect, it } from "vitest"
 import { config } from "@/config"
-import { calculateScore } from "@/jobs/score-updater"
+import { calculateScore, updateReputations } from "@/jobs/score-updater"
 
 describe("calculateScore", () => {
 	it("returns correct weighted score for equal reputation votes", () => {
@@ -130,6 +131,67 @@ describe("calculateScore", () => {
 		const result = calculateScore(1, votes)
 
 		expect(result.effective_score).toBe(1)
+	})
+})
+
+describe("updateReputations", () => {
+	interface DBCall {
+		sql: string
+		params: unknown[]
+	}
+
+	function createMockEnv(): { env: Env; calls: DBCall[] } {
+		const calls: DBCall[] = []
+		const db = {
+			prepare(sql: string) {
+				let params: unknown[] = []
+				return {
+					bind(...args: unknown[]) {
+						params = args
+						return this
+					},
+					async run() {
+						calls.push({ sql, params })
+					},
+				}
+			},
+		}
+		const env = { DB: db } as unknown as Env
+		return { env, calls }
+	}
+
+	it("issues a single SQL statement (no N+1)", async () => {
+		const { env, calls } = createMockEnv()
+		await updateReputations(env)
+		expect(calls).toHaveLength(1)
+	})
+
+	it("uses a CTE-based UPDATE that joins votes to consensus_lyrics", async () => {
+		const { env, calls } = createMockEnv()
+		await updateReputations(env)
+		const sql = calls[0].sql
+		expect(sql).toMatch(/WITH\s+consensus_lyrics\s+AS/i)
+		expect(sql).toMatch(/JOIN\s+consensus_lyrics/i)
+		expect(sql).toMatch(/UPDATE\s+users/i)
+		expect(sql).toMatch(/GREATEST\(.+LEAST\(/i)
+	})
+
+	it("excludes self-votes from reputation deltas", async () => {
+		const { env, calls } = createMockEnv()
+		await updateReputations(env)
+		expect(calls[0].sql).toMatch(/is_self_vote\s*=\s*0/i)
+	})
+
+	it("binds the configured threshold, delta, min, and max in order", async () => {
+		const { env, calls } = createMockEnv()
+		await updateReputations(env)
+		expect(calls[0].params).toEqual([
+			config.reputation.minVotesForConfidence,
+			config.reputation.consensusDelta,
+			config.reputation.consensusDelta,
+			config.reputation.min,
+			config.reputation.max,
+		])
 	})
 })
 

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -133,38 +133,31 @@ export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsS
 }
 
 async function updateReputations(env: Env): Promise<void> {
-	// Find lyrics with strong consensus (effective_score > 0.5 or < -0.5)
-	const consensusLyrics = await env.DB.prepare(`
-		SELECT id, effective_score FROM lyrics
-		WHERE ABS(effective_score) > 0.5
-		AND vote_count >= ?
+	await env.DB.prepare(`
+		WITH consensus_lyrics AS (
+			SELECT id, CASE WHEN effective_score > 0 THEN 1 ELSE -1 END AS consensus
+			FROM lyrics
+			WHERE ABS(effective_score) > 0.5 AND vote_count >= ?
+		),
+		deltas AS (
+			SELECT v.user_id,
+				SUM(CASE WHEN v.vote = cl.consensus THEN ? ELSE -? END) AS delta
+			FROM votes v
+			JOIN consensus_lyrics cl ON v.lyrics_id = cl.id
+			WHERE v.is_self_vote = 0
+			GROUP BY v.user_id
+		)
+		UPDATE users
+		SET reputation = GREATEST(?, LEAST(?, reputation + d.delta))
+		FROM deltas d
+		WHERE users.id = d.user_id
 	`)
-		.bind(config.reputation.minVotesForConfidence)
-		.all<{ id: number; effective_score: number }>()
-
-	for (const { id, effective_score } of consensusLyrics.results || []) {
-		const consensus = effective_score > 0 ? 1 : -1
-
-		// Get all non-self votes for this lyrics
-		const votes = await env.DB.prepare(`
-			SELECT user_id, vote FROM votes
-			WHERE lyrics_id = ? AND is_self_vote = 0
-		`)
-			.bind(id)
-			.all<{ user_id: number; vote: number }>()
-
-		for (const { user_id, vote } of votes.results || []) {
-			const votedWithConsensus = vote === consensus
-			const delta = votedWithConsensus
-				? config.reputation.consensusDelta
-				: -config.reputation.consensusDelta
-
-			await env.DB.prepare(`
-				UPDATE users SET reputation = MAX(?, MIN(?, reputation + ?))
-				WHERE id = ?
-			`)
-				.bind(config.reputation.min, config.reputation.max, delta, user_id)
-				.run()
-		}
-	}
+		.bind(
+			config.reputation.minVotesForConfidence,
+			config.reputation.consensusDelta,
+			config.reputation.consensusDelta,
+			config.reputation.min,
+			config.reputation.max
+		)
+		.run()
 }

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -132,7 +132,7 @@ export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsS
 	}
 }
 
-async function updateReputations(env: Env): Promise<void> {
+export async function updateReputations(env: Env): Promise<void> {
 	await env.DB.prepare(`
 		WITH consensus_lyrics AS (
 			SELECT id, CASE WHEN effective_score > 0 THEN 1 ELSE -1 END AS consensus

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -3,6 +3,7 @@ import { getGlobalFeed, getPersonalizedFeed } from "@/db/feed"
 import { getUserVotesForIds } from "@/db/votes"
 import { config } from "@/config"
 import type { Env, FeedItem } from "@/types"
+import { readRateLimit } from "@/utils/read-rate-limit"
 
 export function toFeedResponse(row: FeedItem) {
 	return {
@@ -27,6 +28,7 @@ export function toFeedResponse(row: FeedItem) {
 export const feedRoutes = (env: Env) =>
 	new Elysia({ prefix: "/feed" })
 		.decorate("env", env)
+		.use(readRateLimit)
 		.derive({ as: "scoped" }, async ({ headers, env }) => {
 			const keyId = headers["x-key-id"]
 			if (!keyId) return { feedUserId: null as number | null }

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -15,6 +15,7 @@ import { toFeedResponse } from "@/routes/feed"
 import { toResponse, toSearchResponse } from "@/routes/lyrics.transformers"
 import type { Env, LyricsSubmission } from "@/types"
 import { signedRequest } from "@/utils/auth"
+import { readRateLimit } from "@/utils/read-rate-limit"
 import { Elysia, t } from "elysia"
 
 const log = new Logger("app")
@@ -22,6 +23,7 @@ const log = new Logger("app")
 export const lyricsRoutes = (env: Env) =>
 	new Elysia({ prefix: "/lyrics" })
 		.decorate("env", env)
+		.use(readRateLimit)
 		.derive({ as: "scoped" }, async ({ headers, env }) => {
 			const keyId = headers["x-key-id"]
 			if (!keyId) return { lyricsUserId: null as number | null }

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia"
+import { config } from "@/config"
 import { getLyricsById } from "@/db/lyrics"
 import { submitReport } from "@/db/reports"
 import { castVote, removeVote } from "@/db/votes"
@@ -79,6 +80,9 @@ export const voteRoutes = (env: Env) =>
 
 				const details =
 					typeof signedPayload.details === "string" ? signedPayload.details : undefined
+				if (details && details.length > config.validation.report.maxDetailsLength) {
+					return status(400, { success: false, error: "Report details too long" })
+				}
 
 				const result = await submitReport(env, id, userId, {
 					reason: reason as "wrong_song" | "bad_sync" | "offensive" | "spam" | "other",

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Env {
 	DB: D1Compat
 	CACHE: KVCompat
 	RATE_LIMITER: RedisRateLimiter
+	READ_RATE_LIMITER: RedisRateLimiter
 	CACHE_TTL_SECONDS: string
 }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -60,15 +60,12 @@ export const signedRequest = new Elysia({ name: "signed-request" }).derive(
 			throw new Error("Request timestamp expired")
 		}
 
-		// Check for nonce replay attacks
 		const nonceKey = `nonce:${payload.keyId}:${payload.nonce}`
-		const existingNonce = await env.CACHE.get(nonceKey)
-		if (existingNonce) {
+		const claimed = await env.CACHE.setNX(nonceKey, "1", 300)
+		if (!claimed) {
 			log.warn("nonce replay attempt", { keyId: payload.keyId })
 			throw new Error("Nonce already used")
 		}
-		// Store nonce immediately to close the race window (TTL: 5 minutes = 300 seconds)
-		await env.CACHE.put(nonceKey, "1", { expirationTtl: 300 })
 
 		let keyRecord = await getPublicKey(env, payload.keyId)
 

--- a/src/utils/read-rate-limit.test.ts
+++ b/src/utils/read-rate-limit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { clientIp } from "./read-rate-limit"
+
+describe("clientIp", () => {
+	it("uses first hop of X-Forwarded-For", () => {
+		expect(clientIp({ "x-forwarded-for": "1.2.3.4" })).toBe("1.2.3.4")
+	})
+
+	it("strips whitespace and takes left-most when XFF has multiple hops", () => {
+		expect(clientIp({ "x-forwarded-for": "  1.2.3.4 , 10.0.0.1, 172.16.0.1" })).toBe("1.2.3.4")
+	})
+
+	it("falls back to X-Real-IP when XFF is absent", () => {
+		expect(clientIp({ "x-real-ip": "5.6.7.8" })).toBe("5.6.7.8")
+	})
+
+	it("prefers X-Forwarded-For over X-Real-IP when both present", () => {
+		expect(clientIp({ "x-forwarded-for": "1.2.3.4", "x-real-ip": "9.9.9.9" })).toBe("1.2.3.4")
+	})
+
+	it("returns 'unknown' when neither header is set", () => {
+		expect(clientIp({})).toBe("unknown")
+	})
+
+	it("returns 'unknown' for explicitly undefined values", () => {
+		expect(clientIp({ "x-forwarded-for": undefined, "x-real-ip": undefined })).toBe("unknown")
+	})
+})

--- a/src/utils/read-rate-limit.ts
+++ b/src/utils/read-rate-limit.ts
@@ -1,7 +1,7 @@
 import { Elysia } from "elysia"
 import type { Env } from "@/types"
 
-function clientIp(headers: Record<string, string | undefined>): string {
+export function clientIp(headers: Record<string, string | undefined>): string {
 	const xff = headers["x-forwarded-for"]
 	if (xff) return xff.split(",")[0].trim()
 	const real = headers["x-real-ip"]

--- a/src/utils/read-rate-limit.ts
+++ b/src/utils/read-rate-limit.ts
@@ -1,0 +1,23 @@
+import { Elysia } from "elysia"
+import type { Env } from "@/types"
+
+function clientIp(headers: Record<string, string | undefined>): string {
+	const xff = headers["x-forwarded-for"]
+	if (xff) return xff.split(",")[0].trim()
+	const real = headers["x-real-ip"]
+	if (real) return real
+	return "unknown"
+}
+
+export const readRateLimit = new Elysia({ name: "read-rate-limit" }).onBeforeHandle(
+	{ as: "scoped" },
+	async (ctx) => {
+		const env = (ctx as unknown as { env: Env }).env
+		const ip = clientIp(ctx.headers as Record<string, string | undefined>)
+		const { success } = await env.READ_RATE_LIMITER.limit({ key: `ip:${ip}` })
+		if (!success) {
+			ctx.set.status = 429
+			return { success: false, error: "Rate limited. Try again later." }
+		}
+	}
+)


### PR DESCRIPTION
## Overview

- Auth/abuse: atomic nonce check (`SET NX EX`) replaces a non-atomic get-then-put. 8 MB body cap via `onParse` so a 1 GB POST can't OOM the container. `report.details` length finally honors the config value (it was defined and never read). Per-IP rate limit (120/min) on read endpoints; search, feed, and lookup were unprotected.
- Reliability: Redis ops fail open with warning logs. Cache reads return null on error, writes swallow, nonce check warns and allows through (the 5-min timestamp window is the fallback). PG pool max 10 → 30. `unhandledRejection` now exits, matching `uncaughtException`, so Railway can restart.
- Cron perf: `updateReputations` is one CTE `UPDATE` instead of N+M round trips. Behavioral note: deltas sum per user before clamping to `[min, max]`, where the old code clamped after each individual vote. Different at the reputation cap, mathematically more correct.
- Tests added for `clientIp` parsing edge cases and the `updateReputations` SQL shape.