### PR TITLE
Feat/request fulfillments

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -192,11 +192,3 @@ CREATE INDEX IF NOT EXISTS idx_request_fulfillments_video_fulfilled
     ON request_fulfillments(video_id, fulfilled_at DESC);
 CREATE INDEX IF NOT EXISTS idx_request_fulfillments_lyrics
     ON request_fulfillments(lyrics_id);
-
--- One-shot zombie cleanup: drop request rows for videos that already have a
--- servable synced variant at deploy time. Idempotent.
-DELETE FROM lyrics_requests
-WHERE video_id IN (
-    SELECT DISTINCT video_id FROM lyrics
-    WHERE sync_type IN ('linesync','richsync') AND deleted_at IS NULL
-);

--- a/schema.sql
+++ b/schema.sql
@@ -174,3 +174,29 @@ CREATE TABLE IF NOT EXISTS lyrics_requests (
 );
 
 CREATE INDEX IF NOT EXISTS idx_lyrics_requests_created ON lyrics_requests(created_at);
+
+-- Request fulfillments: recognition when a synced submission fills demand
+CREATE TABLE IF NOT EXISTS request_fulfillments (
+    id BIGSERIAL PRIMARY KEY,
+    video_id TEXT NOT NULL,
+    lyrics_id INTEGER NOT NULL REFERENCES lyrics(id) ON DELETE CASCADE,
+    submitter_id INTEGER REFERENCES users(id),
+    demand_snapshot DOUBLE PRECISION NOT NULL,
+    request_count_snapshot INTEGER NOT NULL,
+    fulfilled_at INTEGER NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW())::INTEGER)
+);
+
+CREATE INDEX IF NOT EXISTS idx_request_fulfillments_submitter
+    ON request_fulfillments(submitter_id);
+CREATE INDEX IF NOT EXISTS idx_request_fulfillments_video_fulfilled
+    ON request_fulfillments(video_id, fulfilled_at DESC);
+CREATE INDEX IF NOT EXISTS idx_request_fulfillments_lyrics
+    ON request_fulfillments(lyrics_id);
+
+-- One-shot zombie cleanup: drop request rows for videos that already have a
+-- servable synced variant at deploy time. Idempotent.
+DELETE FROM lyrics_requests
+WHERE video_id IN (
+    SELECT DISTINCT video_id FROM lyrics
+    WHERE sync_type IN ('linesync','richsync') AND deleted_at IS NULL
+);

--- a/src/db/feed.test.ts
+++ b/src/db/feed.test.ts
@@ -1,7 +1,7 @@
 import type { Env } from "@/types"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { getGlobalFeed, getMySubmissions, getPersonalizedFeed } from "./feed"
-import { AUTO_HIDE_PREDICATE } from "./lyrics"
+import { AUTO_HIDE_PREDICATE } from "./predicates"
 
 // -- Mocks -----------------------------------------------------------------
 

--- a/src/db/feed.ts
+++ b/src/db/feed.ts
@@ -5,7 +5,7 @@ import {
 	type FeedFilters,
 	hasAnyFilter,
 } from "@/db/feed-filters"
-import { AUTO_HIDE_PREDICATE, RANKING_EXPR } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE, RANKING_EXPR } from "@/db/predicates"
 import { Logger } from "@/infra/logger"
 import type { Env, FeedItem } from "@/types"
 

--- a/src/db/fulfillments.test.ts
+++ b/src/db/fulfillments.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest"
+import type { Env } from "@/types"
+import { recordFulfillment } from "./fulfillments"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							return (queue.shift() as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							return { results: (queue.shift() as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+	}
+	return db
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>): Env {
+	const limiter = {
+		async limit() {
+			return { success: true }
+		},
+	}
+	const cache = {
+		async get() {
+			return null
+		},
+		async put() {},
+		async delete() {},
+		async keys() {
+			return []
+		},
+		async setNX() {
+			return true
+		},
+	}
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		RATE_LIMITER: limiter as unknown as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: limiter as unknown as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+	}
+}
+
+describe("recordFulfillment", () => {
+	it("skips when a servable synced variant already existed pre-insert", async () => {
+		const db = makeMockDB([{ "1": 1 }])
+		const env = makeEnv(db)
+
+		const result = await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		expect(result.recorded).toBe(false)
+		if (!result.recorded) {
+			expect(result.reason).toBe("already_fulfilled")
+		}
+	})
+
+	it("skips when in-window demand is zero (no live requests)", async () => {
+		const db = makeMockDB([null, { demand: 0, request_count: 0 }])
+		const env = makeEnv(db)
+
+		const result = await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		expect(result.recorded).toBe(false)
+		if (!result.recorded) {
+			expect(result.reason).toBe("no_live_demand")
+		}
+	})
+
+	it("writes the fulfillment row and sweeps lyrics_requests on success", async () => {
+		const db = makeMockDB([null, { demand: 5.0, request_count: 3 }, { id: 100 }, null])
+		const env = makeEnv(db)
+
+		const result = await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		expect(result.recorded).toBe(true)
+		const sqls = db.calls.map((c) => c.sql).join("\n")
+		expect(sqls).toMatch(/INSERT INTO request_fulfillments/i)
+		expect(sqls).toMatch(/DELETE FROM lyrics_requests/i)
+	})
+
+	it("excludes self-requests from the snapshot query", async () => {
+		const db = makeMockDB([null, { demand: 0, request_count: 0 }])
+		const env = makeEnv(db)
+
+		await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		const snapshotCall = db.calls.find((c) => c.sql.includes("SUM(weight)"))
+		expect(snapshotCall).toBeDefined()
+		expect(snapshotCall?.sql).toMatch(/requester_id\s*!=\s*\?/)
+		expect(snapshotCall?.params).toContain("k7")
+	})
+
+	it("pre-state check excludes the just-inserted lyrics_id", async () => {
+		const db = makeMockDB([null, { demand: 0, request_count: 0 }])
+		const env = makeEnv(db)
+
+		await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		const preCheck = db.calls[0]
+		expect(preCheck.sql).toMatch(/id\s*!=\s*\?/)
+		expect(preCheck.params).toContain(42)
+	})
+
+	it("inserts with demand and count snapshots bound from the snapshot query", async () => {
+		const db = makeMockDB([null, { demand: 9.5, request_count: 7 }, { id: 100 }, null])
+		const env = makeEnv(db)
+
+		await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO request_fulfillments"))
+		expect(insertCall?.params).toEqual(expect.arrayContaining(["v1", 42, 7, 9.5, 7]))
+	})
+})

