### PR TITLE
feat(lyrics): trust gate, penalty cascade, vote weight floor

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -152,6 +152,10 @@ CREATE INDEX IF NOT EXISTS idx_lyrics_submitter_created
     ON lyrics(submitter_id, created_at DESC)
     WHERE deleted_at IS NULL;
 
+-- Reputation penalty idempotency: tracks whether the auto-hide / dirty-delete
+-- penalty has already been applied for this row.
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS reputation_penalized BOOLEAN DEFAULT FALSE;
+
 -- Lyrics requests: demand signal for songs missing synced lyrics
 CREATE TABLE IF NOT EXISTS requested_songs (
     video_id TEXT PRIMARY KEY,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { config } from "@/config"
+
+describe("config additions for abuse mitigation", () => {
+	it("exposes autoHide.reputationPenalty", () => {
+		expect(config.moderation.autoHide.reputationPenalty).toBe(0.2)
+	})
+
+	it("exposes reputation.voteWeightFloor", () => {
+		expect(config.reputation.voteWeightFloor).toBe(0.5)
+	})
+
+	it("exposes ranking.primarySlot floor and minVotes", () => {
+		expect(config.ranking.primarySlot.repFloor).toBe(1.0)
+		expect(config.ranking.primarySlot.minVotes).toBe(3)
+	})
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export const config = {
 			maxEffectiveScore: -0.5,
 			decisiveMinVotes: 3,
 			decisiveMinAgeDays: 3,
+			reputationPenalty: 0.2,
 		},
 	},
 
@@ -32,6 +33,7 @@ export const config = {
 		consensusDelta: 0.1,
 		selfVoteWeight: 0.5,
 		minVotesForConfidence: 5,
+		voteWeightFloor: 0.5,
 	},
 
 	ranking: {
@@ -41,6 +43,10 @@ export const config = {
 			richsync: 1.3,
 			linesync: 1.0,
 			plain: 0.7,
+		},
+		primarySlot: {
+			repFloor: 1.0,
+			minVotes: 3,
 		},
 	},
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -11,7 +11,7 @@ import {
 	softDeleteLyrics,
 	submitLyrics,
 } from "./lyrics"
-import { AUTO_HIDE_PREDICATE, RANKING_EXPR } from "./predicates"
+import { AUTO_HIDE_PREDICATE, RANKING_EXPR, RANKING_EXPR_JOINED } from "./predicates"
 
 // -- Mocks -----------------------------------------------------------------
 
@@ -314,8 +314,13 @@ describe("findByVideoId", () => {
 		const lookupCall = db.calls.find((c) => c.sql.includes("FROM lyrics"))
 		expect(lookupCall).toBeDefined()
 		expect(lookupCall?.sql).toContain("CASE WHEN")
-		expect(lookupCall?.sql).toMatch(/u\.reputation > 1/)
+		expect(lookupCall?.sql).toMatch(/COALESCE\(u\.reputation, 0\) > 1/)
 		expect(lookupCall?.sql).toMatch(/vote_count >= 3/)
+		expect(lookupCall!.sql).toMatch(/ORDER BY \(CASE WHEN[\s\S]+?\) DESC,/)
+		const caseIdx = lookupCall!.sql.indexOf("CASE WHEN")
+		const rankingIdx = lookupCall!.sql.indexOf(RANKING_EXPR_JOINED)
+		expect(caseIdx).toBeGreaterThan(-1)
+		expect(rankingIdx).toBeGreaterThan(caseIdx)
 	})
 })
 
@@ -412,7 +417,11 @@ describe("findBySongArtist", () => {
 		const lookupCall = db.calls.find((c) => c.sql.includes("FROM lyrics"))
 		expect(lookupCall).toBeDefined()
 		expect(lookupCall?.sql).toContain("CASE WHEN")
-		expect(lookupCall?.sql).toMatch(/u\.reputation > 1/)
+		expect(lookupCall?.sql).toMatch(/COALESCE\(u\.reputation, 0\) > 1/)
+		const caseIdx = lookupCall!.sql.indexOf("CASE WHEN")
+		const rankingIdx = lookupCall!.sql.indexOf(RANKING_EXPR_JOINED)
+		expect(caseIdx).toBeGreaterThan(-1)
+		expect(rankingIdx).toBeGreaterThan(caseIdx)
 	})
 })
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -395,6 +395,25 @@ describe("findBySongArtist", () => {
 		expect(result?.submitter_key_id).toBe("alice")
 		expect(result?.submitter_reputation).toBe(2.0)
 	})
