### PR TITLE
Feat/structured submission errors

### DIFF
--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -786,7 +786,7 @@ describe("POST /lyrics/submit formatted-TTML rejection", () => {
 		}
 		expect(body.success).toBe(false)
 		expect(body.code).toBe("TTML_FORMATTED")
-		expect(body.error).toBe("TTML formatting issue")
+		expect(body.error).toBe("Formatted TTML")
 		expect(body.hint).toMatch(/line breaks/i)
 		expect(db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))).toBeUndefined()
 	})
@@ -962,7 +962,7 @@ describe("POST /lyrics/submit formatted-TTML rejection", () => {
 		})
 		const body = (await res.json()) as { error: string; hint: string; code: string }
 		expect(body.code).toBe("TTML_FORMATTED")
-		expect(body.error).toBe("TTML formatting issue")
+		expect(body.error).toBe("Formatted TTML")
 		expect(body.hint.length).toBeGreaterThan(40)
 	})
 

--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -494,37 +494,37 @@ describe("GET /lyrics/mine", () => {
 	})
 })
 
+const FORMAT_PARAM_INDEX = 10
+const SYNC_TYPE_PARAM_INDEX = 12
+
+function seedSubmitDB(keyId: string, publicJwk: JsonWebKey) {
+	return makeMockDB([
+		{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 },
+		{ id: 7, key_id: keyId },
+		{ count: 0 },
+		{ id: 99 },
+	])
+}
+
+async function submit(
+	body: Record<string, unknown>
+): Promise<{ res: Response; db: ReturnType<typeof makeMockDB> }> {
+	const keyPair = await generateKeyPair()
+	const publicJwk = await exportPublicJwk(keyPair)
+	const keyId = await hashPublicKey(publicJwk)
+	const db = seedSubmitDB(keyId, publicJwk)
+	const env = makeEnv(db)
+	const app = lyricsRoutes(env)
+	const req = await buildSubmitRequest(keyPair, keyId, body)
+	const res = await app.handle(req)
+	return { res, db }
+}
+
+function findInsert(db: ReturnType<typeof makeMockDB>): DBCall | undefined {
+	return db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
+}
+
 describe("POST /lyrics/submit format override", () => {
-	const FORMAT_PARAM_INDEX = 10
-	const SYNC_TYPE_PARAM_INDEX = 12
-
-	function seedSubmitDB(keyId: string, publicJwk: JsonWebKey) {
-		return makeMockDB([
-			{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 },
-			{ id: 7, key_id: keyId },
-			{ count: 0 },
-			{ id: 99 },
-		])
-	}
-
-	async function submit(
-		body: Record<string, unknown>
-	): Promise<{ res: Response; db: ReturnType<typeof makeMockDB> }> {
-		const keyPair = await generateKeyPair()
-		const publicJwk = await exportPublicJwk(keyPair)
-		const keyId = await hashPublicKey(publicJwk)
-		const db = seedSubmitDB(keyId, publicJwk)
-		const env = makeEnv(db)
-		const app = lyricsRoutes(env)
-		const req = await buildSubmitRequest(keyPair, keyId, body)
-		const res = await app.handle(req)
-		return { res, db }
-	}
-
-	function findInsert(db: ReturnType<typeof makeMockDB>): DBCall | undefined {
-		return db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
-	}
-
 	it("overrides plain claim with ttml when content is well-formed TTML", async () => {
 		const { res, db } = await submit({
 			videoId: "abc123",
@@ -762,5 +762,121 @@ describe("POST /lyrics/submit format override", () => {
 		expect(body.code).toBe("TTML_MALFORMED")
 		expect(typeof body.hint).toBe("string")
 		expect(body.hint.length).toBeGreaterThan(40)
+	})
+})
+
+describe("POST /lyrics/submit formatted-TTML rejection", () => {
+	it("rejects pretty-printed TTML with newlines between span siblings", async () => {
+		const formatted =
+			'<tt><body><div><p begin="0:00.0" end="0:02.0">\n  <span begin="0:00.0" end="0:01.0">Hello</span>\n  <span begin="0:01.0" end="0:02.0">world</span>\n</p></div></body></tt>'
+		const { res, db } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: formatted,
+			format: "ttml",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as {
+			success: boolean
+			code: string
+			error: string
+			hint: string
+		}
+		expect(body.success).toBe(false)
+		expect(body.code).toBe("TTML_FORMATTED")
+		expect(body.error).toBe("TTML formatting issue")
+		expect(body.hint).toMatch(/line breaks/i)
+		expect(db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))).toBeUndefined()
+	})
+
+	it("rejects row-69 shape with a trailing-whitespace-specific hint", async () => {
+		const row69Like =
+			'<tt><body><div><p begin="0:00.0" end="0:01.0">' +
+			'<span begin="0:00.0" end="0:01.0">Focus </span>' +
+			'<span begin="0:01.0" end="0:02.0">Aim</span>' +
+			"</p></div></body></tt>"
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: row69Like,
+			format: "ttml",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as { code: string; hint: string }
+		expect(body.code).toBe("TTML_FORMATTED")
+		expect(body.hint).toMatch(/end/i)
+	})
+
+	it("rejects leading-whitespace-in-span with a leading-specific hint", async () => {
+		const leading =
+			'<tt><body><div><p begin="0:00.0" end="0:02.0">' +
+			'<span begin="0:00.0" end="0:01.0">Hello</span>' +
+			'<span begin="0:01.0" end="0:02.0"> world</span>' +
+			"</p></div></body></tt>"
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: leading,
+			format: "ttml",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as { code: string; hint: string }
+		expect(body.code).toBe("TTML_FORMATTED")
+		expect(body.hint).toMatch(/start with/i)
+	})
+
+	it("accepts clean single-line word-synced TTML (regression guard)", async () => {
+		const clean =
+			"<tt><body><div>" +
+			'<p begin="0:00.0" end="0:02.0">' +
+			'<span begin="0:00.0" end="0:01.0">Hello</span> ' +
+			'<span begin="0:01.0" end="0:02.0">world</span>' +
+			"</p></div></body></tt>"
+		const { res, db } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: clean,
+			format: "ttml",
+		})
+		expect(res.status).toBe(201)
+		expect(db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))).toBeDefined()
+	})
+
+	it("accepts TTML with newlines between <p> siblings (line-level pretty-print OK)", async () => {
+		const lineLevel =
+			"<tt><body><div>\n" +
+			'<p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:01.0">Hi</span> <span begin="0:01.0" end="0:02.0">there</span></p>\n' +
+			'<p begin="0:02.0" end="0:04.0"><span begin="0:02.0" end="0:03.0">More</span> <span begin="0:03.0" end="0:04.0">words</span></p>\n' +
+			"</div></body></tt>"
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: lineLevel,
+			format: "ttml",
+		})
+		expect(res.status).toBe(201)
+	})
+
+	it("does not gate non-ttml submissions", async () => {
+		const lrc = "[00:01.00]Hello\n[00:03.00]World"
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: lrc,
+			format: "lrc",
+		})
+		expect(res.status).toBe(201)
 	})
 })

--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -916,4 +916,113 @@ describe("POST /lyrics/submit formatted-TTML rejection", () => {
 		expect(body.code).toBe("TTML_FORMATTED")
 		expect(body.hint).toMatch(/line breaks/i)
 	})