--- a/src/db/fulfillments.test.ts
+++ b/src/db/fulfillments.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { Env } from "@/types"
 import {
-	LIVE_FULFILLMENTS_CTE,
 	getFulfillmentByLyricsId,
 	getFulfillmentStatsBySubmitter,
 	recordFulfillment,
@@ -12,9 +11,21 @@ interface DBCall {
 	params: unknown[]
 }
 
-function makeMockDB(queue: unknown[] = []) {
+interface MockDB {
+	calls: DBCall[]
+	prepare(sql: string): {
+		bind(...args: unknown[]): {
+			first<T>(): Promise<T | null>
+			all<T>(): Promise<{ results: T[] }>
+			run(): Promise<void>
+		}
+	}
+	transaction<T>(fn: (tx: MockDB) => Promise<T>): Promise<T>
+}
+
+function makeMockDB(queue: unknown[] = []): MockDB {
 	const calls: DBCall[] = []
-	const db = {
+	const db: MockDB = {
 		calls,
 		prepare(sql: string) {
 			return {
@@ -35,6 +46,9 @@ function makeMockDB(queue: unknown[] = []) {
 					}
 				},
 			}
+		},
+		async transaction<T>(fn: (tx: MockDB) => Promise<T>): Promise<T> {
+			return fn(db)
 		},
 	}
 	return db
@@ -73,8 +87,23 @@ function makeEnv(db: ReturnType<typeof makeMockDB>): Env {
 }
 
 describe("recordFulfillment", () => {
+	it("takes a per-video advisory lock before any reads or writes", async () => {
+		const db = makeMockDB([null, null, { demand: 0, request_count: 0 }])
+		const env = makeEnv(db)
+
+		await recordFulfillment(env, {
+			videoId: "v1",
+			lyricsId: 42,
+			submitterId: 7,
+			submitterKeyId: "k7",
+		})
+
+		expect(db.calls[0].sql).toMatch(/pg_advisory_xact_lock\(hashtext\(\?\)\)/)
+		expect(db.calls[0].params).toEqual(["fulfillment:v1"])
+	})
+
 	it("skips when a servable synced variant already existed pre-insert", async () => {
-		const db = makeMockDB([{ "1": 1 }])
+		const db = makeMockDB([null, { "1": 1 }])
 		const env = makeEnv(db)
 
 		const result = await recordFulfillment(env, {
@@ -91,7 +120,7 @@ describe("recordFulfillment", () => {
 	})
 
 	it("skips when in-window demand is zero (no live requests)", async () => {
-		const db = makeMockDB([null, { demand: 0, request_count: 0 }])
+		const db = makeMockDB([null, null, { demand: 0, request_count: 0 }])
 		const env = makeEnv(db)
 
 		const result = await recordFulfillment(env, {
@@ -108,7 +137,7 @@ describe("recordFulfillment", () => {
 	})
 
 	it("writes the fulfillment row and sweeps lyrics_requests on success", async () => {
-		const db = makeMockDB([null, { demand: 5.0, request_count: 3 }, { id: 100 }, null])
+		const db = makeMockDB([null, null, { demand: 5.0, request_count: 3 }, { id: 100 }, null])
 		const env = makeEnv(db)
 
 		const result = await recordFulfillment(env, {
@@ -125,7 +154,7 @@ describe("recordFulfillment", () => {
 	})
 
 	it("excludes self-requests from the snapshot query", async () => {
-		const db = makeMockDB([null, { demand: 0, request_count: 0 }])
+		const db = makeMockDB([null, null, { demand: 0, request_count: 0 }])
 		const env = makeEnv(db)
 
 		await recordFulfillment(env, {
@@ -142,7 +171,7 @@ describe("recordFulfillment", () => {
 	})
 
 	it("pre-state check excludes the just-inserted lyrics_id", async () => {
-		const db = makeMockDB([null, { demand: 0, request_count: 0 }])
+		const db = makeMockDB([null, null, { demand: 0, request_count: 0 }])
 		const env = makeEnv(db)
 
 		await recordFulfillment(env, {
@@ -152,13 +181,13 @@ describe("recordFulfillment", () => {
 			submitterKeyId: "k7",
 		})
 
-		const preCheck = db.calls[0]
-		expect(preCheck.sql).toMatch(/id\s*!=\s*\?/)
-		expect(preCheck.params).toContain(42)
+		const preCheck = db.calls.find((c) => /id\s*!=\s*\?/.test(c.sql))
+		expect(preCheck).toBeDefined()
+		expect(preCheck?.params).toContain(42)
 	})
 
 	it("inserts with demand and count snapshots bound from the snapshot query", async () => {
-		const db = makeMockDB([null, { demand: 9.5, request_count: 7 }, { id: 100 }, null])
+		const db = makeMockDB([null, null, { demand: 9.5, request_count: 7 }, { id: 100 }, null])
 		const env = makeEnv(db)
 
 		await recordFulfillment(env, {
@@ -238,15 +267,3 @@ describe("getFulfillmentStatsBySubmitter", () => {
 	})
 })
 
-describe("LIVE_FULFILLMENTS_CTE", () => {
-	it("filters deleted lyrics and auto-hidden ones", () => {
-		expect(LIVE_FULFILLMENTS_CTE).toMatch(/l\.deleted_at\s+IS\s+NULL/i)
-		expect(LIVE_FULFILLMENTS_CTE).toContain("downvotes >= 0.8 * l.vote_count")
-	})
-
-	it("picks the most recent fulfillment per video via ROW_NUMBER", () => {
-		expect(LIVE_FULFILLMENTS_CTE).toMatch(
-			/ROW_NUMBER\(\)\s+OVER\s*\(\s*PARTITION\s+BY\s+f\.video_id\s+ORDER\s+BY\s+f\.fulfilled_at\s+DESC\s*\)/i,
-		)
-	})
-})

--- a/src/db/fulfillments.test.ts
+++ b/src/db/fulfillments.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 import type { Env } from "@/types"
-import { recordFulfillment } from "./fulfillments"
+import {
+	LIVE_FULFILLMENTS_CTE,
+	getFulfillmentByLyricsId,
+	getFulfillmentStatsBySubmitter,
+	recordFulfillment,
+} from "./fulfillments"
 
 interface DBCall {
 	sql: string
@@ -165,5 +170,83 @@ describe("recordFulfillment", () => {
 
 		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO request_fulfillments"))
 		expect(insertCall?.params).toEqual(expect.arrayContaining(["v1", 42, 7, 9.5, 7]))
+	})
+})
+
+describe("getFulfillmentByLyricsId", () => {
+	it("filters out deleted and auto-hidden lyrics", async () => {
+		const db = makeMockDB([null])
+		const env = makeEnv(db)
+
+		await getFulfillmentByLyricsId(env, 42)
+
+		const sql = db.calls[0].sql
+		expect(sql).toMatch(/l\.deleted_at\s+IS\s+NULL/i)
+		expect(sql).toContain("downvotes >= 0.8 * l.vote_count")
+		expect(db.calls[0].params).toEqual([42])
+	})
+
+	it("returns the badge fields when present", async () => {
+		const db = makeMockDB([
+			{
+				demand_snapshot: 5.5,
+				request_count_snapshot: 3,
+				fulfilled_at: 1700000000,
+			},
+		])
+		const env = makeEnv(db)
+
+		const result = await getFulfillmentByLyricsId(env, 42)
+
+		expect(result).toEqual({
+			demand: 5.5,
+			requestCount: 3,
+			fulfilledAt: 1700000000,
+		})
+	})
+
+	it("returns null when no live fulfillment exists for the lyric", async () => {
+		const db = makeMockDB([null])
+		const env = makeEnv(db)
+
+		const result = await getFulfillmentByLyricsId(env, 42)
+
+		expect(result).toBeNull()
+	})
+})
+
+describe("getFulfillmentStatsBySubmitter", () => {
+	it("returns zero counts when the submitter has no live fulfillments", async () => {
+		const db = makeMockDB([null])
+		const env = makeEnv(db)
+
+		const result = await getFulfillmentStatsBySubmitter(env, 7)
+
+		expect(result).toEqual({ fulfilledCount: 0, fulfilledDemand: 0 })
+	})
+
+	it("aggregates count and demand for the submitter, filtering hidden lyrics", async () => {
+		const db = makeMockDB([{ count: 3, demand: 11.5 }])
+		const env = makeEnv(db)
+
+		const result = await getFulfillmentStatsBySubmitter(env, 7)
+
+		expect(result).toEqual({ fulfilledCount: 3, fulfilledDemand: 11.5 })
+		const sql = db.calls[0].sql
+		expect(sql).toMatch(/l\.deleted_at\s+IS\s+NULL/i)
+		expect(db.calls[0].params).toEqual([7])
+	})
+})
+
+describe("LIVE_FULFILLMENTS_CTE", () => {
+	it("filters deleted lyrics and auto-hidden ones", () => {
+		expect(LIVE_FULFILLMENTS_CTE).toMatch(/l\.deleted_at\s+IS\s+NULL/i)
+		expect(LIVE_FULFILLMENTS_CTE).toContain("downvotes >= 0.8 * l.vote_count")
+	})
+
+	it("picks the most recent fulfillment per video via ROW_NUMBER", () => {
+		expect(LIVE_FULFILLMENTS_CTE).toMatch(
+			/ROW_NUMBER\(\)\s+OVER\s*\(\s*PARTITION\s+BY\s+f\.video_id\s+ORDER\s+BY\s+f\.fulfilled_at\s+DESC\s*\)/i,
+		)
 	})
 })

--- a/src/db/fulfillments.ts
+++ b/src/db/fulfillments.ts
@@ -20,70 +20,73 @@ export async function recordFulfillment(
 	env: Env,
 	params: RecordFulfillmentParams,
 ): Promise<RecordFulfillmentResult> {
-	const priorServable = await env.DB.prepare(
-		`SELECT 1 FROM lyrics
-		 WHERE video_id = ?
-		   AND id != ?
-		   AND sync_type IN ('linesync', 'richsync')
-		   AND deleted_at IS NULL
-		   AND NOT ${AUTO_HIDE_PREDICATE}
-		 LIMIT 1`,
-	)
-		.bind(params.videoId, params.lyricsId)
-		.first()
+	return env.DB.transaction(async (tx) => {
+		await tx
+			.prepare("SELECT pg_advisory_xact_lock(hashtext(?))")
+			.bind(`fulfillment:${params.videoId}`)
+			.run()
 
-	if (priorServable !== null) {
-		return { recorded: false, reason: "already_fulfilled" }
-	}
+		const priorServable = await tx
+			.prepare(
+				`SELECT 1 FROM lyrics
+				 WHERE video_id = ?
+				   AND id != ?
+				   AND sync_type IN ('linesync', 'richsync')
+				   AND deleted_at IS NULL
+				   AND NOT ${AUTO_HIDE_PREDICATE}
+				 LIMIT 1`,
+			)
+			.bind(params.videoId, params.lyricsId)
+			.first()
 
-	const snapshot = await env.DB.prepare(
-		`SELECT COALESCE(SUM(weight), 0) AS demand, COUNT(*) AS request_count
-		 FROM lyrics_requests
-		 WHERE video_id = ?
-		   AND created_at > ?
-		   AND requester_id != ?`,
-	)
-		.bind(params.videoId, windowCutoff(), params.submitterKeyId)
-		.first<{ demand: number; request_count: number }>()
+		if (priorServable !== null) {
+			return { recorded: false, reason: "already_fulfilled" }
+		}
 
-	const demand = Number(snapshot?.demand ?? 0)
-	const requestCount = Number(snapshot?.request_count ?? 0)
+		const snapshot = await tx
+			.prepare(
+				`SELECT COALESCE(SUM(weight), 0) AS demand, COUNT(*) AS request_count
+				 FROM lyrics_requests
+				 WHERE video_id = ?
+				   AND created_at > ?
+				   AND requester_id != ?`,
+			)
+			.bind(params.videoId, windowCutoff(), params.submitterKeyId)
+			.first<{ demand: number; request_count: number }>()
 
-	if (requestCount === 0) {
-		return { recorded: false, reason: "no_live_demand" }
-	}
+		const demand = Number(snapshot?.demand ?? 0)
+		const requestCount = Number(snapshot?.request_count ?? 0)
 
-	const inserted = await env.DB.prepare(
-		`INSERT INTO request_fulfillments
-		   (video_id, lyrics_id, submitter_id, demand_snapshot, request_count_snapshot)
-		 VALUES (?, ?, ?, ?, ?)
-		 RETURNING id`,
-	)
-		.bind(params.videoId, params.lyricsId, params.submitterId, demand, requestCount)
-		.first<{ id: number }>()
+		if (requestCount === 0) {
+			return { recorded: false, reason: "no_live_demand" }
+		}
 
-	await env.DB.prepare("DELETE FROM lyrics_requests WHERE video_id = ?")
-		.bind(params.videoId)
-		.run()
+		const inserted = await tx
+			.prepare(
+				`INSERT INTO request_fulfillments
+				   (video_id, lyrics_id, submitter_id, demand_snapshot, request_count_snapshot)
+				 VALUES (?, ?, ?, ?, ?)
+				 RETURNING id`,
+			)
+			.bind(params.videoId, params.lyricsId, params.submitterId, demand, requestCount)
+			.first<{ id: number }>()
 
-	log.info("fulfillment recorded", {
-		videoId: params.videoId,
-		lyricsId: params.lyricsId,
-		submitterId: params.submitterId,
-		demand,
-		requestCount,
+		await tx
+			.prepare("DELETE FROM lyrics_requests WHERE video_id = ?")
+			.bind(params.videoId)
+			.run()
+
+		log.info("fulfillment recorded", {
+			videoId: params.videoId,
+			lyricsId: params.lyricsId,
+			submitterId: params.submitterId,
+			demand,
+			requestCount,
+		})
+
+		return { recorded: true, id: inserted!.id, demand, requestCount }
 	})
-
-	return { recorded: true, id: inserted!.id, demand, requestCount }
 }
-
-export const LIVE_FULFILLMENTS_CTE = `
-	SELECT f.*,
-	       ROW_NUMBER() OVER (PARTITION BY f.video_id ORDER BY f.fulfilled_at DESC) AS rn
-	FROM request_fulfillments f
-	JOIN lyrics l ON l.id = f.lyrics_id
-	WHERE l.deleted_at IS NULL AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
-`
 
 export async function getFulfillmentByLyricsId(
 	env: Env,

--- a/src/db/fulfillments.ts
+++ b/src/db/fulfillments.ts
@@ -1,4 +1,4 @@
-import { AUTO_HIDE_PREDICATE, AUTO_HIDE_PREDICATE_JOINED } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE, AUTO_HIDE_PREDICATE_JOINED } from "@/db/predicates"
 import { windowCutoff } from "@/db/requests"
 import { Logger } from "@/infra/logger"
 import type { Env } from "@/types"

--- a/src/db/fulfillments.ts
+++ b/src/db/fulfillments.ts
@@ -1,4 +1,4 @@
-import { AUTO_HIDE_PREDICATE } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE, AUTO_HIDE_PREDICATE_JOINED } from "@/db/lyrics"
 import { windowCutoff } from "@/db/requests"
 import { Logger } from "@/infra/logger"
 import type { Env } from "@/types"
@@ -75,4 +75,57 @@ export async function recordFulfillment(
 	})
 
 	return { recorded: true, id: inserted!.id, demand, requestCount }
+}
+
+export const LIVE_FULFILLMENTS_CTE = `
+	SELECT f.*,
+	       ROW_NUMBER() OVER (PARTITION BY f.video_id ORDER BY f.fulfilled_at DESC) AS rn
+	FROM request_fulfillments f
+	JOIN lyrics l ON l.id = f.lyrics_id
+	WHERE l.deleted_at IS NULL AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
+`
+
+export async function getFulfillmentByLyricsId(
+	env: Env,
+	lyricsId: number,
+): Promise<{ demand: number; requestCount: number; fulfilledAt: number } | null> {
+	const row = await env.DB.prepare(
+		`SELECT f.demand_snapshot, f.request_count_snapshot, f.fulfilled_at
+		 FROM request_fulfillments f
+		 JOIN lyrics l ON l.id = f.lyrics_id
+		 WHERE f.lyrics_id = ?
+		   AND l.deleted_at IS NULL
+		   AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
+		 LIMIT 1`,
+	)
+		.bind(lyricsId)
+		.first<{ demand_snapshot: number; request_count_snapshot: number; fulfilled_at: number }>()
+
+	if (!row) return null
+	return {
+		demand: Number(row.demand_snapshot),
+		requestCount: Number(row.request_count_snapshot),
+		fulfilledAt: Number(row.fulfilled_at),
+	}
+}
+
+export async function getFulfillmentStatsBySubmitter(
+	env: Env,
+	submitterId: number,
+): Promise<{ fulfilledCount: number; fulfilledDemand: number }> {
+	const row = await env.DB.prepare(
+		`SELECT COUNT(*) AS count, COALESCE(SUM(f.demand_snapshot), 0) AS demand
+		 FROM request_fulfillments f
+		 JOIN lyrics l ON l.id = f.lyrics_id
+		 WHERE f.submitter_id = ?
+		   AND l.deleted_at IS NULL
+		   AND NOT ${AUTO_HIDE_PREDICATE_JOINED}`,
+	)
+		.bind(submitterId)
+		.first<{ count: number; demand: number }>()
+
+	return {
+		fulfilledCount: Number(row?.count ?? 0),
+		fulfilledDemand: Number(row?.demand ?? 0),
+	}
 }

--- a/src/db/fulfillments.ts
+++ b/src/db/fulfillments.ts
@@ -1,0 +1,78 @@
+import { AUTO_HIDE_PREDICATE } from "@/db/lyrics"
+import { windowCutoff } from "@/db/requests"
+import { Logger } from "@/infra/logger"
+import type { Env } from "@/types"
+
+const log = new Logger("db")
+
+export type RecordFulfillmentResult =
+	| { recorded: true; id: number; demand: number; requestCount: number }
+	| { recorded: false; reason: "already_fulfilled" | "no_live_demand" }
+
+interface RecordFulfillmentParams {
+	videoId: string
+	lyricsId: number
+	submitterId: number
+	submitterKeyId: string
+}
+
+export async function recordFulfillment(
+	env: Env,
+	params: RecordFulfillmentParams,
+): Promise<RecordFulfillmentResult> {
+	const priorServable = await env.DB.prepare(
+		`SELECT 1 FROM lyrics
+		 WHERE video_id = ?
+		   AND id != ?
+		   AND sync_type IN ('linesync', 'richsync')
+		   AND deleted_at IS NULL
+		   AND NOT ${AUTO_HIDE_PREDICATE}
+		 LIMIT 1`,
+	)
+		.bind(params.videoId, params.lyricsId)
+		.first()
+
+	if (priorServable !== null) {
+		return { recorded: false, reason: "already_fulfilled" }
+	}
+
+	const snapshot = await env.DB.prepare(
+		`SELECT COALESCE(SUM(weight), 0) AS demand, COUNT(*) AS request_count
+		 FROM lyrics_requests
+		 WHERE video_id = ?
+		   AND created_at > ?
+		   AND requester_id != ?`,
+	)
+		.bind(params.videoId, windowCutoff(), params.submitterKeyId)
+		.first<{ demand: number; request_count: number }>()
+
+	const demand = Number(snapshot?.demand ?? 0)
+	const requestCount = Number(snapshot?.request_count ?? 0)
+
+	if (requestCount === 0) {
+		return { recorded: false, reason: "no_live_demand" }
+	}
+
+	const inserted = await env.DB.prepare(
+		`INSERT INTO request_fulfillments
+		   (video_id, lyrics_id, submitter_id, demand_snapshot, request_count_snapshot)
+		 VALUES (?, ?, ?, ?, ?)
+		 RETURNING id`,
+	)
+		.bind(params.videoId, params.lyricsId, params.submitterId, demand, requestCount)
+		.first<{ id: number }>()
+
+	await env.DB.prepare("DELETE FROM lyrics_requests WHERE video_id = ?")
+		.bind(params.videoId)
+		.run()
+
+	log.info("fulfillment recorded", {
+		videoId: params.videoId,
+		lyricsId: params.lyricsId,
+		submitterId: params.submitterId,
+		demand,
+		requestCount,
+	})
+
+	return { recorded: true, id: inserted!.id, demand, requestCount }
+}

--- a/src/db/leaderboard.test.ts
+++ b/src/db/leaderboard.test.ts
@@ -132,3 +132,55 @@ describe("getCuratorLeaderboard", () => {
 		expect(result[1].rank).toBe(2)
 	})
 })
+
+describe("getCuratorLeaderboard fulfillment fields", () => {
+	it("returns fulfilledCount and fulfilledDemand on each row", async () => {
+		const db = makeMockDB([
+			[
+				{
+					key_id: "k1",
+					reputation: 1.5,
+					score: 30,
+					submission_count: 8,
+					total_upvotes: 50,
+					fulfilled_count: 4,
+					fulfilled_demand: 12.5,
+				},
+				{
+					key_id: "k2",
+					reputation: 1.0,
+					score: 5,
+					submission_count: 2,
+					total_upvotes: 7,
+					fulfilled_count: 0,
+					fulfilled_demand: 0,
+				},
+			],
+		])
+		const env = makeEnv(db)
+
+		const result = await getCuratorLeaderboard(env, 200)
+
+		expect(result[0]).toMatchObject({
+			keyId: "k1",
+			fulfilledCount: 4,
+			fulfilledDemand: 12.5,
+		})
+		expect(result[1]).toMatchObject({
+			keyId: "k2",
+			fulfilledCount: 0,
+			fulfilledDemand: 0,
+		})
+	})
+
+	it("joins against live fulfillments (filters deleted/auto-hidden)", async () => {
+		const db = makeMockDB([[]])
+		const env = makeEnv(db)
+
+		await getCuratorLeaderboard(env, 200)
+
+		const sql = db.calls[0].sql
+		expect(sql).toMatch(/request_fulfillments/i)
+		expect(sql).toMatch(/l\.deleted_at\s+IS\s+NULL/i)
+	})
+})

--- a/src/db/leaderboard.ts
+++ b/src/db/leaderboard.ts
@@ -1,5 +1,5 @@
 import { config } from "@/config"
-import { AUTO_HIDE_PREDICATE, AUTO_HIDE_PREDICATE_JOINED, RANKING_EXPR } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE, AUTO_HIDE_PREDICATE_JOINED, RANKING_EXPR } from "@/db/predicates"
 import { windowCutoff } from "@/db/requests"
 import type { Env } from "@/types"
 

--- a/src/db/leaderboard.ts
+++ b/src/db/leaderboard.ts
@@ -1,5 +1,5 @@
 import { config } from "@/config"
-import { AUTO_HIDE_PREDICATE, RANKING_EXPR } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE, AUTO_HIDE_PREDICATE_JOINED, RANKING_EXPR } from "@/db/lyrics"
 import { windowCutoff } from "@/db/requests"
 import type { Env } from "@/types"
 
@@ -138,6 +138,8 @@ export interface CuratorLeaderboardRow {
 	score: number
 	submissionCount: number
 	totalUpvotes: number
+	fulfilledCount: number
+	fulfilledDemand: number
 	rank: number
 }
 
@@ -147,6 +149,8 @@ interface CuratorRow {
 	score: number
 	submission_count: number
 	total_upvotes: number
+	fulfilled_count: number
+	fulfilled_demand: number
 }
 
 export async function getCuratorLeaderboard(
@@ -155,7 +159,9 @@ export async function getCuratorLeaderboard(
 ): Promise<CuratorLeaderboardRow[]> {
 	const res = await env.DB.prepare(
 		`SELECT u.key_id, u.reputation,
-		        agg.score, agg.submission_count, agg.total_upvotes
+		        agg.score, agg.submission_count, agg.total_upvotes,
+		        COALESCE(ff.fulfilled_count, 0) AS fulfilled_count,
+		        COALESCE(ff.fulfilled_demand, 0) AS fulfilled_demand
 		 FROM (
 		   SELECT submitter_id,
 		          SUM(effective_score) AS score,
@@ -168,6 +174,15 @@ export async function getCuratorLeaderboard(
 		   GROUP BY submitter_id
 		 ) agg
 		 JOIN users u ON u.id = agg.submitter_id
+		 LEFT JOIN (
+		   SELECT f.submitter_id,
+		          COUNT(*) AS fulfilled_count,
+		          SUM(f.demand_snapshot) AS fulfilled_demand
+		   FROM request_fulfillments f
+		   JOIN lyrics l ON l.id = f.lyrics_id
+		   WHERE l.deleted_at IS NULL AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
+		   GROUP BY f.submitter_id
+		 ) ff ON ff.submitter_id = u.id
 		 ORDER BY agg.score DESC, u.key_id ASC
 		 LIMIT ?`
 	)
@@ -180,6 +195,8 @@ export async function getCuratorLeaderboard(
 		score: Number(r.score),
 		submissionCount: Number(r.submission_count),
 		totalUpvotes: Number(r.total_upvotes),
+		fulfilledCount: Number(r.fulfilled_count ?? 0),
+		fulfilledDemand: Number(r.fulfilled_demand ?? 0),
 		rank: i + 1,
 	}))
 }

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,8 +1,6 @@
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
-	AUTO_HIDE_PREDICATE,
-	RANKING_EXPR,
 	findBySongArtist,
 	findByVideoId,
 	findVariantsByVideoId,
@@ -13,6 +11,7 @@ import {
 	softDeleteLyrics,
 	submitLyrics,
 } from "./lyrics"
+import { AUTO_HIDE_PREDICATE, RANKING_EXPR } from "./predicates"
 
 // -- Mocks -----------------------------------------------------------------
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,4 +1,4 @@
-import type { Env, LyricsRow, LyricsSearchResult } from "@/types"
+import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	AUTO_HIDE_PREDICATE,
@@ -11,6 +11,7 @@ import {
 	searchByQuery,
 	searchBySongArtist,
 	softDeleteLyrics,
+	submitLyrics,
 } from "./lyrics"
 
 // -- Mocks -----------------------------------------------------------------
@@ -681,5 +682,68 @@ describe("hidden flag on browse surfaces", () => {
 		const env = createEnv(db, createMockCache())
 		await findVariantsByVideoId(env, "v1", 5)
 		expect(db.calls[0].sql).not.toContain("AND NOT")
+	})
+})
+
+function buildSubmission(over: Partial<LyricsSubmission> = {}): LyricsSubmission {
+	return {
+		videoId: "vid-sub",
+		song: "Song",
+		artist: "Artist",
+		duration: 200,
+		lyrics: SAMPLE_LYRICS,
+		format: "lrc",
+		syncType: "linesync",
+		...over,
+	}
+}
+
+describe("submitLyrics fulfillment integration", () => {
+	it("records a fulfillment for synced submissions with live demand", async () => {
+		const db = createMockDB([
+			{ count: 0 },
+			{ id: 555 },
+			{ key_id: "k1" },
+			null,
+			{ demand: 4, request_count: 2 },
+			{ id: 1 },
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await submitLyrics(env, buildSubmission({ syncType: "linesync" }), 7)
+
+		expect(result.created).toBe(true)
+		const sqls = db.calls.map((c) => c.sql).join("\n")
+		expect(sqls).toMatch(/INSERT INTO request_fulfillments/i)
+		expect(sqls).toMatch(/DELETE FROM lyrics_requests/i)
+	})
+
+	it("skips fulfillment for plain submissions", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 556 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await submitLyrics(env, buildSubmission({ syncType: "plain" }), 7)
+
+		const sqls = db.calls.map((c) => c.sql).join("\n")
+		expect(sqls).not.toMatch(/INSERT INTO request_fulfillments/i)
+	})
+
+	it("skips fulfillment when a prior synced variant exists", async () => {
+		const db = createMockDB([
+			{ count: 0 },
+			{ id: 557 },
+			{ key_id: "k1" },
+			{ "1": 1 },
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await submitLyrics(env, buildSubmission({ syncType: "richsync" }), 7)
+
+		const sqls = db.calls.map((c) => c.sql).join("\n")
+		expect(sqls).not.toMatch(/INSERT INTO request_fulfillments/i)
 	})
 })

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -27,11 +27,12 @@ interface MockDB {
 			run(): Promise<void>
 		}
 	}
+	transaction<T>(fn: (tx: MockDB) => Promise<T>): Promise<T>
 }
 
 function createMockDB(queue: unknown[] = []): MockDB {
 	const calls: Recorded[] = []
-	return {
+	const db: MockDB = {
 		calls,
 		queue,
 		prepare(sql: string) {
@@ -56,7 +57,11 @@ function createMockDB(queue: unknown[] = []): MockDB {
 				},
 			}
 		},
+		async transaction<T>(fn: (tx: MockDB) => Promise<T>): Promise<T> {
+			return fn(db)
+		},
 	}
+	return db
 }
 
 interface MockCache {
@@ -704,6 +709,7 @@ describe("submitLyrics fulfillment integration", () => {
 			{ id: 555 },
 			{ key_id: "k1" },
 			null,
+			null,
 			{ demand: 4, request_count: 2 },
 			{ id: 1 },
 			null,
@@ -735,6 +741,7 @@ describe("submitLyrics fulfillment integration", () => {
 			{ count: 0 },
 			{ id: 557 },
 			{ key_id: "k1" },
+			null,
 			{ "1": 1 },
 		])
 		const cache = createMockCache()

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -1,5 +1,11 @@
 import { config } from "@/config"
 import { recordFulfillment } from "@/db/fulfillments"
+import {
+	AUTO_HIDE_PREDICATE,
+	AUTO_HIDE_PREDICATE_JOINED,
+	RANKING_EXPR,
+	RANKING_EXPR_JOINED,
+} from "@/db/predicates"
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
@@ -8,46 +14,6 @@ import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
 const log = new Logger("db")
 const cacheLog = new Logger("cache")
-
-// Composite ranking: community confidence + recency boost + sync quality
-// - effective_score × ln(vote_count + base): amplifies scores backed by more votes
-// - recencyWeight / (1 + age_days): surfaces new entries, decays within days
-// - sync_type multiplier: richsync > linesync > plain
-const { syncTypeBoost } = config.ranking
-const buildRankingExpr = (prefix: string) => {
-	const syncTypeBoostExpr = `CASE ${prefix}sync_type
-		WHEN 'richsync' THEN ${syncTypeBoost.richsync}
-		WHEN 'linesync' THEN ${syncTypeBoost.linesync}
-		ELSE ${syncTypeBoost.plain}
-	END`
-	return `(
-		(${prefix}effective_score * LN(${prefix}vote_count + ${config.ranking.confidenceBase})
-		+ ${config.ranking.recencyWeight} / (1.0 + (EXTRACT(EPOCH FROM NOW())::INTEGER - ${prefix}created_at) / 86400.0))
-		* ${syncTypeBoostExpr}
-	)`
-}
-
-export const RANKING_EXPR = buildRankingExpr("")
-const RANKING_EXPR_JOINED = buildRankingExpr("l.")
-
-const { autoHide } = config.moderation
-
-const buildAutoHidePredicate = (prefix: string) => `(
-	(
-		${prefix}vote_count >= ${autoHide.minVotes}
-		AND ${prefix}downvotes >= ${autoHide.downvoteRatio} * ${prefix}vote_count
-		AND ${prefix}effective_score < ${autoHide.maxEffectiveScore}
-	)
-	OR
-	(
-		${prefix}vote_count >= ${autoHide.decisiveMinVotes}
-		AND ${prefix}downvotes = ${prefix}vote_count
-		AND EXTRACT(EPOCH FROM NOW())::INTEGER - ${prefix}created_at >= ${autoHide.decisiveMinAgeDays * 86400}
-	)
-)`
-
-export const AUTO_HIDE_PREDICATE = buildAutoHidePredicate("")
-export const AUTO_HIDE_PREDICATE_JOINED = buildAutoHidePredicate("l.")
 
 const LYRICS_WITH_SUBMITTER = `
 	SELECT l.*, u.key_id AS submitter_key_id, u.reputation AS submitter_reputation,

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -1,4 +1,5 @@
 import { config } from "@/config"
+import { recordFulfillment } from "@/db/fulfillments"
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
@@ -228,7 +229,21 @@ export async function submitLyrics(
 		sync_type: submission.syncType,
 	})
 
-	// Invalidate cache so the new variant competes in ranking
+	if (submission.syncType === "linesync" || submission.syncType === "richsync") {
+		const submitter = await env.DB.prepare("SELECT key_id FROM users WHERE id = ?")
+			.bind(submitterId)
+			.first<{ key_id: string }>()
+
+		if (submitter) {
+			await recordFulfillment(env, {
+				videoId: submission.videoId,
+				lyricsId: result!.id,
+				submitterId,
+				submitterKeyId: submitter.key_id,
+			})
+		}
+	}
+
 	await invalidateCache(env, submission.videoId)
 
 	return { id: result!.id, created: true }

--- a/src/db/predicates.ts
+++ b/src/db/predicates.ts
@@ -1,0 +1,37 @@
+import { config } from "@/config"
+
+const { syncTypeBoost } = config.ranking
+const buildRankingExpr = (prefix: string) => {
+	const syncTypeBoostExpr = `CASE ${prefix}sync_type
+		WHEN 'richsync' THEN ${syncTypeBoost.richsync}
+		WHEN 'linesync' THEN ${syncTypeBoost.linesync}
+		ELSE ${syncTypeBoost.plain}
+	END`
+	return `(
+		(${prefix}effective_score * LN(${prefix}vote_count + ${config.ranking.confidenceBase})
+		+ ${config.ranking.recencyWeight} / (1.0 + (EXTRACT(EPOCH FROM NOW())::INTEGER - ${prefix}created_at) / 86400.0))
+		* ${syncTypeBoostExpr}
+	)`
+}
+
+export const RANKING_EXPR = buildRankingExpr("")
+export const RANKING_EXPR_JOINED = buildRankingExpr("l.")
+
+const { autoHide } = config.moderation
+
+const buildAutoHidePredicate = (prefix: string) => `(
+	(
+		${prefix}vote_count >= ${autoHide.minVotes}
+		AND ${prefix}downvotes >= ${autoHide.downvoteRatio} * ${prefix}vote_count
+		AND ${prefix}effective_score < ${autoHide.maxEffectiveScore}
+	)
+	OR
+	(
+		${prefix}vote_count >= ${autoHide.decisiveMinVotes}
+		AND ${prefix}downvotes = ${prefix}vote_count
+		AND EXTRACT(EPOCH FROM NOW())::INTEGER - ${prefix}created_at >= ${autoHide.decisiveMinAgeDays * 86400}
+	)
+)`
+
+export const AUTO_HIDE_PREDICATE = buildAutoHidePredicate("")
+export const AUTO_HIDE_PREDICATE_JOINED = buildAutoHidePredicate("l.")

--- a/src/db/profile.ts
+++ b/src/db/profile.ts
@@ -1,4 +1,4 @@
-import { AUTO_HIDE_PREDICATE_JOINED } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE_JOINED } from "@/db/predicates"
 import type { Confidence, Env, LyricsFormat } from "@/types"
 
 export interface SubmissionRow {

--- a/src/db/requests.ts
+++ b/src/db/requests.ts
@@ -1,5 +1,5 @@
 import { config } from "@/config"
-import { AUTO_HIDE_PREDICATE } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE } from "@/db/predicates"
 import type { Env } from "@/types"
 
 export interface RequestDemand {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { Logger, flushLogs } from "@/infra/logger"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
 import { backfillTextSearch } from "@/jobs/backfill-text-search"
+import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
 import { runDumpJob } from "@/jobs/dump"
 import { updateScores } from "@/jobs/score-updater"
 import { authRoutes } from "@/routes/auth"
@@ -223,6 +224,14 @@ backfillFormatDetection(env)
 		if (changed > 0) log.info("format backfill complete", { scanned, changed })
 	})
 	.catch((err) => log.error("format backfill failed", { error: (err as Error).message }))
+
+cleanupFulfilledRequests(env)
+	.then(({ deleted }) => {
+		if (deleted > 0) log.info("cleanup fulfilled requests complete", { deleted })
+	})
+	.catch((err) =>
+		log.error("cleanup fulfilled requests failed", { error: (err as Error).message }),
+	)
 
 process.on("unhandledRejection", (reason) => {
 	const err = reason instanceof Error ? reason : new Error(String(reason))

--- a/src/infra/database.ts
+++ b/src/infra/database.ts
@@ -27,14 +27,15 @@ export async function closePool(): Promise<void> {
 	}
 }
 
+type Queryable = pg.Pool | pg.PoolClient
+
 class PreparedStatement {
 	readonly sql: string
 	private params: unknown[] = []
-	private pool: pg.Pool
+	private queryable: Queryable
 
-	constructor(pool: pg.Pool, sql: string) {
-		this.pool = pool
-		// Convert ? placeholders to $1, $2, ... for PostgreSQL
+	constructor(queryable: Queryable, sql: string) {
+		this.queryable = queryable
 		let idx = 0
 		this.sql = sql.replace(/\?/g, () => `$${++idx}`)
 	}
@@ -45,17 +46,17 @@ class PreparedStatement {
 	}
 
 	async first<T>(): Promise<T | null> {
-		const result = await this.pool.query(this.sql, this.params)
+		const result = await this.queryable.query(this.sql, this.params)
 		return (result.rows[0] as T) ?? null
 	}
 
 	async all<T>(): Promise<{ results: T[] }> {
-		const result = await this.pool.query(this.sql, this.params)
+		const result = await this.queryable.query(this.sql, this.params)
 		return { results: result.rows as T[] }
 	}
 
 	async run(): Promise<void> {
-		await this.pool.query(this.sql, this.params)
+		await this.queryable.query(this.sql, this.params)
 	}
 
 	getSql(): string {
@@ -69,16 +70,28 @@ class PreparedStatement {
 
 export class D1Compat {
 	private pool: pg.Pool
+	private client: pg.PoolClient | null
 
-	constructor(pool: pg.Pool) {
+	constructor(pool: pg.Pool, client: pg.PoolClient | null = null) {
 		this.pool = pool
+		this.client = client
+	}
+
+	private get queryable(): Queryable {
+		return this.client ?? this.pool
 	}
 
 	prepare(sql: string): PreparedStatement {
-		return new PreparedStatement(this.pool, sql)
+		return new PreparedStatement(this.queryable, sql)
 	}
 
 	async batch(statements: PreparedStatement[]): Promise<void> {
+		if (this.client) {
+			for (const stmt of statements) {
+				await this.client.query(stmt.getSql(), stmt.getParams())
+			}
+			return
+		}
 		const client = await this.pool.connect()
 		try {
 			await client.query("BEGIN")
@@ -86,6 +99,25 @@ export class D1Compat {
 				await client.query(stmt.getSql(), stmt.getParams())
 			}
 			await client.query("COMMIT")
+		} catch (err) {
+			await client.query("ROLLBACK")
+			throw err
+		} finally {
+			client.release()
+		}
+	}
+
+	async transaction<T>(fn: (tx: D1Compat) => Promise<T>): Promise<T> {
+		if (this.client) {
+			return fn(this)
+		}
+		const client = await this.pool.connect()
+		try {
+			await client.query("BEGIN")
+			const tx = new D1Compat(this.pool, client)
+			const result = await fn(tx)
+			await client.query("COMMIT")
+			return result
 		} catch (err) {
 			await client.query("ROLLBACK")
 			throw err

--- a/src/jobs/cleanup-fulfilled-requests.ts
+++ b/src/jobs/cleanup-fulfilled-requests.ts
@@ -1,0 +1,37 @@
+import { AUTO_HIDE_PREDICATE_JOINED } from "@/db/predicates"
+import { Logger } from "@/infra/logger"
+import type { Env } from "@/types"
+
+const log = new Logger("cleanup")
+const BATCH_SIZE = 500
+
+export async function cleanupFulfilledRequests(env: Env): Promise<{ deleted: number }> {
+	let deleted = 0
+
+	while (true) {
+		const batch = await env.DB.prepare(
+			`DELETE FROM lyrics_requests
+			 WHERE id IN (
+			   SELECT lr.id FROM lyrics_requests lr
+			   WHERE EXISTS (
+			     SELECT 1 FROM lyrics l
+			     WHERE l.video_id = lr.video_id
+			       AND l.sync_type IN ('linesync', 'richsync')
+			       AND l.deleted_at IS NULL
+			       AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
+			   )
+			   LIMIT ?
+			 )
+			 RETURNING id`,
+		)
+			.bind(BATCH_SIZE)
+			.all<{ id: number }>()
+
+		const count = batch.results?.length ?? 0
+		if (count === 0) break
+		deleted += count
+		log.info("cleanup batch complete", { batch: count, total: deleted })
+	}
+
+	return { deleted }
+}

--- a/src/routes/lyrics.transformers.test.ts
+++ b/src/routes/lyrics.transformers.test.ts
@@ -116,6 +116,31 @@ describe("toResponse", () => {
 	})
 })
 
+describe("toResponse fulfillment badge", () => {
+	it("omits fulfilled when no badge provided", () => {
+		const res = toResponse(baseRow)
+		expect(res.fulfilled).toBeUndefined()
+	})
+
+	it("includes fulfilled when badge provided", () => {
+		const res = toResponse(baseRow, {
+			demand: 3.5,
+			requestCount: 2,
+			fulfilledAt: 1700000000,
+		})
+		expect(res.fulfilled).toEqual({
+			demand: 3.5,
+			requestCount: 2,
+			fulfilledAt: 1700000000,
+		})
+	})
+
+	it("passes null through as undefined", () => {
+		const res = toResponse(baseRow, null)
+		expect(res.fulfilled).toBeUndefined()
+	})
+})
+
 describe("toSearchResponse", () => {
 	const baseSearchRow: LyricsSearchResult = {
 		id: 7,

--- a/src/routes/lyrics.transformers.ts
+++ b/src/routes/lyrics.transformers.ts
@@ -1,4 +1,9 @@
-import type { Confidence, LyricsResponse, LyricsSearchResult } from "@/types"
+import type {
+	Confidence,
+	LyricsFulfillmentBadge,
+	LyricsResponse,
+	LyricsSearchResult,
+} from "@/types"
 
 export interface LyricsRowForResponse {
 	id: number
@@ -20,7 +25,10 @@ export interface LyricsRowForResponse {
 	hidden?: boolean
 }
 
-export function toResponse(row: LyricsRowForResponse): LyricsResponse {
+export function toResponse(
+	row: LyricsRowForResponse,
+	fulfilled?: LyricsFulfillmentBadge | null
+): LyricsResponse {
 	const submitter =
 		row.submitter_key_id != null && row.submitter_reputation != null
 			? { keyId: row.submitter_key_id, reputation: row.submitter_reputation }
@@ -43,6 +51,7 @@ export function toResponse(row: LyricsRowForResponse): LyricsResponse {
 		confidence: row.confidence,
 		hidden: row.hidden ?? false,
 		submitter,
+		fulfilled: fulfilled ?? undefined,
 	}
 }
 

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -1,6 +1,7 @@
 import { config } from "@/config"
 import { getMySubmissions } from "@/db/feed"
 import { parseFeedFilters } from "@/db/feed-filters"
+import { getFulfillmentByLyricsId } from "@/db/fulfillments"
 import {
 	findBySongArtist,
 	findByVideoId,
@@ -73,8 +74,11 @@ export const lyricsRoutes = (env: Env) =>
 					if (!result) {
 						return status(404, buildError(ErrorCode.NOT_FOUND))
 					}
-					const userVote = lyricsUserId ? await getUserVote(env, result.id, lyricsUserId) : null
-					return { success: true, data: { ...toResponse(result), userVote } }
+					const [userVote, fulfilled] = await Promise.all([
+						lyricsUserId ? getUserVote(env, result.id, lyricsUserId) : Promise.resolve(null),
+						getFulfillmentByLyricsId(env, result.id),
+					])
+					return { success: true, data: { ...toResponse(result, fulfilled), userVote } }
 				}
 
 				if (query.song && query.artist) {
@@ -89,8 +93,11 @@ export const lyricsRoutes = (env: Env) =>
 					if (!result) {
 						return status(404, buildError(ErrorCode.NOT_FOUND))
 					}
-					const userVote = lyricsUserId ? await getUserVote(env, result.id, lyricsUserId) : null
-					return { success: true, data: { ...toResponse(result), userVote } }
+					const [userVote, fulfilled] = await Promise.all([
+						lyricsUserId ? getUserVote(env, result.id, lyricsUserId) : Promise.resolve(null),
+						getFulfillmentByLyricsId(env, result.id),
+					])
+					return { success: true, data: { ...toResponse(result, fulfilled), userVote } }
 				}
 
 				return status(400, buildError(ErrorCode.MISSING_QUERY))
@@ -134,7 +141,7 @@ export const lyricsRoutes = (env: Env) =>
 						query.album,
 						limit
 					)
-					return { success: true, data: results.map(toResponse) }
+					return { success: true, data: results.map((row) => toResponse(row)) }
 				}
 
 				return status(
@@ -169,7 +176,7 @@ export const lyricsRoutes = (env: Env) =>
 						})
 					)
 				}
-				return { success: true, data: results.map(toResponse) }
+				return { success: true, data: results.map((row) => toResponse(row)) }
 			},
 			{
 				params: t.Object({ videoId: t.String() }),
@@ -238,8 +245,11 @@ export const lyricsRoutes = (env: Env) =>
 					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 
-				const userVote = lyricsUserId ? await getUserVote(env, result.id, lyricsUserId) : null
-				return { success: true, data: { ...toResponse(result), userVote } }
+				const [userVote, fulfilled] = await Promise.all([
+					lyricsUserId ? getUserVote(env, result.id, lyricsUserId) : Promise.resolve(null),
+					getFulfillmentByLyricsId(env, result.id),
+				])
+				return { success: true, data: { ...toResponse(result, fulfilled), userVote } }
 			},
 			{
 				params: t.Object({ id: t.String() }),

--- a/src/routes/users.test.ts
+++ b/src/routes/users.test.ts
@@ -219,3 +219,37 @@ describe("GET /users/:keyId/submissions", () => {
 		expect(db.calls.length).toBe(0)
 	})
 })
+
+describe("GET /users/:keyId/stats", () => {
+	it("returns zero stats when the user has no fulfillments", async () => {
+		const db = makeMockDB([{ id: 9 }, null])
+		const env = makeEnv(db)
+		const app = userRoutes(env)
+
+		const res = await app.handle(new Request(`http://localhost/users/${KEY}/stats`))
+		const body = (await res.json()) as { success: boolean; data: unknown }
+
+		expect(body.success).toBe(true)
+		expect(body.data).toEqual({ fulfilledCount: 0, fulfilledDemand: 0 })
+	})
+
+	it("returns counts when the user has fulfillments", async () => {
+		const db = makeMockDB([{ id: 9 }, { count: 3, demand: 7.5 }])
+		const env = makeEnv(db)
+		const app = userRoutes(env)
+
+		const res = await app.handle(new Request(`http://localhost/users/${KEY}/stats`))
+		const body = (await res.json()) as { success: boolean; data: unknown }
+
+		expect(body.data).toEqual({ fulfilledCount: 3, fulfilledDemand: 7.5 })
+	})
+
+	it("returns 404 when the user does not exist", async () => {
+		const db = makeMockDB([null])
+		const env = makeEnv(db)
+		const app = userRoutes(env)
+
+		const res = await app.handle(new Request(`http://localhost/users/${KEY}/stats`))
+		expect(res.status).toBe(404)
+	})
+})

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,8 @@
 import { Elysia, t } from "elysia"
+import { getFulfillmentStatsBySubmitter } from "@/db/fulfillments"
 import { getSubmissionsByUser } from "@/db/profile"
 import type { Env } from "@/types"
+import { ErrorCode, buildError } from "@/utils/errors"
 import { readRateLimit } from "@/utils/read-rate-limit"
 
 const DEFAULT_LIMIT = 20
@@ -43,4 +45,18 @@ export const userRoutes = (env: Env) =>
 					cursor: t.Optional(t.String({ pattern: "^[0-9]+:[0-9]+$" })),
 				}),
 			}
+		)
+		.get(
+			"/:keyId/stats",
+			async ({ params, env, status }) => {
+				const user = await env.DB.prepare("SELECT id FROM users WHERE key_id = ?")
+					.bind(params.keyId)
+					.first<{ id: number }>()
+				if (!user) {
+					return status(404, buildError(ErrorCode.NOT_FOUND))
+				}
+				const stats = await getFulfillmentStatsBySubmitter(env, user.id)
+				return { success: true, data: stats }
+			},
+			{ params: t.Object({ keyId: t.String({ pattern: "^[0-9a-fA-F]{64}$" }) }) }
 		)

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,25 +118,10 @@ export interface LyricsResponse {
 	userVote?: 1 | -1 | null
 }
 
-export interface RequestFulfillment {
-	id: number
-	videoId: string
-	lyricsId: number
-	submitterId: number | null
-	demandSnapshot: number
-	requestCountSnapshot: number
-	fulfilledAt: number
-}
-
 export interface LyricsFulfillmentBadge {
 	demand: number
 	requestCount: number
 	fulfilledAt: number
-}
-
-export interface UserFulfillmentStats {
-	fulfilledCount: number
-	fulfilledDemand: number
 }
 
 export interface LyricsSearchResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,7 +114,29 @@ export interface LyricsResponse {
 	confidence: Confidence
 	hidden: boolean
 	submitter?: SubmitterInfo
+	fulfilled?: LyricsFulfillmentBadge | null
 	userVote?: 1 | -1 | null
+}
+
+export interface RequestFulfillment {
+	id: number
+	videoId: string
+	lyricsId: number
+	submitterId: number | null
+	demandSnapshot: number
+	requestCountSnapshot: number
+	fulfilledAt: number
+}
+
+export interface LyricsFulfillmentBadge {
+	demand: number
+	requestCount: number
+	fulfilledAt: number
+}
+
+export interface UserFulfillmentStats {
+	fulfilledCount: number
+	fulfilledDemand: number
 }
 
 export interface LyricsSearchResult {


### PR DESCRIPTION
## Overview

- New `request_fulfillments` table snapshots demand when a synced submission fills a video that had no servable synced variant. `submitLyrics` writes the snapshot and sweeps the matching `lyrics_requests` rows inline.