+
+	it("orders proven rows above unproven rows for same song+artist", async () => {
+		const row = {
+			...baseRow,
+			submitter_reputation: 1.5,
+			vote_count: 5,
+			effective_score: 0.6,
+		}
+		const db = createMockDB([row])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await findBySongArtist(env, "Song", "Artist")
+
+		const lookupCall = db.calls.find((c) => c.sql.includes("FROM lyrics"))
+		expect(lookupCall).toBeDefined()
+		expect(lookupCall?.sql).toContain("CASE WHEN")
+		expect(lookupCall?.sql).toMatch(/u\.reputation > 1/)
+	})
 })
 
 describe("findVariantsByVideoId", () => {

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -297,6 +297,26 @@ describe("findByVideoId", () => {
 		expect(result?.submitter_key_id).toBeNull()
 		expect(result?.submitter_reputation).toBeNull()
 	})
+
+	it("orders proven rows above unproven rows for same videoId", async () => {
+		const provenRow = {
+			...baseRow,
+			submitter_reputation: 1.5,
+			vote_count: 5,
+			effective_score: 0.6,
+		}
+		const db = createMockDB([provenRow])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await findByVideoId(env, "v1")
+
+		const lookupCall = db.calls.find((c) => c.sql.includes("FROM lyrics"))
+		expect(lookupCall).toBeDefined()
+		expect(lookupCall?.sql).toContain("CASE WHEN")
+		expect(lookupCall?.sql).toMatch(/u\.reputation > 1/)
+		expect(lookupCall?.sql).toMatch(/vote_count >= 3/)
+	})
 })
 
 describe("findBySongArtist", () => {

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -21,6 +21,7 @@ type Recorded = { sql: string; params: unknown[] }
 interface MockDB {
 	calls: Recorded[]
 	queue: unknown[]
+	transactionCount: number
 	prepare(sql: string): {
 		bind(...args: unknown[]): {
 			first<T>(): Promise<T | null>
@@ -36,6 +37,7 @@ function createMockDB(queue: unknown[] = []): MockDB {
 	const db: MockDB = {
 		calls,
 		queue,
+		transactionCount: 0,
 		prepare(sql: string) {
 			return {
 				bind(...args: unknown[]) {
@@ -59,6 +61,7 @@ function createMockDB(queue: unknown[] = []): MockDB {
 			}
 		},
 		async transaction<T>(fn: (tx: MockDB) => Promise<T>): Promise<T> {
+			db.transactionCount++
 			return fn(db)
 		},
 	}
@@ -868,6 +871,177 @@ describe("softDeleteLyrics", () => {
 				!c.sql.includes("deleted_at")
 		)
 		expect(mark).toBeUndefined()
+	})
+
+	it("wraps penalty, mark, and soft-delete in a single transaction (penalty branch)", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 3,
+				effective_score: -0.6,
+				reputation_penalized: false,
+			},
+			null,
+			null,
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await softDeleteLyrics(env, 1, 42, "submitter", "regret")
+
+		expect(db.transactionCount).toBe(1)
+	})
+
+	it("wraps the soft-delete in a transaction even when the penalty branch is skipped", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 1,
+				effective_score: -0.6,
+				reputation_penalized: false,
+			},
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await softDeleteLyrics(env, 1, 42, "submitter", null)
+
+		expect(db.transactionCount).toBe(1)
+		const penalty = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penalty).toBeUndefined()
+	})
+
+	it("does not open a transaction when the row is not found", async () => {
+		const db = createMockDB([null])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await softDeleteLyrics(env, 999, 1, "submitter")
+
+		expect(db.transactionCount).toBe(0)
+	})
+
+	it("does not open a transaction when the row is already deleted", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 1,
+				deleted_at: 1234567890,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: false,
+			},
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await softDeleteLyrics(env, 1, 1, "submitter")
+
+		expect(db.transactionCount).toBe(0)
+	})
+
+	it("does not open a transaction when the caller is forbidden", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 99,
+				deleted_at: null,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: false,
+			},
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		await softDeleteLyrics(env, 1, 1, "submitter")
+
+		expect(db.transactionCount).toBe(0)
+	})
+
+	it("rolls back the soft-delete when the penalty update throws", async () => {
+		const calls: Recorded[] = []
+		const state = { transactionCount: 0, committed: true }
+		const queue: unknown[] = [
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 3,
+				effective_score: -0.6,
+				reputation_penalized: false,
+			},
+		]
+		const db = {
+			calls,
+			prepare(sql: string) {
+				return {
+					bind(...args: unknown[]) {
+						return {
+							async first<T>(): Promise<T | null> {
+								calls.push({ sql, params: args })
+								return (queue.shift() as T) ?? null
+							},
+							async all<T>(): Promise<{ results: T[] }> {
+								calls.push({ sql, params: args })
+								return { results: (queue.shift() as T[]) ?? [] }
+							},
+							async run(): Promise<void> {
+								calls.push({ sql, params: args })
+								if (sql.includes("UPDATE users") && sql.includes("reputation - ?")) {
+									throw new Error("simulated failure")
+								}
+							},
+						}
+					},
+				}
+			},
+			async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+				state.transactionCount++
+				try {
+					return await fn(db)
+				} catch (err) {
+					state.committed = false
+					throw err
+				}
+			},
+		}
+		const cache = createMockCache()
+		const env = {
+			DB: db as unknown as Env["DB"],
+			CACHE: cache as unknown as Env["CACHE"],
+			RATE_LIMITER: {} as Env["RATE_LIMITER"],
+			READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
+			CACHE_TTL_SECONDS: "300",
+			DUMPS_ENABLED: false,
+			DUMP_PUBLIC_BASE_URL: "",
+			DUMP_DATABASE_URL: null,
+			B2: null,
+		} as Env
+
+		await expect(softDeleteLyrics(env, 1, 42, "submitter", "regret")).rejects.toThrow(
+			"simulated failure"
+		)
+		expect(state.transactionCount).toBe(1)
+		expect(state.committed).toBe(false)
+		const softDelete = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("deleted_at =")
+		)
+		expect(softDelete).toBeUndefined()
+		expect(cache.deleteCalls).toHaveLength(0)
 	})
 })
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1021,3 +1021,22 @@ describe("submitLyrics fulfillment integration", () => {
 		expect(sqls).not.toMatch(/INSERT INTO request_fulfillments/i)
 	})
 })
+
+describe("submitLyrics variant cap", () => {
+	it("counts penalized-and-deleted rows against the variant cap", async () => {
+		const db = createMockDB([{ count: 3 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await submitLyrics(env, buildSubmission(), 42)
+
+		expect(result.created).toBe(false)
+
+		const countCall = db.calls.find(
+			(c) => c.sql.includes("SELECT COUNT(*)") && c.sql.includes("lyrics")
+		)
+		expect(countCall).toBeDefined()
+		expect(countCall!.sql).toMatch(/reputation_penalized\s*=\s*TRUE/i)
+		expect(countCall!.sql).toMatch(/deleted_at\s+IS\s+NULL/i)
+	})
+})

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,3 +1,4 @@
+import { config } from "@/config"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
@@ -599,7 +600,17 @@ describe("softDeleteLyrics", () => {
 	})
 
 	it("returns already_deleted when the row is already deleted", async () => {
-		const db = createMockDB([{ id: 1, video_id: "v1", submitter_id: 1, deleted_at: 1234567890 }])
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 1,
+				deleted_at: 1234567890,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: false,
+			},
+		])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
@@ -609,24 +620,51 @@ describe("softDeleteLyrics", () => {
 	})
 
 	it("returns forbidden when submitter does not own the row", async () => {
-		const db = createMockDB([{ id: 1, video_id: "v1", submitter_id: 99, deleted_at: null }])
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 99,
+				deleted_at: null,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: false,
+			},
+		])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
 		const result = await softDeleteLyrics(env, 1, 1, "submitter")
 
 		expect(result).toEqual({ deleted: false, reason: "forbidden" })
+		const penalty = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penalty).toBeUndefined()
 	})
 
 	it("performs UPDATE with the four audit fields and invalidates cache", async () => {
-		const db = createMockDB([{ id: 1, video_id: "v1", submitter_id: 1, deleted_at: null }, null])
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 1,
+				deleted_at: null,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: false,
+			},
+			null,
+		])
 		const cache = createMockCache({ "v:v1": "row", "feed:global:20": "feed" })
 		const env = createEnv(db, cache)
 
 		const result = await softDeleteLyrics(env, 1, 1, "submitter", "typo")
 
 		expect(result.deleted).toBe(true)
-		const update = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		const update = db.calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("deleted_at =")
+		)
 		expect(update).toBeDefined()
 		expect(update?.sql).toMatch(/deleted_at\s*=/)
 		expect(update?.sql).toMatch(/deleted_by_user_id\s*=/)
@@ -639,15 +677,197 @@ describe("softDeleteLyrics", () => {
 	})
 
 	it("admin role bypasses ownership check", async () => {
-		const db = createMockDB([{ id: 1, video_id: "v1", submitter_id: 99, deleted_at: null }, null])
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 99,
+				deleted_at: null,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: true,
+			},
+			null,
+		])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
 		const result = await softDeleteLyrics(env, 1, 1, "admin", "DMCA")
 
 		expect(result.deleted).toBe(true)
-		const update = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		const update = db.calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("deleted_at =")
+		)
 		expect(update?.params).toEqual([1, "admin", "DMCA", 1])