+
+	it("rejects pretty-printed TTML carried in a format=plain claim with no DB write", async () => {
+		const formatted =
+			'<tt><body><div><p>\n<span begin="0:00.0" end="0:01.0">Hi</span>\n<span begin="0:01.0" end="0:02.0">there</span>\n</p></div></body></tt>'
+		const { res, db } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: formatted,
+			format: "plain",
+		})
+		expect(res.status).toBe(400)
+		expect(db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))).toBeUndefined()
+		expect(db.calls.find((c) => /UPDATE lyrics/i.test(c.sql))).toBeUndefined()
+	})
+
+	it("malformed-TTML gate fires before formatted-TTML gate when both would apply", async () => {
+		const both =
+			'<tt><body><div><p>\n<span begin="0:00.0" end="0:01.0">Hi</span>\n<span begin="0:01.0" end="0:02.0">there</span>\n</p></div></body>'
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: both,
+			format: "ttml",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as { code: string }
+		expect(body.code).toBe("TTML_MALFORMED")
+	})
+
+	it("rejects with the canonical TTML_FORMATTED error string", async () => {
+		const formatted =
+			'<tt><body><div><p>\n<span begin="0:00.0" end="0:01.0">Hi</span>\n<span begin="0:01.0" end="0:02.0">there</span>\n</p></div></body></tt>'
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: formatted,
+			format: "ttml",
+		})
+		const body = (await res.json()) as { error: string; hint: string; code: string }
+		expect(body.code).toBe("TTML_FORMATTED")
+		expect(body.error).toBe("TTML formatting issue")
+		expect(body.hint.length).toBeGreaterThan(40)
+	})
+
+	it("each reason returns a distinct, non-empty hint", async () => {
+		const interSpan =
+			'<tt><body><div><p>\n<span begin="0:00.0" end="0:01.0">a</span>\n<span begin="0:01.0" end="0:02.0">b</span>\n</p></div></body></tt>'
+		const trailing =
+			'<tt><body><div><p><span begin="0:00.0" end="0:01.0">a </span><span begin="0:01.0" end="0:02.0">b</span></p></div></body></tt>'
+		const leading =
+			'<tt><body><div><p><span begin="0:00.0" end="0:01.0">a</span><span begin="0:01.0" end="0:02.0"> b</span></p></div></body></tt>'
+
+		const results = await Promise.all(
+			[interSpan, trailing, leading].map((lyrics) =>
+				submit({
+					videoId: "abc",
+					song: "S",
+					artist: "A",
+					duration: 100,
+					lyrics,
+					format: "ttml",
+				}),
+			),
+		)
+		const hints = await Promise.all(results.map(({ res }) => res.json() as Promise<{ hint: string }>))
+		expect(new Set(hints.map((h) => h.hint)).size).toBe(3)
+	})
+
+	it("accepts adjacent-syllable spans without inter-span whitespace (regression guard)", async () => {
+		const ttml =
+			'<tt><body><div><p>' +
+			'<span begin="0:00.0" end="0:00.5">Hel</span>' +
+			'<span begin="0:00.5" end="0:01.0">lo</span>' +
+			'</p></div></body></tt>'
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: ttml,
+			format: "ttml",
+		})
+		expect(res.status).toBe(201)
+	})
+
+	it("accepts background-span container with clean inner spans", async () => {
+		const ttml =
+			'<tt><body><div><p>' +
+			'<span begin="0:00.0" end="0:01.0">Main</span> ' +
+			'<span ttm:role="x-bg">' +
+			'<span begin="0:00.5" end="0:01.0">bg</span>' +
+			'</span>' +
+			'</p></div></body></tt>'
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: ttml,
+			format: "ttml",
+		})
+		expect(res.status).toBe(201)
+	})
 })

--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest"
 import type { Env, FeedItem } from "@/types"
 import { canonicalJson, hashPublicKey } from "@/utils/crypto"
+import { describe, expect, it } from "vitest"
 import { lyricsRoutes } from "./lyrics"
 
 const baseFeedItem: FeedItem = {

--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -879,4 +879,41 @@ describe("POST /lyrics/submit formatted-TTML rejection", () => {
 		})
 		expect(res.status).toBe(201)
 	})
+
+	it("triggers on pretty-printed TTML content even when claim is plain", async () => {
+		const formatted =
+			'<tt><body><div><p begin="0:00.0" end="0:02.0">\n  <span begin="0:00.0" end="0:01.0">Hello</span>\n  <span begin="0:01.0" end="0:02.0">world</span>\n</p></div></body></tt>'
+		const { res, db } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: formatted,
+			format: "plain",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as { code: string }
+		expect(body.code).toBe("TTML_FORMATTED")
+		expect(db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))).toBeUndefined()
+	})
+
+	it("prefers inter-span-newline hint over trailing-whitespace when both are present", async () => {
+		const both =
+			'<tt><body><div><p begin="0:00.0" end="0:02.0">\n' +
+			'<span begin="0:00.0" end="0:01.0">Focus </span>\n' +
+			'<span begin="0:01.0" end="0:02.0">Aim </span>\n' +
+			"</p></div></body></tt>"
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: both,
+			format: "ttml",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as { code: string; hint: string }
+		expect(body.code).toBe("TTML_FORMATTED")
+		expect(body.hint).toMatch(/line breaks/i)
+	})
 })

--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -619,9 +619,9 @@ describe("POST /lyrics/submit format override", () => {
 		})
 
 		expect(res.status).toBe(400)
-		const body = (await res.json()) as { success: boolean; error: string }
+		const body = (await res.json()) as { success: boolean; error: string; code: string }
 		expect(body.success).toBe(false)
-		expect(body.error).toMatch(/malformed ttml/i)
+		expect(body.code).toBe("TTML_MALFORMED")
 		expect(findInsert(db)).toBeUndefined()
 	})
 
@@ -739,5 +739,28 @@ describe("POST /lyrics/submit format override", () => {
 		const insert = findInsert(db)
 		expect(insert?.params[FORMAT_PARAM_INDEX]).toBe("ttml")
 		expect(insert?.params[SYNC_TYPE_PARAM_INDEX]).toBe("richsync")
+	})
+
+	it("4xx submission responses carry code, error, and hint fields", async () => {
+		const { res } = await submit({
+			videoId: "abc",
+			song: "S",
+			artist: "A",
+			duration: 100,
+			lyrics: "<tt><body><div><p>x",
+			format: "ttml",
+		})
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as {
+			success: boolean
+			error: string
+			code: string
+			hint: string
+		}
+		expect(body.success).toBe(false)
+		expect(typeof body.error).toBe("string")
+		expect(body.code).toBe("TTML_MALFORMED")
+		expect(typeof body.hint).toBe("string")
+		expect(body.hint.length).toBeGreaterThan(40)
 	})
 })

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -162,7 +162,12 @@ export const lyricsRoutes = (env: Env) =>
 				const limit = Math.min(Math.max(1, Number.isNaN(parsed) ? 10 : parsed), 50)
 				const results = await findVariantsByVideoId(env, params.videoId, limit)
 				if (results.length === 0) {
-					return status(404, buildError(ErrorCode.NOT_FOUND))
+					return status(
+						404,
+						buildError(ErrorCode.NOT_FOUND, {
+							error: "No lyrics found for this video",
+						})
+					)
 				}
 				return { success: true, data: results.map(toResponse) }
 			},

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -17,7 +17,7 @@ import { toFeedResponse } from "@/routes/feed"
 import { toResponse, toSearchResponse } from "@/routes/lyrics.transformers"
 import type { Env, LyricsSubmission } from "@/types"
 import { signedRequest } from "@/utils/auth"
-import { buildError, ErrorCode } from "@/utils/errors"
+import { ErrorCode, buildError } from "@/utils/errors"
 import { readRateLimit } from "@/utils/read-rate-limit"
 import {
 	detectFormat,
@@ -137,9 +137,12 @@ export const lyricsRoutes = (env: Env) =>
 					return { success: true, data: results.map(toResponse) }
 				}
 