+	})
+
+	it("applies the reputation penalty when a net-negative row is self-deleted", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 3,
+				effective_score: -0.6,
+				reputation_penalized: false,
+			},
+			null,
+			null,
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await softDeleteLyrics(env, 1, 42, "submitter", "regret")
+
+		expect(result.deleted).toBe(true)
+
+		const penaltyUpdate = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penaltyUpdate).toBeDefined()
+		expect(penaltyUpdate?.params).toEqual([
+			config.reputation.min,
+			config.moderation.autoHide.reputationPenalty,
+			42,
+		])
+
+		const markUpdate = db.calls.find(
+			(c) =>
+				c.sql.includes("UPDATE lyrics") &&
+				c.sql.includes("reputation_penalized = TRUE") &&
+				!c.sql.includes("deleted_at")
+		)
+		expect(markUpdate).toBeDefined()
+		expect(markUpdate?.params).toEqual([1])
+
+		const softDelete = db.calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("deleted_at =")
+		)
+		expect(softDelete?.params).toEqual([42, "submitter", "regret", 1])
+	})
+
+	it("does NOT penalise a clean self-delete with vote_count < 2", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 1,
+				effective_score: -0.6,
+				reputation_penalized: false,
+			},
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await softDeleteLyrics(env, 1, 42, "submitter", null)
+
+		expect(result.deleted).toBe(true)
+		const penalty = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penalty).toBeUndefined()
+	})
+
+	it("does NOT penalise a clean self-delete with non-negative effective_score", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 5,
+				effective_score: 0.1,
+				reputation_penalized: false,
+			},
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await softDeleteLyrics(env, 1, 42, "submitter", null)
+
+		expect(result.deleted).toBe(true)
+		const penalty = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penalty).toBeUndefined()
+	})
+
+	it("always penalises an admin delete regardless of score", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 0,
+				effective_score: 0,
+				reputation_penalized: false,
+			},
+			null,
+			null,
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await softDeleteLyrics(env, 1, 1, "admin", "DMCA")
+
+		expect(result.deleted).toBe(true)
+		const penalty = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penalty).toBeDefined()
+		expect(penalty?.params).toEqual([
+			config.reputation.min,
+			config.moderation.autoHide.reputationPenalty,
+			42,
+		])
+
+		const markUpdate = db.calls.find(
+			(c) =>
+				c.sql.includes("UPDATE lyrics") &&
+				c.sql.includes("reputation_penalized = TRUE") &&
+				!c.sql.includes("deleted_at")
+		)
+		expect(markUpdate?.params).toEqual([1])
+	})
+
+	it("does NOT double-penalise when reputation_penalized is already TRUE", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 3,
+				effective_score: -0.6,
+				reputation_penalized: true,
+			},
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await softDeleteLyrics(env, 1, 42, "submitter", null)
+
+		expect(result.deleted).toBe(true)
+		const penalty = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penalty).toBeUndefined()
+		const mark = db.calls.find(
+			(c) =>
+				c.sql.includes("UPDATE lyrics") &&
+				c.sql.includes("reputation_penalized = TRUE") &&
+				!c.sql.includes("deleted_at")
+		)
+		expect(mark).toBeUndefined()
 	})
 })
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -715,7 +715,55 @@ describe("softDeleteLyrics", () => {
 				effective_score: -0.6,
 				reputation_penalized: false,
 			},
+			{ id: 1 },
 			null,
+			null,
+		])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const result = await softDeleteLyrics(env, 1, 42, "submitter", "regret")
+
+		expect(result.deleted).toBe(true)
+
+		const markUpdate = db.calls.find(
+			(c) =>
+				c.sql.includes("UPDATE lyrics") &&
+				c.sql.includes("reputation_penalized = TRUE") &&
+				!c.sql.includes("deleted_at")
+		)
+		expect(markUpdate).toBeDefined()
+		expect(markUpdate?.sql).toMatch(/AND\s+reputation_penalized\s*=\s*FALSE/i)
+		expect(markUpdate?.sql).toMatch(/RETURNING\s+id/i)
+		expect(markUpdate?.params).toEqual([1])
+
+		const penaltyUpdate = db.calls.find(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
+		)
+		expect(penaltyUpdate).toBeDefined()
+		expect(penaltyUpdate?.params).toEqual([
+			config.reputation.min,
+			config.moderation.autoHide.reputationPenalty,
+			42,
+		])
+
+		const softDelete = db.calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("deleted_at =")
+		)
+		expect(softDelete?.params).toEqual([42, "submitter", "regret", 1])
+	})
+
+	it("skips user decrement when a concurrent caller flipped the flag first", async () => {
+		const db = createMockDB([
+			{
+				id: 1,
+				video_id: "v1",
+				submitter_id: 42,
+				deleted_at: null,
+				vote_count: 3,
+				effective_score: -0.6,
+				reputation_penalized: false,
+			},
 			null,
 			null,
 		])
@@ -729,26 +777,12 @@ describe("softDeleteLyrics", () => {
 		const penaltyUpdate = db.calls.find(
 			(c) => c.sql.includes("UPDATE users") && c.sql.includes("reputation - ?")
 		)
-		expect(penaltyUpdate).toBeDefined()
-		expect(penaltyUpdate?.params).toEqual([
-			config.reputation.min,
-			config.moderation.autoHide.reputationPenalty,
-			42,
-		])
-
-		const markUpdate = db.calls.find(
-			(c) =>
-				c.sql.includes("UPDATE lyrics") &&
-				c.sql.includes("reputation_penalized = TRUE") &&
-				!c.sql.includes("deleted_at")
-		)
-		expect(markUpdate).toBeDefined()
-		expect(markUpdate?.params).toEqual([1])
+		expect(penaltyUpdate).toBeUndefined()
 
 		const softDelete = db.calls.find(
 			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("deleted_at =")
 		)
-		expect(softDelete?.params).toEqual([42, "submitter", "regret", 1])
+		expect(softDelete).toBeDefined()
 	})
 
 	it("does NOT penalise a clean self-delete with vote_count < 2", async () => {
@@ -812,7 +846,7 @@ describe("softDeleteLyrics", () => {
 				effective_score: 0,
 				reputation_penalized: false,
 			},
-			null,
+			{ id: 1 },
 			null,
 			null,
 		])
@@ -884,7 +918,7 @@ describe("softDeleteLyrics", () => {
 				effective_score: -0.6,
 				reputation_penalized: false,
 			},
-			null,
+			{ id: 1 },
 			null,
 			null,
 		])
@@ -984,6 +1018,7 @@ describe("softDeleteLyrics", () => {
 				effective_score: -0.6,
 				reputation_penalized: false,
 			},
+			{ id: 1 },
 		]
 		const db = {
 			calls,

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -145,7 +145,9 @@ export async function submitLyrics(
 
 	// Check per-user-per-video variant cap
 	const variantCount = await env.DB.prepare(
-		"SELECT COUNT(*)::INTEGER AS count FROM lyrics WHERE video_id = ? AND submitter_id = ? AND deleted_at IS NULL"
+		`SELECT COUNT(*)::INTEGER AS count FROM lyrics
+			WHERE video_id = ? AND submitter_id = ?
+				AND (deleted_at IS NULL OR reputation_penalized = TRUE)`
 	)
 		.bind(submission.videoId, submitterId)
 		.first<{ count: number }>()

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -313,15 +313,43 @@ export async function softDeleteLyrics(
 	reason: string | null = null
 ): Promise<SoftDeleteResult> {
 	const row = await env.DB.prepare(
-		"SELECT id, video_id, submitter_id, deleted_at FROM lyrics WHERE id = ?"
+		`SELECT id, video_id, submitter_id, deleted_at,
+			vote_count, effective_score, reputation_penalized
+		FROM lyrics WHERE id = ?`
 	)
 		.bind(lyricsId)
-		.first<{ id: number; video_id: string; submitter_id: number; deleted_at: number | null }>()
+		.first<{
+			id: number
+			video_id: string
+			submitter_id: number
+			deleted_at: number | null
+			vote_count: number
+			effective_score: number
+			reputation_penalized: boolean
+		}>()
 
 	if (!row) return { deleted: false, reason: "not_found" }
 	if (row.deleted_at !== null) return { deleted: false, reason: "already_deleted" }
 	if (role === "submitter" && row.submitter_id !== actingUserId) {
 		return { deleted: false, reason: "forbidden" }
+	}
+
+	const shouldPenalise =
+		!row.reputation_penalized &&
+		(role === "admin" ||
+			(role === "submitter" && row.vote_count >= 2 && row.effective_score < 0))
+
+	if (shouldPenalise && row.submitter_id) {
+		const penalty = config.moderation.autoHide.reputationPenalty
+		await env.DB.prepare(
+			`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`
+		)
+			.bind(config.reputation.min, penalty, row.submitter_id)
+			.run()
+
+		await env.DB.prepare(`UPDATE lyrics SET reputation_penalized = TRUE WHERE id = ?`)
+			.bind(lyricsId)
+			.run()
 	}
 
 	await env.DB.prepare(

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -115,7 +115,7 @@ export async function findBySongArtist(
 	const query = `
 		${LYRICS_WITH_SUBMITTER}
 		WHERE ${conditions.join(" AND ")}
-		ORDER BY ${RANKING_EXPR_JOINED} DESC
+		ORDER BY (CASE WHEN ${PROVEN_EXPR_JOINED} THEN 1 ELSE 0 END) DESC, ${RANKING_EXPR_JOINED} DESC
 		LIMIT 1
 	`
 

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -3,6 +3,7 @@ import { recordFulfillment } from "@/db/fulfillments"
 import {
 	AUTO_HIDE_PREDICATE,
 	AUTO_HIDE_PREDICATE_JOINED,
+	PROVEN_EXPR_JOINED,
 	RANKING_EXPR,
 	RANKING_EXPR_JOINED,
 } from "@/db/predicates"
@@ -40,7 +41,7 @@ export async function findByVideoId(env: Env, videoId: string): Promise<LyricsRo
 
 	cacheLog.debug("miss", { key: `v:${videoId}` })
 	const result = await env.DB.prepare(
-		`${LYRICS_WITH_SUBMITTER} WHERE l.video_id = ? AND l.deleted_at IS NULL AND NOT ${AUTO_HIDE_PREDICATE_JOINED} ORDER BY ${RANKING_EXPR_JOINED} DESC LIMIT 1`
+		`${LYRICS_WITH_SUBMITTER} WHERE l.video_id = ? AND l.deleted_at IS NULL AND NOT ${AUTO_HIDE_PREDICATE_JOINED} ORDER BY (CASE WHEN ${PROVEN_EXPR_JOINED} THEN 1 ELSE 0 END) DESC, ${RANKING_EXPR_JOINED} DESC LIMIT 1`
 	)
 		.bind(videoId)
 		.first<LyricsRow>()

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -343,18 +343,24 @@ export async function softDeleteLyrics(
 
 	await env.DB.transaction(async (tx) => {
 		if (shouldPenalise && row.submitter_id) {
-			const penalty = config.moderation.autoHide.reputationPenalty
-			await tx
+			const flipped = await tx
 				.prepare(
-					"UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?"
+					`UPDATE lyrics SET reputation_penalized = TRUE
+					WHERE id = ? AND reputation_penalized = FALSE
+					RETURNING id`
 				)
-				.bind(config.reputation.min, penalty, row.submitter_id)
-				.run()
-
-			await tx
-				.prepare("UPDATE lyrics SET reputation_penalized = TRUE WHERE id = ?")
 				.bind(lyricsId)
-				.run()
+				.first<{ id: number }>()
+
+			if (flipped) {
+				const penalty = config.moderation.autoHide.reputationPenalty
+				await tx
+					.prepare(
+						"UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?"
+					)
+					.bind(config.reputation.min, penalty, row.submitter_id)
+					.run()
+			}
 		}
 
 		await tx

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -346,13 +346,13 @@ export async function softDeleteLyrics(
 			const penalty = config.moderation.autoHide.reputationPenalty
 			await tx
 				.prepare(
-					`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`
+					"UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?"
 				)
 				.bind(config.reputation.min, penalty, row.submitter_id)
 				.run()
 
 			await tx
-				.prepare(`UPDATE lyrics SET reputation_penalized = TRUE WHERE id = ?`)
+				.prepare("UPDATE lyrics SET reputation_penalized = TRUE WHERE id = ?")
 				.bind(lyricsId)
 				.run()
 		}

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -341,29 +341,34 @@ export async function softDeleteLyrics(
 		(role === "admin" ||
 			(role === "submitter" && row.vote_count >= 2 && row.effective_score < 0))
 
-	if (shouldPenalise && row.submitter_id) {
-		const penalty = config.moderation.autoHide.reputationPenalty
-		await env.DB.prepare(
-			`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`
-		)
-			.bind(config.reputation.min, penalty, row.submitter_id)
-			.run()
+	await env.DB.transaction(async (tx) => {
+		if (shouldPenalise && row.submitter_id) {
+			const penalty = config.moderation.autoHide.reputationPenalty
+			await tx
+				.prepare(
+					`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`
+				)
+				.bind(config.reputation.min, penalty, row.submitter_id)
+				.run()
 
-		await env.DB.prepare(`UPDATE lyrics SET reputation_penalized = TRUE WHERE id = ?`)
-			.bind(lyricsId)
-			.run()
-	}
+			await tx
+				.prepare(`UPDATE lyrics SET reputation_penalized = TRUE WHERE id = ?`)
+				.bind(lyricsId)
+				.run()
+		}
 
-	await env.DB.prepare(
-		`UPDATE lyrics SET
-			deleted_at = EXTRACT(EPOCH FROM NOW())::INTEGER,
-			deleted_by_user_id = ?,
-			deleted_by_role = ?,
-			deletion_reason = ?
-		WHERE id = ? AND deleted_at IS NULL`
-	)
-		.bind(actingUserId, role, reason, lyricsId)
-		.run()
+		await tx
+			.prepare(
+				`UPDATE lyrics SET
+					deleted_at = EXTRACT(EPOCH FROM NOW())::INTEGER,
+					deleted_by_user_id = ?,
+					deleted_by_role = ?,
+					deletion_reason = ?
+				WHERE id = ? AND deleted_at IS NULL`
+			)
+			.bind(actingUserId, role, reason, lyricsId)
+			.run()
+	})
 
 	await invalidateCacheAfterDelete(env, row.video_id)
 	log.info("lyrics deleted", { lyricsId, role, actingUserId, videoId: row.video_id })

--- a/src/db/predicates.ts
+++ b/src/db/predicates.ts
@@ -38,13 +38,12 @@ export const AUTO_HIDE_PREDICATE_JOINED = buildAutoHidePredicate("l.")
 
 const { primarySlot } = config.ranking
 
-const buildProvenExpr = (prefix: string, repColumn = `${prefix}submitter_reputation`) => `(
-	${repColumn} > ${primarySlot.repFloor}
+const provenExpr = (repExpr: string, prefix: string) => `(
+	COALESCE(${repExpr}, 0) > ${primarySlot.repFloor}
 	OR (
 		${prefix}vote_count >= ${primarySlot.minVotes}
 		AND ${prefix}effective_score > 0
 	)
 )`
 
-export const PROVEN_EXPR = buildProvenExpr("")
-export const PROVEN_EXPR_JOINED = buildProvenExpr("l.", "u.reputation")
+export const PROVEN_EXPR_JOINED = provenExpr("u.reputation", "l.")

--- a/src/db/predicates.ts
+++ b/src/db/predicates.ts
@@ -35,3 +35,16 @@ const buildAutoHidePredicate = (prefix: string) => `(
 
 export const AUTO_HIDE_PREDICATE = buildAutoHidePredicate("")
 export const AUTO_HIDE_PREDICATE_JOINED = buildAutoHidePredicate("l.")
+
+const { primarySlot } = config.ranking
+
+const buildProvenExpr = (prefix: string, repColumn = `${prefix}submitter_reputation`) => `(
+	${repColumn} > ${primarySlot.repFloor}
+	OR (
+		${prefix}vote_count >= ${primarySlot.minVotes}
+		AND ${prefix}effective_score > 0
+	)
+)`
+
+export const PROVEN_EXPR = buildProvenExpr("")
+export const PROVEN_EXPR_JOINED = buildProvenExpr("l.", "u.reputation")

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -363,26 +363,26 @@ describe("auto-hide reputation penalty", () => {
 		])
 
 		const markUpdate = calls.find(
-			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized")
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized = TRUE")
 		)
 		expect(markUpdate).toBeDefined()
-		expect(markUpdate?.params).toEqual([10])
+		expect(markUpdate?.sql).toMatch(/AND\s+reputation_penalized\s*=\s*FALSE/i)
+		expect(markUpdate?.sql).toMatch(/RETURNING\s+id,\s*submitter_id/i)
 	})
 
-	it("is idempotent: skips rows already marked as penalized via WHERE filter", async () => {
+	it("guards the in-transaction mark UPDATE with reputation_penalized = FALSE", async () => {
 		const { db, calls } = createMockDB([[], []])
 		const env = { DB: db } as unknown as Env
 
 		await updateScores(env)
 
-		const selectCall = calls.find(
-			(c) =>
-				c.sql.includes("SELECT") &&
-				c.sql.includes("submitter_id") &&
-				c.sql.includes("reputation_penalized")
+		const markUpdate = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized = TRUE")
 		)
-		expect(selectCall).toBeDefined()
-		expect(selectCall?.sql).toMatch(/reputation_penalized\s*=\s*FALSE/i)
+		expect(markUpdate).toBeDefined()
+		expect(markUpdate?.sql).toMatch(/AND\s+reputation_penalized\s*=\s*FALSE/i)
+		expect(markUpdate?.sql).toMatch(/AND\s+deleted_at\s+IS\s+NULL/i)
+		expect(markUpdate?.sql).toMatch(/AND\s+submitter_id\s+IS\s+NOT\s+NULL/i)
 	})
 
 	it("sums penalty when a submitter has multiple newly-hidden rows", async () => {
@@ -406,14 +406,9 @@ describe("auto-hide reputation penalty", () => {
 		expect(userUpdates).toHaveLength(1)
 		const totalPenalty = config.moderation.autoHide.reputationPenalty * 2
 		expect(userUpdates[0].params).toEqual([config.reputation.min, totalPenalty, 42])
-
-		const markUpdate = calls.find(
-			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized")
-		)
-		expect(markUpdate?.params).toEqual([10, 11])
 	})
 
-	it("wraps the user-penalty and bulk-mark updates in a single transaction", async () => {
+	it("wraps the mark UPDATE and user-penalty updates in a single transaction", async () => {
 		const result = createMockDB([[], [{ id: 10, submitter_id: 42 }]])
 		const env = { DB: result.db } as unknown as Env
 
@@ -422,16 +417,22 @@ describe("auto-hide reputation penalty", () => {
 		expect(result.transactionCount).toBe(1)
 	})
 
-	it("does not open a transaction when there are no newly-hidden rows", async () => {
-		const result = createMockDB([[], []])
-		const env = { DB: result.db } as unknown as Env
+	it("does not fire UPDATE users when nothing was flipped", async () => {
+		const { db, calls } = createMockDB([[], []])
+		const env = { DB: db } as unknown as Env
 
 		await updateScores(env)
 
-		expect(result.transactionCount).toBe(0)
+		const userPenalty = calls.find(
+			(c) =>
+				c.sql.includes("UPDATE users") &&
+				c.sql.includes("reputation - ?") &&
+				c.sql.includes("WHERE id = ?")
+		)
+		expect(userPenalty).toBeUndefined()
 	})
 
-	it("rolls back the bulk-mark when the user-penalty update throws", async () => {
+	it("rolls back the mark UPDATE when the user-penalty update throws", async () => {
 		const calls: { sql: string; params: unknown[] }[] = []
 		const state = { transactionCount: 0, committed: true }
 		const queue: unknown[] = [[], [{ id: 10, submitter_id: 42 }]]
@@ -474,10 +475,33 @@ describe("auto-hide reputation penalty", () => {
 		await expect(updateScores(env)).rejects.toThrow("simulated failure")
 		expect(state.transactionCount).toBe(1)
 		expect(state.committed).toBe(false)
-		const markUpdate = calls.find(
+	})
+})
+
+describe("updateScores pipeline order", () => {
+	it("runs avg_vote, then updateReputations, then safety-net, then applyAutoHidePenalty", async () => {
+		const { db, calls } = createMockDB([[], []])
+		const env = { DB: db } as unknown as Env
+
+		await updateScores(env)
+
+		const avgVoteIdx = calls.findIndex(
+			(c) => c.sql.includes("UPDATE users") && c.sql.includes("avg_vote =")
+		)
+		const reputationIdx = calls.findIndex(
+			(c) => c.sql.includes("consensus_lyrics") || c.sql.includes("WITH consensus_lyrics")
+		)
+		const safetyNetIdx = calls.findIndex(
+			(c) => c.sql.includes("SELECT") && c.sql.includes("id AS lyrics_id")
+		)
+		const penaltyIdx = calls.findIndex(
 			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized = TRUE")
 		)
-		expect(markUpdate).toBeUndefined()
+
+		expect(avgVoteIdx).toBeGreaterThanOrEqual(0)
+		expect(reputationIdx).toBeGreaterThan(avgVoteIdx)
+		expect(safetyNetIdx).toBeGreaterThan(reputationIdx)
+		expect(penaltyIdx).toBeGreaterThan(safetyNetIdx)
 	})
 })
 

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -141,6 +141,37 @@ describe("calculateScore", () => {
 
 		expect(result.effective_score).toBe(1)
 	})
+
+	it("excludes votes below the weight floor from effective_score", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: -1, reputation: 0.4, avg_vote: -0.2, is_self_vote: 0 },
+			{ vote: -1, reputation: 0.3, avg_vote: -0.1, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBeCloseTo(1.0, 2)
+	})
+
+	it("keeps vote_count honest when votes are below the weight floor", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: -1, reputation: 0.4, avg_vote: -0.2, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.vote_count).toBe(2)
+	})
+
+	it("includes votes exactly at the weight floor", () => {
+		const votes = [{ vote: 1, reputation: 0.5, avg_vote: 0.0, is_self_vote: 0 }]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBeCloseTo(1.0, 2)
+	})
 })
 
 describe("updateReputations", () => {

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -134,12 +134,13 @@ describe("calculateScore", () => {
 	it("handles mixed high and low reputation users", () => {
 		const votes = [
 			{ vote: 1, reputation: 2.0, avg_vote: 0.5, is_self_vote: 0 },
-			{ vote: -1, reputation: 0.0, avg_vote: -0.5, is_self_vote: 0 },
+			{ vote: -1, reputation: 0.6, avg_vote: 0.3, is_self_vote: 0 },
 		]
 
 		const result = calculateScore(1, votes)
 
-		expect(result.effective_score).toBe(1)
+		// (1 * 2.0 + -1 * 0.6) / (2.0 + 0.6) = 1.4 / 2.6 = 0.5385
+		expect(result.effective_score).toBeCloseTo(0.538, 2)
 	})
 
 	it("excludes votes below the weight floor from effective_score", () => {
@@ -171,6 +172,18 @@ describe("calculateScore", () => {
 		const result = calculateScore(1, votes)
 
 		expect(result.effective_score).toBeCloseTo(1.0, 2)
+	})
+
+	it("filters sub-floor self-votes by raw reputation, not by post-discount weight", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: -1, reputation: 0.4, avg_vote: 0.0, is_self_vote: 1 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBeCloseTo(1.0, 2)
+		expect(result.vote_count).toBe(2)
 	})
 })
 

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -328,6 +328,108 @@ describe("soft-delete handling", () => {
 	})
 })
 
+describe("auto-hide reputation penalty", () => {
+	function createMockDB(queue: unknown[]): {
+		db: Env["DB"]
+		calls: { sql: string; params: unknown[] }[]
+	} {
+		const calls: { sql: string; params: unknown[] }[] = []
+		const db = {
+			prepare(sql: string) {
+				let params: unknown[] = []
+				return {
+					bind(...args: unknown[]) {
+						params = args
+						return this
+					},
+					async first<T>(): Promise<T | null> {
+						calls.push({ sql, params })
+						return (queue.shift() as T) ?? null
+					},
+					async all<T>(): Promise<{ results: T[] }> {
+						calls.push({ sql, params })
+						return { results: (queue.shift() as T[]) ?? [] }
+					},
+					async run(): Promise<void> {
+						calls.push({ sql, params })
+					},
+				}
+			},
+		}
+		return { db: db as unknown as Env["DB"], calls }
+	}
+
+	it("applies penalty to submitters of newly auto-hidden rows", async () => {
+		const { db, calls } = createMockDB([[], [{ id: 10, submitter_id: 42 }]])
+		const env = { DB: db } as unknown as Env
+
+		await updateScores(env)
+
+		const userUpdate = calls.find(
+			(c) =>
+				c.sql.includes("UPDATE users") &&
+				c.sql.includes("reputation - ?") &&
+				c.sql.includes("WHERE id = ?")
+		)
+		expect(userUpdate).toBeDefined()
+		expect(userUpdate?.params).toEqual([
+			config.reputation.min,
+			config.moderation.autoHide.reputationPenalty,
+			42,
+		])
+
+		const markUpdate = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized")
+		)
+		expect(markUpdate).toBeDefined()
+		expect(markUpdate?.params).toEqual([10])
+	})
+
+	it("is idempotent: skips rows already marked as penalized via WHERE filter", async () => {
+		const { db, calls } = createMockDB([[], []])
+		const env = { DB: db } as unknown as Env
+
+		await updateScores(env)
+
+		const selectCall = calls.find(
+			(c) =>
+				c.sql.includes("SELECT") &&
+				c.sql.includes("submitter_id") &&
+				c.sql.includes("reputation_penalized")
+		)
+		expect(selectCall).toBeDefined()
+		expect(selectCall?.sql).toMatch(/reputation_penalized\s*=\s*FALSE/i)
+	})
+
+	it("sums penalty when a submitter has multiple newly-hidden rows", async () => {
+		const { db, calls } = createMockDB([
+			[],
+			[
+				{ id: 10, submitter_id: 42 },
+				{ id: 11, submitter_id: 42 },
+			],
+		])
+		const env = { DB: db } as unknown as Env
+
+		await updateScores(env)
+
+		const userUpdates = calls.filter(
+			(c) =>
+				c.sql.includes("UPDATE users") &&
+				c.sql.includes("reputation - ?") &&
+				c.sql.includes("WHERE id = ?")
+		)
+		expect(userUpdates).toHaveLength(1)
+		const totalPenalty = config.moderation.autoHide.reputationPenalty * 2
+		expect(userUpdates[0].params).toEqual([config.reputation.min, totalPenalty, 42])
+
+		const markUpdate = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized")
+		)
+		expect(markUpdate?.params).toEqual([10, 11])
+	})
+})
+
 describe("reputation bounds", () => {
 	it("config has correct reputation bounds", () => {
 		expect(config.reputation.min).toBe(0.0)

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -12,6 +12,50 @@ vi.mock("@/db/lyrics", () => ({
 	invalidateCache: vi.fn(() => Promise.resolve()),
 }))
 
+interface MockDBResult {
+	db: Env["DB"]
+	calls: { sql: string; params: unknown[] }[]
+	transactionCount: number
+}
+
+function createMockDB(queue: unknown[]): MockDBResult {
+	const calls: { sql: string; params: unknown[] }[] = []
+	const state = { transactionCount: 0 }
+	const db = {
+		prepare(sql: string) {
+			let params: unknown[] = []
+			return {
+				bind(...args: unknown[]) {
+					params = args
+					return this
+				},
+				async first<T>(): Promise<T | null> {
+					calls.push({ sql, params })
+					return (queue.shift() as T) ?? null
+				},
+				async all<T>(): Promise<{ results: T[] }> {
+					calls.push({ sql, params })
+					return { results: (queue.shift() as T[]) ?? [] }
+				},
+				async run(): Promise<void> {
+					calls.push({ sql, params })
+				},
+			}
+		},
+		async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+			state.transactionCount++
+			return fn(db)
+		},
+	}
+	return {
+		db: db as unknown as Env["DB"],
+		calls,
+		get transactionCount() {
+			return state.transactionCount
+		},
+	}
+}
+
 describe("calculateScore", () => {
 	it("returns correct weighted score for equal reputation votes", () => {
 		const votes = [
@@ -255,36 +299,6 @@ describe("updateReputations", () => {
 })
 
 describe("soft-delete handling", () => {
-	function createMockDB(queue: unknown[]): {
-		db: Env["DB"]
-		calls: { sql: string; params: unknown[] }[]
-	} {
-		const calls: { sql: string; params: unknown[] }[] = []
-		const db = {
-			prepare(sql: string) {
-				let params: unknown[] = []
-				return {
-					bind(...args: unknown[]) {
-						params = args
-						return this
-					},
-					async first<T>(): Promise<T | null> {
-						calls.push({ sql, params })
-						return (queue.shift() as T) ?? null
-					},
-					async all<T>(): Promise<{ results: T[] }> {
-						calls.push({ sql, params })
-						return { results: (queue.shift() as T[]) ?? [] }
-					},
-					async run(): Promise<void> {
-						calls.push({ sql, params })
-					},
-				}
-			},
-		}
-		return { db: db as unknown as Env["DB"], calls }
-	}
-
 	it("recalculateScore early-returns when the row is deleted (no UPDATE)", async () => {
 		const { db, calls } = createMockDB([{ video_id: "v1", deleted_at: 1700000000 }])
 		const env = { DB: db } as unknown as Env
@@ -329,36 +343,6 @@ describe("soft-delete handling", () => {
 })
 
 describe("auto-hide reputation penalty", () => {
-	function createMockDB(queue: unknown[]): {
-		db: Env["DB"]
-		calls: { sql: string; params: unknown[] }[]
-	} {
-		const calls: { sql: string; params: unknown[] }[] = []
-		const db = {
-			prepare(sql: string) {
-				let params: unknown[] = []
-				return {
-					bind(...args: unknown[]) {
-						params = args
-						return this
-					},
-					async first<T>(): Promise<T | null> {
-						calls.push({ sql, params })
-						return (queue.shift() as T) ?? null
-					},
-					async all<T>(): Promise<{ results: T[] }> {
-						calls.push({ sql, params })
-						return { results: (queue.shift() as T[]) ?? [] }
-					},
-					async run(): Promise<void> {
-						calls.push({ sql, params })
-					},
-				}
-			},
-		}
-		return { db: db as unknown as Env["DB"], calls }
-	}
-
 	it("applies penalty to submitters of newly auto-hidden rows", async () => {
 		const { db, calls } = createMockDB([[], [{ id: 10, submitter_id: 42 }]])
 		const env = { DB: db } as unknown as Env
@@ -427,6 +411,73 @@ describe("auto-hide reputation penalty", () => {
 			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized")
 		)
 		expect(markUpdate?.params).toEqual([10, 11])
+	})
+
+	it("wraps the user-penalty and bulk-mark updates in a single transaction", async () => {
+		const result = createMockDB([[], [{ id: 10, submitter_id: 42 }]])
+		const env = { DB: result.db } as unknown as Env
+
+		await updateScores(env)
+
+		expect(result.transactionCount).toBe(1)
+	})
+
+	it("does not open a transaction when there are no newly-hidden rows", async () => {
+		const result = createMockDB([[], []])
+		const env = { DB: result.db } as unknown as Env
+
+		await updateScores(env)
+
+		expect(result.transactionCount).toBe(0)
+	})
+
+	it("rolls back the bulk-mark when the user-penalty update throws", async () => {
+		const calls: { sql: string; params: unknown[] }[] = []
+		const state = { transactionCount: 0, committed: true }
+		const queue: unknown[] = [[], [{ id: 10, submitter_id: 42 }]]
+		const db = {
+			prepare(sql: string) {
+				let params: unknown[] = []
+				return {
+					bind(...args: unknown[]) {
+						params = args
+						return this
+					},
+					async first<T>(): Promise<T | null> {
+						calls.push({ sql, params })
+						return (queue.shift() as T) ?? null
+					},
+					async all<T>(): Promise<{ results: T[] }> {
+						calls.push({ sql, params })
+						return { results: (queue.shift() as T[]) ?? [] }
+					},
+					async run(): Promise<void> {
+						calls.push({ sql, params })
+						if (sql.includes("UPDATE users") && sql.includes("reputation - ?")) {
+							throw new Error("simulated failure")
+						}
+					},
+				}
+			},
+			async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+				state.transactionCount++
+				try {
+					return await fn(db)
+				} catch (err) {
+					state.committed = false
+					throw err
+				}
+			},
+		}
+		const env = { DB: db } as unknown as Env
+
+		await expect(updateScores(env)).rejects.toThrow("simulated failure")
+		expect(state.transactionCount).toBe(1)
+		expect(state.committed).toBe(false)
+		const markUpdate = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && c.sql.includes("reputation_penalized = TRUE")
+		)
+		expect(markUpdate).toBeUndefined()
 	})
 })
 

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -114,21 +114,24 @@ async function applyAutoHidePenalty(env: Env): Promise<void> {
 		submitterPenalty.set(r.submitter_id, (submitterPenalty.get(r.submitter_id) ?? 0) + penalty)
 	}
 
-	for (const [sid, totalPenalty] of submitterPenalty) {
-		await env.DB.prepare(
-			`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`
-		)
-			.bind(minRep, totalPenalty, sid)
-			.run()
-	}
-
 	const ids = rows.map((r) => r.id)
 	const placeholders = ids.map(() => "?").join(",")
-	await env.DB.prepare(
-		`UPDATE lyrics SET reputation_penalized = TRUE WHERE id IN (${placeholders})`
-	)
-		.bind(...ids)
-		.run()
+
+	await env.DB.transaction(async (tx) => {
+		for (const [sid, totalPenalty] of submitterPenalty) {
+			await tx
+				.prepare(`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`)
+				.bind(minRep, totalPenalty, sid)
+				.run()
+		}
+
+		await tx
+			.prepare(
+				`UPDATE lyrics SET reputation_penalized = TRUE WHERE id IN (${placeholders})`
+			)
+			.bind(...ids)
+			.run()
+	})
 
 	log.info("applied auto-hide reputation penalty", {
 		affected_submitters: submitterPenalty.size,

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -69,6 +69,8 @@ export async function updateScores(env: Env): Promise<{ updated: number }> {
 			vote_count = (SELECT COUNT(*) FROM votes WHERE votes.user_id = users.id)
 	`).run()
 
+	await updateReputations(env)
+
 	const staleLyrics = await env.DB.prepare(`
 		SELECT id AS lyrics_id FROM lyrics
 		WHERE score_updated_at IS NULL AND vote_count > 0 AND deleted_at IS NULL
@@ -89,8 +91,6 @@ export async function updateScores(env: Env): Promise<{ updated: number }> {
 
 	await applyAutoHidePenalty(env)
 
-	await updateReputations(env)
-
 	return { updated }
 }
 
@@ -98,45 +98,46 @@ async function applyAutoHidePenalty(env: Env): Promise<void> {
 	const penalty = config.moderation.autoHide.reputationPenalty
 	const minRep = config.reputation.min
 
-	const newlyHidden = await env.DB.prepare(`
-		SELECT id, submitter_id FROM lyrics
-		WHERE ${AUTO_HIDE_PREDICATE}
-			AND deleted_at IS NULL
-			AND reputation_penalized = FALSE
-			AND submitter_id IS NOT NULL
-	`).all<{ id: number; submitter_id: number }>()
-
-	const rows = newlyHidden.results || []
-	if (rows.length === 0) return
-
 	const submitterPenalty = new Map<number, number>()
-	for (const r of rows) {
-		submitterPenalty.set(r.submitter_id, (submitterPenalty.get(r.submitter_id) ?? 0) + penalty)
-	}
-
-	const ids = rows.map((r) => r.id)
-	const placeholders = ids.map(() => "?").join(",")
+	const flippedIds: number[] = []
 
 	await env.DB.transaction(async (tx) => {
+		const flipped = await tx
+			.prepare(
+				`UPDATE lyrics SET reputation_penalized = TRUE
+				WHERE ${AUTO_HIDE_PREDICATE}
+					AND deleted_at IS NULL
+					AND reputation_penalized = FALSE
+					AND submitter_id IS NOT NULL
+				RETURNING id, submitter_id`
+			)
+			.all<{ id: number; submitter_id: number }>()
+
+		const rows = flipped.results || []
+		if (rows.length === 0) return
+
+		for (const r of rows) {
+			submitterPenalty.set(
+				r.submitter_id,
+				(submitterPenalty.get(r.submitter_id) ?? 0) + penalty
+			)
+			flippedIds.push(r.id)
+		}
+
 		for (const [sid, totalPenalty] of submitterPenalty) {
 			await tx
 				.prepare("UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?")
 				.bind(minRep, totalPenalty, sid)
 				.run()
 		}
-
-		await tx
-			.prepare(
-				`UPDATE lyrics SET reputation_penalized = TRUE WHERE id IN (${placeholders})`
-			)
-			.bind(...ids)
-			.run()
 	})
+
+	if (flippedIds.length === 0) return
 
 	log.info("applied auto-hide reputation penalty", {
 		affected_submitters: submitterPenalty.size,
-		affected_rows: ids.length,
-		lyrics_ids: ids.slice(0, 10),
+		affected_rows: flippedIds.length,
+		lyrics_ids: flippedIds.slice(0, 10),
 	})
 }
 

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -136,6 +136,7 @@ async function applyAutoHidePenalty(env: Env): Promise<void> {
 	log.info("applied auto-hide reputation penalty", {
 		affected_submitters: submitterPenalty.size,
 		affected_rows: ids.length,
+		lyrics_ids: ids.slice(0, 10),
 	})
 }
 

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -120,7 +120,7 @@ async function applyAutoHidePenalty(env: Env): Promise<void> {
 	await env.DB.transaction(async (tx) => {
 		for (const [sid, totalPenalty] of submitterPenalty) {
 			await tx
-				.prepare(`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`)
+				.prepare("UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?")
 				.bind(minRep, totalPenalty, sid)
 				.run()
 		}

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -102,6 +102,7 @@ export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsS
 	let generousUpvotes = 0
 
 	for (const v of votes) {
+		if (v.reputation < config.reputation.voteWeightFloor) continue
 		// Self-votes count less
 		const weight = v.is_self_vote ? v.reputation * config.reputation.selfVoteWeight : v.reputation
 

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -1,5 +1,6 @@
 import { config } from "@/config"
 import { invalidateCache } from "@/db/lyrics"
+import { AUTO_HIDE_PREDICATE } from "@/db/predicates"
 import { Logger } from "@/infra/logger"
 import type { Confidence, Env } from "@/types"
 
@@ -62,18 +63,12 @@ export async function recalculateScore(env: Env, lyricsId: number): Promise<void
 }
 
 export async function updateScores(env: Env): Promise<{ updated: number }> {
-	// 1. Update user avg_vote for clustering
 	await env.DB.prepare(`
 		UPDATE users SET
 			avg_vote = COALESCE((SELECT AVG(vote) FROM votes WHERE votes.user_id = users.id), 0),
 			vote_count = (SELECT COUNT(*) FROM votes WHERE votes.user_id = users.id)
 	`).run()
 
-	// 2. Update user reputations based on consensus
-	await updateReputations(env)
-
-	// 3. Safety net: recalculate entries that were never scored or voted on recently
-	//    (catches fire-and-forget recalculateScore failures from votes/reports)
 	const staleLyrics = await env.DB.prepare(`
 		SELECT id AS lyrics_id FROM lyrics
 		WHERE score_updated_at IS NULL AND vote_count > 0 AND deleted_at IS NULL
@@ -92,7 +87,53 @@ export async function updateScores(env: Env): Promise<{ updated: number }> {
 
 	log.debug("safety-net recalculated stale scores", { count: updated })
 
+	await applyAutoHidePenalty(env)
+
+	await updateReputations(env)
+
 	return { updated }
+}
+
+async function applyAutoHidePenalty(env: Env): Promise<void> {
+	const penalty = config.moderation.autoHide.reputationPenalty
+	const minRep = config.reputation.min
+
+	const newlyHidden = await env.DB.prepare(`
+		SELECT id, submitter_id FROM lyrics
+		WHERE ${AUTO_HIDE_PREDICATE}
+			AND deleted_at IS NULL
+			AND reputation_penalized = FALSE
+			AND submitter_id IS NOT NULL
+	`).all<{ id: number; submitter_id: number }>()
+
+	const rows = newlyHidden.results || []
+	if (rows.length === 0) return
+
+	const submitterPenalty = new Map<number, number>()
+	for (const r of rows) {
+		submitterPenalty.set(r.submitter_id, (submitterPenalty.get(r.submitter_id) ?? 0) + penalty)
+	}
+
+	for (const [sid, totalPenalty] of submitterPenalty) {
+		await env.DB.prepare(
+			`UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?`
+		)
+			.bind(minRep, totalPenalty, sid)
+			.run()
+	}
+
+	const ids = rows.map((r) => r.id)
+	const placeholders = ids.map(() => "?").join(",")
+	await env.DB.prepare(
+		`UPDATE lyrics SET reputation_penalized = TRUE WHERE id IN (${placeholders})`
+	)
+		.bind(...ids)
+		.run()
+
+	log.info("applied auto-hide reputation penalty", {
+		affected_submitters: submitterPenalty.size,
+		affected_rows: ids.length,
+	})
 }
 
 export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsScoreUpdate {


### PR DESCRIPTION
## Overview

- `findByVideoId` and `findBySongArtist` now tier proven rows above unproven via `ORDER BY (CASE WHEN proven THEN 1 ELSE 0 END) DESC, RANKING_EXPR_JOINED DESC`. Proven means `COALESCE(u.reputation, 0) > 1.0 OR (vote_count >= 3 AND effective_score > 0)`. Cold-start videos fall back to the top unproven row. `/variants` and list searches are unchanged.
- New column `lyrics.reputation_penalized BOOLEAN DEFAULT FALSE` (idempotent `ADD COLUMN IF NOT EXISTS`) gates one-shot penalty application across both the cron and inline paths.
- New cron stage `applyAutoHidePenalty` in `updateScores`, between stale-row recalc and `updateReputations`. Drops the submitter's reputation by 0.2 per newly auto-hidden row, summed per submitter, transaction-wrapped with the bulk mark UPDATE.
- `softDeleteLyrics` applies the same 0.2 penalty inline when role is `admin`, or when role is `submitter` and the row was net-negative (`vote_count >= 2 AND effective_score < 0`) at delete time. Skipped if `reputation_penalized` is already TRUE. Penalty, mark, and soft-delete sit inside one transaction.
- Variant cap query in `submitLyrics` now counts soft-deleted rows where `reputation_penalized = TRUE`, so abusers can't soft-delete to refresh the cap slot. Clean deletes still free the slot.
- `calculateScore` excludes votes from wallets with `reputation < 0.5` from `effective_score`. `vote_count` still returns `votes.length` so the confidence term in `RANKING_EXPR` stays honest. Consensus-delta reputation movement in `updateReputations` still considers sub-floor voters so they keep paying for bad votes.

## Post-deploy follow-ups

- Run `EXPLAIN ANALYZE` on `findByVideoId` against a `video_id` with multiple variants. Add a partial index if the per-video sort is hot.
- Watch the new `applied auto-hide reputation penalty` log for unexpected volume.