-				return status(400, buildError(ErrorCode.MISSING_QUERY, {
-					hint: "Provide 'q' for fuzzy search, or both 'song' and 'artist' for exact match.",
-				}))
+				return status(
+					400,
+					buildError(ErrorCode.MISSING_QUERY, {
+						hint: "Provide 'q' for fuzzy search, or both 'song' and 'artist' for exact match.",
+					})
+				)
 			},
 			{
 				query: t.Object({
@@ -181,9 +184,7 @@ export const lyricsRoutes = (env: Env) =>
 				const limit = Math.min(Math.max(1, Number.isNaN(parsed) ? 20 : parsed), 50)
 
 				const parsedCursor = query.cursor ? Number(query.cursor) : 0
-				const offset = Number.isFinite(parsedCursor)
-					? Math.floor(Math.max(0, parsedCursor))
-					: 0
+				const offset = Number.isFinite(parsedCursor) ? Math.floor(Math.max(0, parsedCursor)) : 0
 
 				const filters = parseFeedFilters(query)
 

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -141,9 +141,7 @@ export const lyricsRoutes = (env: Env) =>
 				const limit = Math.min(Math.max(1, Number.isNaN(parsed) ? 10 : parsed), 50)
 				const results = await findVariantsByVideoId(env, params.videoId, limit)
 				if (results.length === 0) {
-					return status(404, buildError(ErrorCode.NOT_FOUND, {
-						error: "No lyrics found for this video",
-					}))
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 				return { success: true, data: results.map(toResponse) }
 			},

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -19,7 +19,12 @@ import type { Env, LyricsSubmission } from "@/types"
 import { signedRequest } from "@/utils/auth"
 import { buildError, ErrorCode } from "@/utils/errors"
 import { readRateLimit } from "@/utils/read-rate-limit"
-import { detectFormat, detectSyncType, validateTtmlStructure } from "@/utils/validation"
+import {
+	detectFormat,
+	detectPrettyPrintedTtml,
+	detectSyncType,
+	validateTtmlStructure,
+} from "@/utils/validation"
 import { Elysia, t } from "elysia"
 
 const log = new Logger("app")
@@ -33,6 +38,19 @@ function parseDuration(raw: string | undefined): number | undefined {
 		return undefined
 	}
 	return rounded
+}
+
+function prettyPrintHint(
+	reason: "inter-span-newline" | "span-trailing-whitespace" | "span-leading-whitespace"
+): string {
+	switch (reason) {
+		case "inter-span-newline":
+			return "The TTML file has line breaks between word tags, which throws off the word-by-word timing. Try re-exporting without auto-formatting."
+		case "span-trailing-whitespace":
+			return "Some words in the TTML have extra spaces tacked onto the end, which throws off the highlighting. Try re-exporting from a clean source."
+		case "span-leading-whitespace":
+			return "Some words in the TTML start with extra spaces, which throws off the highlighting. Try re-exporting from a clean source."
+	}
 }
 
 export const lyricsRoutes = (env: Env) =>
@@ -281,6 +299,23 @@ export const lyricsRoutes = (env: Env) =>
 					claimed: claimedFormat,
 					detected: format,
 				})
+			}
+
+			if (format === "ttml") {
+				const prettyCheck = detectPrettyPrintedTtml(lyricsContent)
+				if (!prettyCheck.ok) {
+					log.warn("rejecting pretty-printed ttml", {
+						keyId,
+						videoId: p.videoId as string,
+						reason: prettyCheck.reason,
+					})
+					return status(
+						400,
+						buildError(ErrorCode.TTML_FORMATTED, {
+							hint: prettyPrintHint(prettyCheck.reason),
+						})
+					)
+				}
 			}
 
 			const detectedSyncType = detectSyncType(lyricsContent, format)

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -17,6 +17,7 @@ import { toFeedResponse } from "@/routes/feed"
 import { toResponse, toSearchResponse } from "@/routes/lyrics.transformers"
 import type { Env, LyricsSubmission } from "@/types"
 import { signedRequest } from "@/utils/auth"
+import { buildError, ErrorCode } from "@/utils/errors"
 import { readRateLimit } from "@/utils/read-rate-limit"
 import { detectFormat, detectSyncType, validateTtmlStructure } from "@/utils/validation"
 import { Elysia, t } from "elysia"
@@ -52,7 +53,7 @@ export const lyricsRoutes = (env: Env) =>
 				if (query.v) {
 					const result = await findByVideoId(env, query.v)
 					if (!result) {
-						return status(404, { success: false, error: "Lyrics not found" })
+						return status(404, buildError(ErrorCode.NOT_FOUND))
 					}
 					const userVote = lyricsUserId ? await getUserVote(env, result.id, lyricsUserId) : null
 					return { success: true, data: { ...toResponse(result), userVote } }
@@ -68,16 +69,13 @@ export const lyricsRoutes = (env: Env) =>
 						query.album
 					)
 					if (!result) {
-						return status(404, { success: false, error: "Lyrics not found" })
+						return status(404, buildError(ErrorCode.NOT_FOUND))
 					}
 					const userVote = lyricsUserId ? await getUserVote(env, result.id, lyricsUserId) : null
 					return { success: true, data: { ...toResponse(result), userVote } }
 				}
 
-				return status(400, {
-					success: false,
-					error: "Provide either 'v' (videoId) or 'song' + 'artist'",
-				})
+				return status(400, buildError(ErrorCode.MISSING_QUERY))
 			},
 			{
 				query: t.Object({
@@ -121,10 +119,9 @@ export const lyricsRoutes = (env: Env) =>
 					return { success: true, data: results.map(toResponse) }
 				}
 
-				return status(400, {
-					success: false,
-					error: "Provide 'q' for fuzzy search, or 'song' + 'artist' for exact match",
-				})
+				return status(400, buildError(ErrorCode.MISSING_QUERY, {
+					hint: "Provide 'q' for fuzzy search, or both 'song' and 'artist' for exact match.",
+				}))
 			},
 			{
 				query: t.Object({
@@ -144,7 +141,9 @@ export const lyricsRoutes = (env: Env) =>
 				const limit = Math.min(Math.max(1, Number.isNaN(parsed) ? 10 : parsed), 50)
 				const results = await findVariantsByVideoId(env, params.videoId, limit)
 				if (results.length === 0) {
-					return status(404, { success: false, error: "No lyrics found for this video" })
+					return status(404, buildError(ErrorCode.NOT_FOUND, {
+						error: "No lyrics found for this video",
+					}))
 				}
 				return { success: true, data: results.map(toResponse) }
 			},
@@ -159,7 +158,7 @@ export const lyricsRoutes = (env: Env) =>
 			"/mine",
 			async ({ query, env, lyricsUserId, status }) => {
 				if (!lyricsUserId) {
-					return status(401, { success: false, error: "Authentication required" })
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
 				}
 
 				const parsed = query.limit ? Number(query.limit) : 20
@@ -209,12 +208,12 @@ export const lyricsRoutes = (env: Env) =>
 			async ({ params, env, lyricsUserId, status }) => {
 				const id = Number(params.id)
 				if (Number.isNaN(id)) {
-					return status(400, { success: false, error: "Invalid ID" })
+					return status(400, buildError(ErrorCode.INVALID_ID))
 				}
 
 				const result = await getLyricsById(env, id)
 				if (!result) {
-					return status(404, { success: false, error: "Lyrics not found" })
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 
 				const userVote = lyricsUserId ? await getUserVote(env, result.id, lyricsUserId) : null
@@ -228,7 +227,7 @@ export const lyricsRoutes = (env: Env) =>
 		.post("/submit", async ({ env, keyId, userId, signedPayload, status }) => {
 			const { success } = await env.RATE_LIMITER.limit({ key: keyId })
 			if (!success) {
-				return status(429, { success: false, error: "Rate limited. Try again later." })
+				return status(429, buildError(ErrorCode.RATE_LIMITED))
 			}
 
 			const p = signedPayload
@@ -245,23 +244,23 @@ export const lyricsRoutes = (env: Env) =>
 				typeof p.format !== "string" ||
 				!["ttml", "lrc", "plain"].includes(p.format)
 			) {
-				return status(400, { success: false, error: "Invalid submission payload" })
+				return status(400, buildError(ErrorCode.INVALID_PAYLOAD))
 			}
 
 			if ((p.song as string).length > config.validation.song.maxLength) {
-				return status(400, { success: false, error: "Song name too long" })
+				return status(400, buildError(ErrorCode.SONG_TOO_LONG))
 			}
 			if ((p.artist as string).length > config.validation.artist.maxLength) {
-				return status(400, { success: false, error: "Artist name too long" })
+				return status(400, buildError(ErrorCode.ARTIST_TOO_LONG))
 			}
 			if ((p.lyrics as string).length > config.validation.ttml.maxSizeBytes) {
-				return status(400, { success: false, error: "Lyrics content too large" })
+				return status(400, buildError(ErrorCode.PAYLOAD_TOO_LARGE))
 			}
 			if (
 				(p.duration as number) < config.validation.duration.min ||
 				(p.duration as number) > config.validation.duration.max
 			) {
-				return status(400, { success: false, error: "Invalid duration" })
+				return status(400, buildError(ErrorCode.INVALID_DURATION))
 			}
 
 			const claimedFormat = p.format as "ttml" | "lrc" | "plain"
@@ -272,7 +271,7 @@ export const lyricsRoutes = (env: Env) =>
 					keyId,
 					videoId: p.videoId as string,
 				})
-				return status(400, { success: false, error: "Malformed TTML content" })
+				return status(400, buildError(ErrorCode.TTML_MALFORMED))
 			}
 
 			const format = detectFormat(lyricsContent)
@@ -319,11 +318,7 @@ export const lyricsRoutes = (env: Env) =>
 			const result = await submitLyrics(env, submission, userId)
 
 			if (!result.created) {
-				return status(409, {
-					success: false,
-					error:
-						"You've reached the maximum active variants for this video. Delete one of your existing variants to submit another.",
-				})
+				return status(409, buildError(ErrorCode.VARIANT_CAP_REACHED))
 			}
 
 			return status(201, {
@@ -336,7 +331,7 @@ export const lyricsRoutes = (env: Env) =>
 			async ({ params, env, userId, status }) => {
 				const id = Number(params.id)
 				if (Number.isNaN(id)) {
-					return status(400, { success: false, error: "Invalid ID" })
+					return status(400, buildError(ErrorCode.INVALID_ID))
 				}
 
 				const result = await softDeleteLyrics(env, id, userId, "submitter")
@@ -345,9 +340,9 @@ export const lyricsRoutes = (env: Env) =>
 					return { success: true }
 				}
 				if (result.reason === "forbidden") {
-					return status(403, { success: false, error: "Not your submission" })
+					return status(403, buildError(ErrorCode.NOT_OWNER))
 				}
-				return status(404, { success: false, error: "Lyrics not found" })
+				return status(404, buildError(ErrorCode.NOT_FOUND))
 			},
 			{ params: t.Object({ id: t.String() }) }
 		)

--- a/src/routes/requests.ts
+++ b/src/routes/requests.ts
@@ -4,6 +4,7 @@ import { createRequest } from "@/db/requests"
 import { getUserById } from "@/db/users"
 import type { Env } from "@/types"
 import { signedRequest } from "@/utils/auth"
+import { ErrorCode, buildError } from "@/utils/errors"
 
 export const requestRoutes = (env: Env) =>
 	new Elysia({ prefix: "/requests" })
@@ -12,7 +13,7 @@ export const requestRoutes = (env: Env) =>
 		.post("/", async ({ env, keyId, userId, signedPayload, status }) => {
 			const { success } = await env.RATE_LIMITER.limit({ key: keyId })
 			if (!success) {
-				return status(429, { success: false, error: "Rate limited. Try again later." })
+				return status(429, buildError(ErrorCode.RATE_LIMITED))
 			}
 
 			const p = signedPayload
@@ -24,14 +25,17 @@ export const requestRoutes = (env: Env) =>
 				typeof p.artist !== "string" ||
 				!p.artist
 			) {
-				return status(400, { success: false, error: "Invalid request payload" })
+				return status(
+					400,
+					buildError(ErrorCode.INVALID_PAYLOAD, { error: "Invalid request payload" })
+				)
 			}
 
 			if (p.song.length > config.validation.song.maxLength) {
-				return status(400, { success: false, error: "Song name too long" })
+				return status(400, buildError(ErrorCode.SONG_TOO_LONG))
 			}
 			if (p.artist.length > config.validation.artist.maxLength) {
-				return status(400, { success: false, error: "Artist name too long" })
+				return status(400, buildError(ErrorCode.ARTIST_TOO_LONG))
 			}
 
 			const thumbnailUrl =

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -5,6 +5,7 @@ import { submitReport } from "@/db/reports"
 import { castVote, removeVote } from "@/db/votes"
 import type { Env } from "@/types"
 import { signedRequest } from "@/utils/auth"
+import { ErrorCode, buildError } from "@/utils/errors"
 
 export const voteRoutes = (env: Env) =>
 	new Elysia({ prefix: "/lyrics" })
@@ -15,17 +16,17 @@ export const voteRoutes = (env: Env) =>
 			async ({ params, env, userId, signedPayload, status }) => {
 				const id = Number(params.id)
 				if (Number.isNaN(id)) {
-					return status(400, { success: false, error: "Invalid ID" })
+					return status(400, buildError(ErrorCode.INVALID_ID))
 				}
 
 				const lyrics = await getLyricsById(env, id)
 				if (!lyrics) {
-					return status(404, { success: false, error: "Lyrics not found" })
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 
 				const vote = signedPayload.vote
 				if (vote !== 1 && vote !== -1) {
-					return status(400, { success: false, error: "Vote must be 1 or -1" })
+					return status(400, buildError(ErrorCode.INVALID_VOTE))
 				}
 
 				const result = await castVote(env, id, userId, vote)
@@ -42,12 +43,12 @@ export const voteRoutes = (env: Env) =>
 			async ({ params, env, userId, status }) => {
 				const id = Number(params.id)
 				if (Number.isNaN(id)) {
-					return status(400, { success: false, error: "Invalid ID" })
+					return status(400, buildError(ErrorCode.INVALID_ID))
 				}
 
 				const lyrics = await getLyricsById(env, id)
 				if (!lyrics) {
-					return status(404, { success: false, error: "Lyrics not found" })
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 
 				const result = await removeVote(env, id, userId)
@@ -64,24 +65,24 @@ export const voteRoutes = (env: Env) =>
 			async ({ params, env, userId, signedPayload, status }) => {
 				const id = Number(params.id)
 				if (Number.isNaN(id)) {
-					return status(400, { success: false, error: "Invalid ID" })
+					return status(400, buildError(ErrorCode.INVALID_ID))
 				}
 
 				const lyrics = await getLyricsById(env, id)
 				if (!lyrics) {
-					return status(404, { success: false, error: "Lyrics not found" })
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 
 				const reason = signedPayload.reason
 				const validReasons = ["wrong_song", "bad_sync", "offensive", "spam", "other"]
 				if (typeof reason !== "string" || !validReasons.includes(reason)) {
-					return status(400, { success: false, error: "Invalid report reason" })
+					return status(400, buildError(ErrorCode.INVALID_REPORT_REASON))
 				}
 
 				const details =
 					typeof signedPayload.details === "string" ? signedPayload.details : undefined
 				if (details && details.length > config.validation.report.maxDetailsLength) {
-					return status(400, { success: false, error: "Report details too long" })
+					return status(400, buildError(ErrorCode.REPORT_DETAILS_TOO_LONG))
 				}
 
 				const result = await submitReport(env, id, userId, {

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -122,7 +122,7 @@ describe("signedRequest middleware: error responses", () => {
 		const body = await readJson(res)
 
 		expect(res.status).toBe(400)
-		expect(body).toEqual({ success: false, error: "INVALID_SIGNED_BODY" })
+		expect(body).toMatchObject({ success: false, error: "INVALID_SIGNED_BODY" })
 	})
 
 	it("returns 401 TIMESTAMP_EXPIRED when payload timestamp is stale", async () => {
@@ -138,7 +138,7 @@ describe("signedRequest middleware: error responses", () => {
 		const body = await readJson(res)
 
 		expect(res.status).toBe(401)
-		expect(body).toEqual({ success: false, error: "TIMESTAMP_EXPIRED" })
+		expect(body).toMatchObject({ success: false, error: "TIMESTAMP_EXPIRED" })
 	})
 
 	it("returns 409 NONCE_REPLAY when setNX fails to claim the nonce", async () => {
@@ -154,7 +154,7 @@ describe("signedRequest middleware: error responses", () => {
 		const body = await readJson(res)
 
 		expect(res.status).toBe(409)
-		expect(body).toEqual({ success: false, error: "NONCE_REPLAY" })
+		expect(body).toMatchObject({ success: false, error: "NONCE_REPLAY" })
 	})
 
 	it("returns 400 PUBLIC_KEY_REQUIRED when keyId is unknown and no publicKey is sent", async () => {
@@ -171,7 +171,7 @@ describe("signedRequest middleware: error responses", () => {
 		const body = await readJson(res)
 
 		expect(res.status).toBe(400)
-		expect(body).toEqual({ success: false, error: "PUBLIC_KEY_REQUIRED" })
+		expect(body).toMatchObject({ success: false, error: "PUBLIC_KEY_REQUIRED" })
 	})
 
 	it("returns 403 KEY_ID_MISMATCH when publicKey does not hash to keyId", async () => {
@@ -191,7 +191,7 @@ describe("signedRequest middleware: error responses", () => {
 		const body = await readJson(res)
 
 		expect(res.status).toBe(403)
-		expect(body).toEqual({ success: false, error: "KEY_ID_MISMATCH" })
+		expect(body).toMatchObject({ success: false, error: "KEY_ID_MISMATCH" })
 	})
 
 	it("returns 401 INVALID_SIGNATURE when stored key cannot verify the signature", async () => {
@@ -217,7 +217,7 @@ describe("signedRequest middleware: error responses", () => {
 		const body = await readJson(res)
 
 		expect(res.status).toBe(401)
-		expect(body).toEqual({ success: false, error: "INVALID_SIGNATURE" })
+		expect(body).toMatchObject({ success: false, error: "INVALID_SIGNATURE" })
 	})
 
 	it("authenticates a valid signed request and exposes keyId/userId to handler", async () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -3,6 +3,7 @@ import { Logger } from "@/infra/logger"
 import type { Env } from "@/types"
 import { getPublicKey, registerPublicKey } from "@/db/publicKeys"
 import { getOrCreateUser } from "@/db/users"
+import { buildError, ErrorCode } from "@/utils/errors"
 import { verifySignature, isTimestampFresh, verifyKeyId } from "./crypto"
 
 const log = new Logger("auth")
@@ -50,21 +51,21 @@ export const signedRequest = new Elysia({ name: "signed-request" }).derive(
 
 		if (!isValidSignedBody(body)) {
 			log.warn("invalid signed request format")
-			return status(400, { success: false, error: "INVALID_SIGNED_BODY" })
+			return status(400, buildError(ErrorCode.INVALID_SIGNED_BODY))
 		}
 
 		const { payload, signature, publicKey } = body
 
 		if (!isTimestampFresh(payload.timestamp)) {
 			log.warn("expired timestamp", { keyId: payload.keyId })
-			return status(401, { success: false, error: "TIMESTAMP_EXPIRED" })
+			return status(401, buildError(ErrorCode.TIMESTAMP_EXPIRED))
 		}
 
 		const nonceKey = `nonce:${payload.keyId}:${payload.nonce}`
 		const claimed = await env.CACHE.setNX(nonceKey, "1", 300)
 		if (!claimed) {
 			log.warn("nonce replay attempt", { keyId: payload.keyId })
-			return status(409, { success: false, error: "NONCE_REPLAY" })
+			return status(409, buildError(ErrorCode.NONCE_REPLAY))
 		}
 
 		let keyRecord = await getPublicKey(env, payload.keyId)
@@ -72,12 +73,12 @@ export const signedRequest = new Elysia({ name: "signed-request" }).derive(
 		if (!keyRecord) {
 			if (!publicKey) {
 				log.info("new key requires registration", { keyId: payload.keyId })
-				return status(400, { success: false, error: "PUBLIC_KEY_REQUIRED" })
+				return status(400, buildError(ErrorCode.PUBLIC_KEY_REQUIRED))
 			}
 
 			if (!(await verifyKeyId(payload.keyId, publicKey))) {
 				log.warn("key ID mismatch", { keyId: payload.keyId })
-				return status(403, { success: false, error: "KEY_ID_MISMATCH" })
+				return status(403, buildError(ErrorCode.KEY_ID_MISMATCH))
 			}
 
 			keyRecord = await registerPublicKey(env, payload.keyId, publicKey)
@@ -87,7 +88,7 @@ export const signedRequest = new Elysia({ name: "signed-request" }).derive(
 		const storedKey = JSON.parse(keyRecord.public_key) as JsonWebKey
 		if (!(await verifySignature(payload, signature, storedKey))) {
 			log.warn("invalid signature", { keyId: payload.keyId })
-			return status(401, { success: false, error: "INVALID_SIGNATURE" })
+			return status(401, buildError(ErrorCode.INVALID_SIGNATURE))
 		}
 
 		const user = await getOrCreateUser(env, payload.keyId)

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -14,7 +14,7 @@ describe("buildError", () => {
 
 	it("every defined code has a non-empty error and a non-empty hint", () => {
 		for (const code of Object.values(ErrorCode)) {
-			const result = buildError(code as ErrorCode)
+			const result = buildError(code)
 			expect(result.code).toBe(code)
 			expect(result.error.length).toBeGreaterThan(0)
 			expect(result.hint.length).toBeGreaterThan(0)
@@ -36,7 +36,7 @@ describe("buildError", () => {
 
 	it("error field is a single line (backwards-compatible single-string display)", () => {
 		for (const code of Object.values(ErrorCode)) {
-			const result = buildError(code as ErrorCode)
+			const result = buildError(code)
 			expect(result.error).not.toContain("\n")
 		}
 	})

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -40,4 +40,17 @@ describe("buildError", () => {
 			expect(result.error).not.toContain("\n")
 		}
 	})
+
+	it("has a stable code for the nonce replay case", () => {
+		const result = buildError(ErrorCode.NONCE_REPLAY)
+		expect(result.code).toBe("NONCE_REPLAY")
+		expect(result.error).toBe("Already received")
+		expect(result.hint).toMatch(/already received/i)
+	})
+
+	it("has a stable code for the report-details-too-long case", () => {
+		const result = buildError(ErrorCode.REPORT_DETAILS_TOO_LONG)
+		expect(result.code).toBe("REPORT_DETAILS_TOO_LONG")
+		expect(result.hint).toMatch(/1000 characters/i)
+	})
 })

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -44,7 +44,7 @@ describe("buildError", () => {
 	it("has a stable code for the nonce replay case", () => {
 		const result = buildError(ErrorCode.NONCE_REPLAY)
 		expect(result.code).toBe("NONCE_REPLAY")
-		expect(result.error).toBe("Already received")
+		expect(result.error).toBe("NONCE_REPLAY")
 		expect(result.hint).toMatch(/already received/i)
 	})
 

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { buildError, ErrorCode } from "./errors"
+
+describe("buildError", () => {
+	it("returns success: false, a short error title, a code, and a rich hint", () => {
+		const result = buildError(ErrorCode.TTML_MALFORMED)
+		expect(result.success).toBe(false)
+		expect(result.code).toBe("TTML_MALFORMED")
+		expect(typeof result.error).toBe("string")
+		expect(result.error.length).toBeGreaterThan(0)
+		expect(typeof result.hint).toBe("string")
+		expect(result.hint.length).toBeGreaterThan(40)
+	})
+
+	it("every defined code has a non-empty error and a non-empty hint", () => {
+		for (const code of Object.values(ErrorCode)) {
+			const result = buildError(code as ErrorCode)
+			expect(result.code).toBe(code)
+			expect(result.error.length).toBeGreaterThan(0)
+			expect(result.hint.length).toBeGreaterThan(0)
+		}
+	})
+
+	it("allows overriding the hint when context-specific guidance is useful", () => {
+		const result = buildError(ErrorCode.MISSING_QUERY, {
+			hint: "Provide 'q' for fuzzy search, or both 'song' and 'artist' for exact match.",
+		})
+		expect(result.hint).toContain("fuzzy search")
+	})
+
+	it("allows overriding the short error title", () => {
+		const result = buildError(ErrorCode.NOT_FOUND, { error: "No lyrics found for this video" })
+		expect(result.error).toBe("No lyrics found for this video")
+		expect(result.code).toBe("NOT_FOUND")
+	})
+
+	it("error field is a single line (backwards-compatible single-string display)", () => {
+		for (const code of Object.values(ErrorCode)) {
+			const result = buildError(code as ErrorCode)
+			expect(result.error).not.toContain("\n")
+		}
+	})
+})

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,99 @@
+export const ErrorCode = {
+	INVALID_PAYLOAD: "INVALID_PAYLOAD",
+	SONG_TOO_LONG: "SONG_TOO_LONG",
+	ARTIST_TOO_LONG: "ARTIST_TOO_LONG",
+	PAYLOAD_TOO_LARGE: "PAYLOAD_TOO_LARGE",
+	INVALID_DURATION: "INVALID_DURATION",
+	TTML_MALFORMED: "TTML_MALFORMED",
+	TTML_FORMATTED: "TTML_FORMATTED",
+	RATE_LIMITED: "RATE_LIMITED",
+	VARIANT_CAP_REACHED: "VARIANT_CAP_REACHED",
+	AUTH_REQUIRED: "AUTH_REQUIRED",
+	INVALID_ID: "INVALID_ID",
+	NOT_OWNER: "NOT_OWNER",
+	NOT_FOUND: "NOT_FOUND",
+	MISSING_QUERY: "MISSING_QUERY",
+} as const
+
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
+
+type Template = { error: string; hint: string }
+
+const TEMPLATES: Record<ErrorCode, Template> = {
+	INVALID_PAYLOAD: {
+		error: "Invalid submission",
+		hint: "Some required info is missing or doesn't look right. Make sure the song name, artist, video, and lyrics are all filled in.",
+	},
+	SONG_TOO_LONG: {
+		error: "Song name too long",
+		hint: "The song name is too long. Try a shorter version.",
+	},
+	ARTIST_TOO_LONG: {
+		error: "Artist name too long",
+		hint: "The artist name is too long. Try a shorter version.",
+	},
+	PAYLOAD_TOO_LARGE: {
+		error: "Lyrics too large",
+		hint: "These lyrics are too big to submit. If there's extra formatting or notes mixed in with the text, try cleaning those out first.",
+	},
+	INVALID_DURATION: {
+		error: "Song length looks off",
+		hint: "The song length doesn't look right. Double-check that it matches the actual track length.",
+	},
+	TTML_MALFORMED: {
+		error: "Broken TTML file",
+		hint: "The TTML file looks incomplete or broken. Try re-exporting it from your lyrics tool and submitting again.",
+	},
+	TTML_FORMATTED: {
+		error: "TTML formatting issue",
+		hint: "The TTML file has extra formatting that breaks the word-by-word timing. Try re-exporting it without any auto-formatting or pretty-printing.",
+	},
+	RATE_LIMITED: {
+		error: "Slow down",
+		hint: "You're submitting too quickly. Wait a moment and try again.",
+	},
+	VARIANT_CAP_REACHED: {
+		error: "Too many submissions",
+		hint: "You've already submitted the maximum number of versions for this song. Delete one of your existing submissions to add a new one.",
+	},
+	AUTH_REQUIRED: {
+		error: "Sign in required",
+		hint: "You need to be signed in to do this.",
+	},
+	INVALID_ID: {
+		error: "Bad request",
+		hint: "Something looks off with the request. Try refreshing the page and trying again.",
+	},
+	NOT_OWNER: {
+		error: "Not yours to delete",
+		hint: "You can only delete submissions you made yourself.",
+	},
+	NOT_FOUND: {
+		error: "Lyrics not found",
+		hint: "Couldn't find lyrics for this. Try a different search, or be the first to submit them.",
+	},
+	MISSING_QUERY: {
+		error: "Search needs more info",
+		hint: "To search, add either a video link or both the song and artist names.",
+	},
+}
+
+export type SubmissionErrorBody = {
+	success: false
+	error: string
+	code: ErrorCode
+	hint: string
+}
+
+export function buildError(
+	code: ErrorCode,
+	overrides?: { error?: string; hint?: string },
+): SubmissionErrorBody {
+	const template = TEMPLATES[code]
+	return {
+		success: false,
+		error: overrides?.error ?? template.error,
+		code,
+		hint: overrides?.hint ?? template.hint,
+	}
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+// The `code` field is the stable contract for clients; switch on it.
+// The `error` and `hint` fields are display copy and may be reworded.
 export const ErrorCode = {
 	INVALID_PAYLOAD: "INVALID_PAYLOAD",
 	SONG_TOO_LONG: "SONG_TOO_LONG",

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,7 @@
-// The `code` field is the stable contract for clients; switch on it.
-// The `error` and `hint` fields are display copy and may be reworded.
+// The `error` field is the legacy single-string contract; existing clients
+// may exact-match on it, so it stays at its pre-existing value per code.
+// The `code` field is the stable machine-readable contract for new clients.
+// The `hint` field is humanized display copy and may evolve.
 export const ErrorCode = {
 	INVALID_PAYLOAD: "INVALID_PAYLOAD",
 	SONG_TOO_LONG: "SONG_TOO_LONG",
@@ -32,7 +34,7 @@ type Template = { error: string; hint: string }
 
 const TEMPLATES: Record<ErrorCode, Template> = {
 	INVALID_PAYLOAD: {
-		error: "Invalid submission",
+		error: "Invalid submission payload",
 		hint: "Some required info is missing or doesn't look right. Make sure the song name, artist, video, and lyrics are all filled in.",
 	},
 	SONG_TOO_LONG: {
@@ -44,39 +46,40 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 		hint: "The artist name is too long. Try a shorter version.",
 	},
 	PAYLOAD_TOO_LARGE: {
-		error: "Lyrics too large",
+		error: "Lyrics content too large",
 		hint: "These lyrics are too big to submit. If there's extra formatting or notes mixed in with the text, try cleaning those out first.",
 	},
 	INVALID_DURATION: {
-		error: "Song length looks off",
+		error: "Invalid duration",
 		hint: "The song length doesn't look right. Double-check that it matches the actual track length.",
 	},
 	TTML_MALFORMED: {
-		error: "Broken TTML file",
+		error: "Malformed TTML content",
 		hint: "The TTML file looks incomplete or broken. Try re-exporting it from your lyrics tool and submitting again.",
 	},
 	TTML_FORMATTED: {
-		error: "TTML formatting issue",
+		error: "Formatted TTML",
 		hint: "The TTML file has extra formatting that breaks the word-by-word timing. Try re-exporting it without any auto-formatting or pretty-printing.",
 	},
 	RATE_LIMITED: {
-		error: "Slow down",
+		error: "Rate limited. Try again later.",
 		hint: "You're submitting too quickly. Wait a moment and try again.",
 	},
 	VARIANT_CAP_REACHED: {
-		error: "Too many submissions",
+		error:
+			"You've reached the maximum active variants for this video. Delete one of your existing variants to submit another.",
 		hint: "You've already submitted the maximum number of versions for this song. Delete one of your existing submissions to add a new one.",
 	},
 	AUTH_REQUIRED: {
-		error: "Sign in required",
+		error: "Authentication required",
 		hint: "You need to be signed in to do this.",
 	},
 	INVALID_ID: {
-		error: "Bad request",
+		error: "Invalid ID",
 		hint: "The link or ID doesn't look right. Double-check it and try again.",
 	},
 	NOT_OWNER: {
-		error: "Not yours to delete",
+		error: "Not your submission",
 		hint: "You can only delete submissions you made yourself.",
 	},
 	NOT_FOUND: {
@@ -84,39 +87,39 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 		hint: "Couldn't find lyrics for this. Try a different search, or be the first to submit them.",
 	},
 	MISSING_QUERY: {
-		error: "Search needs more info",
+		error: "Provide either 'v' (videoId) or 'song' + 'artist'",
 		hint: "To search, add either a video link or both the song and artist names.",
 	},
 	INVALID_SIGNED_BODY: {
-		error: "Request looks broken",
+		error: "INVALID_SIGNED_BODY",
 		hint: "Something looks off with this request. Try again. If it keeps happening, the extension may need an update.",
 	},
 	TIMESTAMP_EXPIRED: {
-		error: "Request expired",
+		error: "TIMESTAMP_EXPIRED",
 		hint: "This took too long to reach us, or your device's clock might be off. Check the time on your device and try again.",
 	},
 	NONCE_REPLAY: {
-		error: "Already received",
+		error: "NONCE_REPLAY",
 		hint: "We already received this exact request. If you meant to send a new submission, refresh and try again.",
 	},
 	PUBLIC_KEY_REQUIRED: {
-		error: "Setup incomplete",
+		error: "PUBLIC_KEY_REQUIRED",
 		hint: "This device isn't fully set up yet. Try again in a moment. If it keeps happening, the extension may need an update.",
 	},
 	KEY_ID_MISMATCH: {
-		error: "Identity check failed",
+		error: "KEY_ID_MISMATCH",
 		hint: "Something's off with how this request was signed. Try again. If it keeps happening, the extension may need an update.",
 	},
 	INVALID_SIGNATURE: {
-		error: "Signature check failed",
+		error: "INVALID_SIGNATURE",
 		hint: "Couldn't verify this request. Try again. If it keeps happening, the extension may need an update.",
 	},
 	INVALID_VOTE: {
-		error: "Vote failed",
+		error: "Vote must be 1 or -1",
 		hint: "Couldn't register your vote. Try again. If it keeps happening, the extension may need an update.",
 	},
 	INVALID_REPORT_REASON: {
-		error: "Report failed",
+		error: "Invalid report reason",
 		hint: "Couldn't submit this report. Pick one of the available reasons and try again.",
 	},
 	REPORT_DETAILS_TOO_LONG: {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -62,7 +62,7 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	},
 	INVALID_ID: {
 		error: "Bad request",
-		hint: "Something looks off with the request. Try refreshing the page and trying again.",
+		hint: "The link or ID doesn't look right. Double-check it and try again.",
 	},
 	NOT_OWNER: {
 		error: "Not yours to delete",

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -66,8 +66,7 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 		hint: "You're submitting too quickly. Wait a moment and try again.",
 	},
 	VARIANT_CAP_REACHED: {
-		error:
-			"You've reached the maximum active variants for this video. Delete one of your existing variants to submit another.",
+		error: "Maximum variants reached",
 		hint: "You've already submitted the maximum number of versions for this song. Delete one of your existing submissions to add a new one.",
 	},
 	AUTH_REQUIRED: {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -15,6 +15,15 @@ export const ErrorCode = {
 	NOT_OWNER: "NOT_OWNER",
 	NOT_FOUND: "NOT_FOUND",
 	MISSING_QUERY: "MISSING_QUERY",
+	INVALID_SIGNED_BODY: "INVALID_SIGNED_BODY",
+	TIMESTAMP_EXPIRED: "TIMESTAMP_EXPIRED",
+	NONCE_REPLAY: "NONCE_REPLAY",
+	PUBLIC_KEY_REQUIRED: "PUBLIC_KEY_REQUIRED",
+	KEY_ID_MISMATCH: "KEY_ID_MISMATCH",
+	INVALID_SIGNATURE: "INVALID_SIGNATURE",
+	INVALID_VOTE: "INVALID_VOTE",
+	INVALID_REPORT_REASON: "INVALID_REPORT_REASON",
+	REPORT_DETAILS_TOO_LONG: "REPORT_DETAILS_TOO_LONG",
 } as const
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
@@ -77,6 +86,42 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	MISSING_QUERY: {
 		error: "Search needs more info",
 		hint: "To search, add either a video link or both the song and artist names.",
+	},
+	INVALID_SIGNED_BODY: {
+		error: "Request looks broken",
+		hint: "Something looks off with this request. Try again. If it keeps happening, the extension may need an update.",
+	},
+	TIMESTAMP_EXPIRED: {
+		error: "Request expired",
+		hint: "This took too long to reach us, or your device's clock might be off. Check the time on your device and try again.",
+	},
+	NONCE_REPLAY: {
+		error: "Already received",
+		hint: "We already received this exact request. If you meant to send a new submission, refresh and try again.",
+	},
+	PUBLIC_KEY_REQUIRED: {
+		error: "Setup incomplete",
+		hint: "This device isn't fully set up yet. Try again in a moment. If it keeps happening, the extension may need an update.",
+	},
+	KEY_ID_MISMATCH: {
+		error: "Identity check failed",
+		hint: "Something's off with how this request was signed. Try again. If it keeps happening, the extension may need an update.",
+	},
+	INVALID_SIGNATURE: {
+		error: "Signature check failed",
+		hint: "Couldn't verify this request. Try again. If it keeps happening, the extension may need an update.",
+	},
+	INVALID_VOTE: {
+		error: "Vote failed",
+		hint: "Couldn't register your vote. Try again. If it keeps happening, the extension may need an update.",
+	},
+	INVALID_REPORT_REASON: {
+		error: "Report failed",
+		hint: "Couldn't submit this report. Pick one of the available reasons and try again.",
+	},
+	REPORT_DETAILS_TOO_LONG: {
+		error: "Report details too long",
+		hint: "The extra details on this report are too long. Try a shorter explanation (under 1000 characters).",
 	},
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { hashIP } from "./hash"
 export { normalize, normalizeSong, normalizeArtist } from "./normalize"
-export { validateTtmlStructure, detectSyncType, detectFormat } from "./validation"
+export { detectFormat, detectPrettyPrintedTtml, detectSyncType, validateTtmlStructure } from "./validation"
 export { parseLrc, lrcToTtml, isLrcFormat } from "./lrc"
 export { compress, decompress, isCompressed } from "./compression"

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -324,6 +324,29 @@ describe("detectPrettyPrintedTtml", () => {
 				'<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:02.0"> whole line text</span></p></div></body></tt>'
 			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
 		})
+
+		it("accepts span content that is purely whitespace inside (no real text)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">   </span><span begin="0:01.0" end="0:02.0">word</span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts spans separated by a single space (canonical word boundary)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Hi</span> <span begin="0:01.0" end="0:02.0">there</span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts spans separated by multiple spaces but no newline", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Hi</span>   <span begin="0:01.0" end="0:02.0">there</span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("flags non-TTML markup with newline-separated <span> siblings (detector is permissive about wrapper structure)", () => {
+			const html = "<div><span>Hello</span>\n<span>World</span></div>"
+			expect(detectPrettyPrintedTtml(html).ok).toBe(false)
+		})
 	})
 
 	describe("pretty-printed TTML (should flag)", () => {
@@ -362,6 +385,65 @@ describe("detectPrettyPrintedTtml", () => {
 			const ttml =
 				'<tt><body><div><p>\r\n<span begin="0:00.0" end="0:01.0">a</span>\r\n<span begin="0:01.0" end="0:02.0">b</span>\r\n</p></div></body></tt>'
 			expect(detectPrettyPrintedTtml(ttml).ok).toBe(false)
+		})
+
+		it("does not flag tabs between span siblings without a newline (documents current regex scope)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">a</span>\t<span begin="0:01.0" end="0:02.0">b</span></p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(true)
+		})
+
+		it("flags newlines between siblings within an x-bg background container", () => {
+			const ttml =
+				'<tt><body><div><p>' +
+				'<span begin="0:00.0" end="0:01.0">main</span> ' +
+				'<span ttm:role="x-bg">' +
+				'\n  <span begin="0:00.5" end="0:01.0">bg1</span>' +
+				'\n  <span begin="0:01.0" end="0:01.5">bg2</span>' +
+				'\n</span>' +
+				'</p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.reason).toBe("inter-span-newline")
+		})
+
+		it("flags mixed-quality TTML (some lines clean, some pretty-printed)", () => {
+			const ttml =
+				'<tt><body><div>' +
+				'<p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:01.0">Clean</span> <span begin="0:01.0" end="0:02.0">line</span></p>' +
+				'<p begin="0:02.0" end="0:04.0">\n  <span begin="0:02.0" end="0:03.0">Dirty</span>\n  <span begin="0:03.0" end="0:04.0">line</span>\n</p>' +
+				"</div></body></tt>"
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(false)
+		})
+
+		it("flags trailing whitespace using a tab character (not just space)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">word\t</span><span begin="0:01.0" end="0:02.0">two</span></p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.reason).toBe("span-trailing-whitespace")
+		})
+
+		it("flags leading whitespace using a tab character", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">one</span><span begin="0:01.0" end="0:02.0">\ttwo</span></p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.reason).toBe("span-leading-whitespace")
+		})
+
+		it("returns a result quickly on a large pretty-printed payload (smoke ReDoS)", () => {
+			let payload = "<tt><body><div>"
+			for (let i = 0; i < 500; i++) {
+				payload += `<p begin="0:${i}.0" end="0:${i + 1}.0">\n  <span begin="0:${i}.0" end="0:${i}.5">a${i}</span>\n  <span begin="0:${i}.5" end="0:${i + 1}.0">b${i}</span>\n</p>`
+			}
+			payload += "</div></body></tt>"
+			const start = Date.now()
+			const result = detectPrettyPrintedTtml(payload)
+			const elapsed = Date.now() - start
+			expect(result.ok).toBe(false)
+			expect(elapsed).toBeLessThan(100)
 		})
 	})
 

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -306,6 +306,24 @@ describe("detectPrettyPrintedTtml", () => {
 				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Hi</span> <span ttm:role="x-bg"><span begin="0:00.5" end="0:01.0">bg</span></span></p></div></body></tt>'
 			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
 		})
+
+		it("accepts self-closing spans", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0"/> <span begin="0:01.0" end="0:02.0"/></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts a single-span line-sync wrap with trailing whitespace inside (no sibling span)", () => {
+			const ttml =
+				'<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:02.0">whole line text </span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts a single-span line-sync wrap with leading whitespace inside (no sibling span)", () => {
+			const ttml =
+				'<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:02.0"> whole line text</span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
 	})
 
 	describe("pretty-printed TTML (should flag)", () => {

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { detectFormat, detectSyncType, validateTtmlStructure } from "./validation"
+import { detectFormat, detectPrettyPrintedTtml, detectSyncType, validateTtmlStructure } from "./validation"
 
 describe("validateTtmlStructure", () => {
 	it("validates basic TTML structure", () => {
@@ -271,6 +271,93 @@ describe("detectFormat", () => {
 		it("classifies the row-431 doc shape (TTML wrongly claimed as plain) as ttml", () => {
 			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><body><div><p begin="0:01.428" end="0:04.847"><span begin="0:01.428" end="0:01.731">Whoa,</span></p></div></body></tt>`
 			expect(detectFormat(ttml)).toBe("ttml")
+		})
+	})
+})
+
+describe("detectPrettyPrintedTtml", () => {
+	describe("clean TTML (should not flag)", () => {
+		it("accepts single-line word-synced TTML", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Hello</span> <span begin="0:01.0" end="0:02.0">world</span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts TTML with newlines between line elements but not between spans", () => {
+			const ttml =
+				'<tt><body><div>\n<p><span begin="0:00.0" end="0:01.0">Hi</span></p>\n<p><span begin="0:02.0" end="0:03.0">There</span></p>\n</div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts line-sync TTML with no spans", () => {
+			const ttml =
+				'<tt><body><div>\n  <p begin="0:00.0" end="0:01.0">Hello world</p>\n</div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts adjacent spans with no whitespace (syllable run)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:00.5">Hel</span><span begin="0:00.5" end="0:01.0">lo</span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+
+		it("accepts background span containers (x-bg)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Hi</span> <span ttm:role="x-bg"><span begin="0:00.5" end="0:01.0">bg</span></span></p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(true)
+		})
+	})
+
+	describe("pretty-printed TTML (should flag)", () => {
+		it("flags newline between span siblings", () => {
+			const ttml =
+				'<tt><body><div><p>\n<span begin="0:00.0" end="0:01.0">Hello</span>\n<span begin="0:01.0" end="0:02.0">world</span>\n</p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.reason).toBe("inter-span-newline")
+		})
+
+		it("flags trailing whitespace inside a span (row-69 pattern)", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Focus </span><span begin="0:01.0" end="0:02.0">Aim</span></p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.reason).toBe("span-trailing-whitespace")
+		})
+
+		it("flags leading whitespace inside a span", () => {
+			const ttml =
+				'<tt><body><div><p><span begin="0:00.0" end="0:01.0">Hello</span><span begin="0:01.0" end="0:02.0"> world</span></p></div></body></tt>'
+			const result = detectPrettyPrintedTtml(ttml)
+			expect(result.ok).toBe(false)
+			if (!result.ok) expect(result.reason).toBe("span-leading-whitespace")
+		})
+
+		it("flags row 69's exact shape", () => {
+			const row69 =
+				'<?xml version="1.0" ?>\n<tt xmlns="http://www.w3.org/ns/ttml">\n  <body>\n    <div>\n      <p begin="00:00:01.417" end="00:00:01.958">\n        <span begin="00:00:01.417" end="00:00:01.958">Focus </span>\n      </p>\n      <p begin="00:00:03.216" end="00:00:04.259">\n        <span begin="00:00:03.216" end="00:00:03.746">Ready </span>\n        <span ttm:role="x-bg">\n          <span begin="00:00:03.711" end="00:00:04.259">Ah </span>\n        </span>\n      </p>\n    </div>\n  </body>\n</tt>'
+			const result = detectPrettyPrintedTtml(row69)
+			expect(result.ok).toBe(false)
+		})
+
+		it("flags CRLF inter-span whitespace", () => {
+			const ttml =
+				'<tt><body><div><p>\r\n<span begin="0:00.0" end="0:01.0">a</span>\r\n<span begin="0:01.0" end="0:02.0">b</span>\r\n</p></div></body></tt>'
+			expect(detectPrettyPrintedTtml(ttml).ok).toBe(false)
+		})
+	})
+
+	describe("non-TTML content", () => {
+		it("returns ok for plain prose (caller is expected to gate on detected format first)", () => {
+			expect(detectPrettyPrintedTtml("just some prose").ok).toBe(true)
+		})
+
+		it("returns ok for LRC", () => {
+			expect(detectPrettyPrintedTtml("[00:01.00]Hello\n[00:02.00]World").ok).toBe(true)
+		})
+
+		it("returns ok for empty string", () => {
+			expect(detectPrettyPrintedTtml("").ok).toBe(true)
 		})
 	})
 })

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -50,9 +50,13 @@ export type PrettyPrintCheckResult =
 			reason: "inter-span-newline" | "span-trailing-whitespace" | "span-leading-whitespace"
 	  }
 
+// Order matters: the inter-span newline check is the strongest signal and
+// subsumes most pretty-print shapes. The trailing/leading checks are
+// scoped to require an adjacent sibling span so they don't fire on
+// single-span line-sync wraps.
 const INTER_SPAN_NEWLINE_REGEX = /<\/span>\s*[\r\n]\s*<span\b/i
-const SPAN_TRAILING_WS_REGEX = /<span\b[^>]*>[^<]*?\S[ \t]+<\/span>/i
-const SPAN_LEADING_WS_REGEX = /<span\b[^>]*>[ \t]+\S[^<]*<\/span>/i
+const SPAN_TRAILING_WS_REGEX = /<span\b[^>]*>[^<]*?\S[ \t]+<\/span>\s*<span\b/i
+const SPAN_LEADING_WS_REGEX = /<\/span>\s*<span\b[^>]*>[ \t]+\S[^<]*<\/span>/i
 
 export function detectPrettyPrintedTtml(content: string): PrettyPrintCheckResult {
 	if (INTER_SPAN_NEWLINE_REGEX.test(content)) {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -43,6 +43,30 @@ export function detectFormat(content: string): LyricsFormat {
 	return "plain"
 }
 
+export type PrettyPrintCheckResult =
+	| { ok: true }
+	| {
+			ok: false
+			reason: "inter-span-newline" | "span-trailing-whitespace" | "span-leading-whitespace"
+	  }
+
+const INTER_SPAN_NEWLINE_REGEX = /<\/span>\s*[\r\n]\s*<span\b/i
+const SPAN_TRAILING_WS_REGEX = /<span\b[^>]*>[^<]*?\S[ \t]+<\/span>/i
+const SPAN_LEADING_WS_REGEX = /<span\b[^>]*>[ \t]+\S[^<]*<\/span>/i
+
+export function detectPrettyPrintedTtml(content: string): PrettyPrintCheckResult {
+	if (INTER_SPAN_NEWLINE_REGEX.test(content)) {
+		return { ok: false, reason: "inter-span-newline" }
+	}
+	if (SPAN_TRAILING_WS_REGEX.test(content)) {
+		return { ok: false, reason: "span-trailing-whitespace" }
+	}
+	if (SPAN_LEADING_WS_REGEX.test(content)) {
+		return { ok: false, reason: "span-leading-whitespace" }
+	}
+	return { ok: true }
+}
+
 function detectLrcSyncType(lrc: string): "richsync" | "linesync" | "plain" {
 	if (LRC_WORD_TAG.test(lrc)) return "richsync"
 	if (LRC_LINE_TAG.test(lrc)) return "linesync"


### PR DESCRIPTION
## Overview

- Structured error response shape for every 4xx on `POST /lyrics/submit` (and other 4xx paths in `src/routes/lyrics.ts`): adds `code` and `hint` fields alongside the existing `error` string. Backwards compatible; `error` is preserved and reworded for clarity.
- New `detectPrettyPrintedTtml` utility flags inter-span newlines and leading/trailing whitespace inside `<span>` tags. The submission handler rejects formatted TTML with `TTML_FORMATTED` and a reason-specific hint, since pretty-printers break word-boundary timing in the Better Lyrics renderer.