### PR TITLE
feat(web): port-protocol sign-in with Better Lyrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,90 @@ All write operations require signed requests using ECDSA P-256:
 - `signature`: ECDSA signature over the canonical JSON payload
 - `publicKey`: Required on first request to register the key
 
+## Sign in with Better Lyrics
+
+The Better Lyrics extension owns the user's ECDSA keypair. To prove identity to a web client, open a long-lived port to the extension and exchange one signed challenge for one signed response.
+
+### Wire protocol
+
+Open a port named `bl-auth-site` against the extension's Chrome Web Store id. Send one request, await one response.
+
+Request:
+
+```ts
+{ type: "bl-auth-request", nonce: string, origin: string }
+```
+
+`nonce` is issued by your backend per challenge. `origin` must equal `window.location.origin`.
+
+Success:
+
+```ts
+{
+  ok: true,
+  signedBody: {
+    payload: { origin: string, timestamp: number, nonce: string, keyId: string },
+    signature: string,    // base64
+    publicKey: JsonWebKey,
+  }
+}
+```
+
+Failure: `{ ok: false, reason }`, with `reason` one of `ORIGIN_MISMATCH`, `INVALID_REQUEST`, `USER_CANCELLED`, `USER_DISMISSED`, `SIGN_FAILED`.
+
+### Client
+
+```ts
+const BL_EXTENSION_ID = "effdbpeggelllpfkjppbokhmmiinhlmg"
+
+async function signInWithBetterLyrics(): Promise<SignedBody> {
+  const { nonce } = await fetch("/auth/challenge").then(r => r.json())
+
+  return new Promise((resolve, reject) => {
+    let port: chrome.runtime.Port
+    try {
+      port = chrome.runtime.connect(BL_EXTENSION_ID, { name: "bl-auth-site" })
+    } catch {
+      reject(new Error("Extension not installed or origin not allowed"))
+      return
+    }
+
+    let settled = false
+    port.onMessage.addListener(msg => {
+      if (settled) return
+      settled = true
+      if (msg.ok) resolve(msg.signedBody)
+      else reject(new Error(msg.reason))
+      try { port.disconnect() } catch {}
+    })
+    port.onDisconnect.addListener(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(chrome.runtime.lastError?.message ?? "Port closed"))
+    })
+
+    port.postMessage({ type: "bl-auth-request", nonce, origin: window.location.origin })
+  })
+}
+```
+
+Listeners must attach before `postMessage`, and the calling button should disable itself until the promise settles so a second click doesn't open a second popup.
+
+### Server
+
+Verify `signedBody` with the same scheme as a per-request signature (see [Authentication](#authentication)): nonce is unused, `origin` matches, `timestamp` within ±5 minutes, ECDSA P-256 over canonical-JSON `payload` against `publicKey`, `keyId === sha256(normalized publicKey)`. If all five pass, treat `keyId` as the stable user id.
+
+### Adding a new origin
+
+To talk to the extension from a new origin, open a PR against [better-lyrics/better-lyrics](https://github.com/better-lyrics/better-lyrics):
+
+1. Add the HTTPS origin to `externally_connectable.matches` in `manifest.json`.
+2. Add an `AUTH_PARTNER_METADATA` entry in `src/core/constants.ts` with an `id` and optional `iconUrl`.
+
+### Browser support
+
+Chrome and Chromium-based browsers only. Firefox does not implement `externally_connectable` for web pages ([Bugzilla 1319168](https://bugzilla.mozilla.org/show_bug.cgi?id=1319168)).
+
 ## API
 
 ### Get lyrics

--- a/web/src/auth/AuthProvider.test.tsx
+++ b/web/src/auth/AuthProvider.test.tsx
@@ -103,6 +103,32 @@ describe("AuthProvider initial state", () => {
   })
 })
 
+function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => {
+        let onMessageListener: ((m: unknown) => void) | null = null
+        const port = {
+          name: info.name,
+          onMessage: {
+            addListener: (l: (m: unknown) => void) => {
+              onMessageListener = l
+            },
+          },
+          onDisconnect: {
+            addListener: (_l: () => void) => {},
+          },
+          postMessage: (req: { type: string }) => {
+            queueMicrotask(() => onMessageListener?.(makeResponse(req)))
+          },
+          disconnect: () => {},
+        }
+        return port
+      },
+    },
+  })
+}
+
 describe("AuthProvider signIn flow", () => {
   it("runs challenge then extension then session and lands in signed-in", async () => {
     const fetchMock = vi
@@ -112,15 +138,11 @@ describe("AuthProvider signIn flow", () => {
       )
       .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: valid }), { status: 200 }))
     vi.stubGlobal("fetch", fetchMock)
-    vi.stubGlobal("chrome", {
-      runtime: {
-        async sendMessage(_id: string, msg: { type: string }) {
-          if (msg.type === "bl-auth-request") {
-            return { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
-          }
-          return { ok: true }
-        },
-      },
+    stubChromePort((msg) => {
+      if (msg.type === "bl-auth-request") {
+        return { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
+      }
+      return { ok: true }
     })
     render(
       <AuthProvider>
@@ -142,13 +164,7 @@ describe("AuthProvider signIn flow", () => {
         new Response(JSON.stringify({ success: true, data: { nonce: "n1", expiresAt: 1 } }), { status: 200 }),
       )
     vi.stubGlobal("fetch", fetchMock)
-    vi.stubGlobal("chrome", {
-      runtime: {
-        async sendMessage() {
-          return { ok: false, reason: "USER_CANCELLED" }
-        },
-      },
-    })
+    stubChromePort(() => ({ ok: false, reason: "USER_CANCELLED" }))
     render(
       <AuthProvider>
         <Probe />
@@ -174,17 +190,13 @@ describe("AuthProvider signIn flow", () => {
       .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: valid }), { status: 200 }))
     vi.stubGlobal("fetch", fetchMock)
     let cancelled = true
-    vi.stubGlobal("chrome", {
-      runtime: {
-        async sendMessage(_id: string, msg: { type: string }) {
-          if (msg.type !== "bl-auth-request") return { ok: true }
-          if (cancelled) {
-            cancelled = false
-            return { ok: false, reason: "USER_CANCELLED" }
-          }
-          return { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
-        },
-      },
+    stubChromePort((msg) => {
+      if (msg.type !== "bl-auth-request") return { ok: true }
+      if (cancelled) {
+        cancelled = false
+        return { ok: false, reason: "USER_CANCELLED" }
+      }
+      return { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
     })
     render(
       <AuthProvider>

--- a/web/src/auth/AuthProvider.test.tsx
+++ b/web/src/auth/AuthProvider.test.tsx
@@ -16,6 +16,10 @@ function Probe() {
   return (
     <>
       <span data-testid="status">{session.status}</span>
+      <span data-testid="ext">{String(session.extensionAvailable)}</span>
+      {session.status === "signed-out" || session.status === "error" ? (
+        <span data-testid="signing-in">{String(session.signingIn)}</span>
+      ) : null}
       {session.status === "signed-in" ? <span data-testid="name">{session.identity.displayName}</span> : null}
       {session.status === "error" ? <span data-testid="error">{session.error.message}</span> : null}
       {session.status === "signed-out" || session.status === "error" ? (
@@ -127,6 +131,51 @@ function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
       },
     },
   })
+}
+
+interface DeferredPort {
+  name: string
+  onMessage: { addListener: (l: (m: unknown) => void) => void }
+  onDisconnect: { addListener: (l: () => void) => void }
+  postMessage: (msg: unknown) => void
+  disconnect: () => void
+}
+
+function stubChromePortDeferred(): {
+  authConnectCount: () => number
+  resolveAll: (response: unknown) => void
+  ports: () => DeferredPort[]
+} {
+  const ports: DeferredPort[] = []
+  const listeners: ((m: unknown) => void)[] = []
+  let authCount = 0
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => {
+        if (info.name === "bl-auth-site") authCount++
+        const port: DeferredPort = {
+          name: info.name,
+          onMessage: {
+            addListener: (l: (m: unknown) => void) => {
+              if (info.name === "bl-auth-site") listeners.push(l)
+            },
+          },
+          onDisconnect: { addListener: (_l: () => void) => {} },
+          postMessage: (_msg: unknown) => {},
+          disconnect: () => {},
+        }
+        ports.push(port)
+        return port
+      },
+    },
+  })
+  return {
+    authConnectCount: () => authCount,
+    resolveAll: (response: unknown) => {
+      for (const l of listeners) l(response)
+    },
+    ports: () => ports,
+  }
 }
 
 describe("AuthProvider signIn flow", () => {
@@ -301,5 +350,102 @@ describe("AuthProvider signOut", () => {
     })
     await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("signed-out"))
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe("AuthProvider extension detection", () => {
+  it("exposes extensionAvailable=true when the chrome runtime looks installed", async () => {
+    stubChromePort(() => ({ ok: true }))
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("signed-out"))
+    expect(screen.getByTestId("ext").textContent).toBe("true")
+  })
+
+  it("exposes extensionAvailable=false when there is no chrome global", async () => {
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("signed-out"))
+    expect(screen.getByTestId("ext").textContent).toBe("false")
+  })
+})
+
+describe("AuthProvider signingIn flag", () => {
+  it("flips signingIn to true while the extension call is in flight", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { nonce: "n1", expiresAt: 1 } }), { status: 200 }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+    const deferred = stubChromePortDeferred()
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByText("sign-in")).toBeTruthy())
+    expect(screen.getByTestId("signing-in").textContent).toBe("false")
+    await act(async () => {
+      screen.getByText("sign-in").click()
+    })
+    await waitFor(() => expect(screen.getByTestId("signing-in").textContent).toBe("true"))
+    expect(screen.getByTestId("status").textContent).toBe("signed-out")
+    expect(deferred.authConnectCount()).toBe(1)
+  })
+
+  it("flips signingIn back to false after USER_CANCELLED so the error state can retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { nonce: "n1", expiresAt: 1 } }), { status: 200 }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+    stubChromePort(() => ({ ok: false, reason: "USER_CANCELLED" }))
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByText("sign-in")).toBeTruthy())
+    await act(async () => {
+      screen.getByText("sign-in").click()
+    })
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("error"))
+    expect(screen.getByTestId("signing-in").textContent).toBe("false")
+  })
+
+  it("dedupes two rapid sign-in clicks into a single port connect", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { nonce: "n1", expiresAt: 1 } }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: valid }), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const deferred = stubChromePortDeferred()
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByText("sign-in")).toBeTruthy())
+    await act(async () => {
+      screen.getByText("sign-in").click()
+      screen.getByText("sign-in").click()
+    })
+    await waitFor(() => expect(screen.getByTestId("signing-in").textContent).toBe("true"))
+    expect(deferred.authConnectCount()).toBe(1)
+    await act(async () => {
+      deferred.resolveAll({ ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } })
+    })
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("signed-in"))
+    expect(deferred.authConnectCount()).toBe(1)
   })
 })

--- a/web/src/auth/AuthProvider.test.tsx
+++ b/web/src/auth/AuthProvider.test.tsx
@@ -120,7 +120,9 @@ function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
             },
           },
           onDisconnect: {
-            addListener: (_l: () => void) => {},
+            addListener: (l: () => void) => {
+              if (info.name === "bl-probe") queueMicrotask(l)
+            },
           },
           postMessage: (req: { type: string }) => {
             queueMicrotask(() => onMessageListener?.(makeResponse(req)))
@@ -129,6 +131,25 @@ function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
         }
         return port
       },
+    },
+  })
+}
+
+function stubChromePortMissing() {
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => ({
+        name: info.name,
+        onMessage: { addListener: (_l: (m: unknown) => void) => {} },
+        onDisconnect: {
+          addListener: (l: () => void) => {
+            queueMicrotask(l)
+          },
+        },
+        postMessage: (_msg: unknown) => {},
+        disconnect: () => {},
+      }),
+      lastError: { message: "Could not establish connection. Receiving end does not exist." },
     },
   })
 }
@@ -144,9 +165,7 @@ interface DeferredPort {
 function stubChromePortDeferred(): {
   authConnectCount: () => number
   resolveAll: (response: unknown) => void
-  ports: () => DeferredPort[]
 } {
-  const ports: DeferredPort[] = []
   const listeners: ((m: unknown) => void)[] = []
   let authCount = 0
   vi.stubGlobal("chrome", {
@@ -160,11 +179,14 @@ function stubChromePortDeferred(): {
               if (info.name === "bl-auth-site") listeners.push(l)
             },
           },
-          onDisconnect: { addListener: (_l: () => void) => {} },
+          onDisconnect: {
+            addListener: (l: () => void) => {
+              if (info.name === "bl-probe") queueMicrotask(l)
+            },
+          },
           postMessage: (_msg: unknown) => {},
           disconnect: () => {},
         }
-        ports.push(port)
         return port
       },
     },
@@ -174,7 +196,6 @@ function stubChromePortDeferred(): {
     resolveAll: (response: unknown) => {
       for (const l of listeners) l(response)
     },
-    ports: () => ports,
   }
 }
 
@@ -366,6 +387,17 @@ describe("AuthProvider extension detection", () => {
   })
 
   it("exposes extensionAvailable=false when there is no chrome global", async () => {
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("signed-out"))
+    expect(screen.getByTestId("ext").textContent).toBe("false")
+  })
+
+  it("exposes extensionAvailable=false when the probe port disconnects with lastError", async () => {
+    stubChromePortMissing()
     render(
       <AuthProvider>
         <Probe />

--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -50,8 +50,19 @@ interface AuthProviderProps {
 export function AuthProvider({ children }: AuthProviderProps) {
   const [phase, setPhase] = useState<Phase>({ kind: "loading" })
   const [signingIn, setSigningIn] = useState(false)
-  const [extensionAvailable] = useState(() => detectBetterLyrics() === "available")
+  const [extensionAvailable, setExtensionAvailable] = useState<boolean | null>(null)
   const signInLock = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+    detectBetterLyrics().then((v) => {
+      if (cancelled) return
+      setExtensionAvailable(v === "available")
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -119,8 +130,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [])
 
   let state: SessionState
-  if (phase.kind === "loading") state = { status: "loading", extensionAvailable }
-  else if (phase.kind === "signed-in")
+  if (phase.kind === "loading" || extensionAvailable === null) {
+    state = { status: "loading", extensionAvailable: extensionAvailable ?? false }
+  } else if (phase.kind === "signed-in")
     state = {
       status: "signed-in",
       extensionAvailable,

--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -8,7 +8,7 @@ import {
   revokeSession,
   saveStoredSession,
 } from "@/lib/auth"
-import { requestSignedAssertion } from "@/lib/extension"
+import { signInWithBetterLyrics } from "@/lib/extension"
 import { type ReactNode, createContext, useCallback, useContext, useEffect, useState } from "react"
 
 type SessionState =
@@ -70,7 +70,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const signIn = useCallback(async () => {
     try {
       const { nonce } = await fetchChallenge()
-      const signedBody = await requestSignedAssertion(nonce, window.location.origin)
+      const signedBody = await signInWithBetterLyrics(nonce)
       const session = await postSession(signedBody)
       saveStoredSession(session)
       setPhase({

--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -8,19 +8,26 @@ import {
   revokeSession,
   saveStoredSession,
 } from "@/lib/auth"
-import { signInWithBetterLyrics } from "@/lib/extension"
-import { type ReactNode, createContext, useCallback, useContext, useEffect, useState } from "react"
+import { detectBetterLyrics, signInWithBetterLyrics } from "@/lib/extension"
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 
 type SessionState =
-  | { status: "loading" }
-  | { status: "signed-out"; signIn: () => Promise<void> }
+  | { status: "loading"; extensionAvailable: boolean }
+  | { status: "signed-out"; extensionAvailable: boolean; signingIn: boolean; signIn: () => Promise<void> }
   | {
       status: "signed-in"
+      extensionAvailable: boolean
       identity: Identity
       signOut: () => void
       updateDisplayName: (displayName: string) => void
     }
-  | { status: "error"; error: Error; signIn: () => Promise<void> }
+  | {
+      status: "error"
+      extensionAvailable: boolean
+      signingIn: boolean
+      error: Error
+      signIn: () => Promise<void>
+    }
 
 const Ctx = createContext<SessionState | null>(null)
 
@@ -42,6 +49,9 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [phase, setPhase] = useState<Phase>({ kind: "loading" })
+  const [signingIn, setSigningIn] = useState(false)
+  const [extensionAvailable] = useState(() => detectBetterLyrics() === "available")
+  const signInLock = useRef(false)
 
   useEffect(() => {
     let cancelled = false
@@ -68,6 +78,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [])
 
   const signIn = useCallback(async () => {
+    if (signInLock.current) return
+    signInLock.current = true
+    setSigningIn(true)
     try {
       const { nonce } = await fetchChallenge()
       const signedBody = await signInWithBetterLyrics(nonce)
@@ -83,6 +96,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       })
     } catch (err) {
       setPhase({ kind: "error", error: err instanceof Error ? err : new Error(String(err)) })
+    } finally {
+      signInLock.current = false
+      setSigningIn(false)
     }
   }, [])
 
@@ -103,11 +119,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [])
 
   let state: SessionState
-  if (phase.kind === "loading") state = { status: "loading" }
+  if (phase.kind === "loading") state = { status: "loading", extensionAvailable }
   else if (phase.kind === "signed-in")
-    state = { status: "signed-in", identity: phase.identity, signOut, updateDisplayName }
-  else if (phase.kind === "error") state = { status: "error", error: phase.error, signIn }
-  else state = { status: "signed-out", signIn }
+    state = {
+      status: "signed-in",
+      extensionAvailable,
+      identity: phase.identity,
+      signOut,
+      updateDisplayName,
+    }
+  else if (phase.kind === "error")
+    state = { status: "error", extensionAvailable, signingIn, error: phase.error, signIn }
+  else state = { status: "signed-out", extensionAvailable, signingIn, signIn }
 
   return <Ctx.Provider value={state}>{children}</Ctx.Provider>
 }

--- a/web/src/components/SignInControl.test.tsx
+++ b/web/src/components/SignInControl.test.tsx
@@ -47,6 +47,30 @@ function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
   })
 }
 
+function stubChromePortDeferred(): { resolveAll: (response: unknown) => void } {
+  const listeners: ((m: unknown) => void)[] = []
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => ({
+        name: info.name,
+        onMessage: {
+          addListener: (l: (m: unknown) => void) => {
+            listeners.push(l)
+          },
+        },
+        onDisconnect: { addListener: (_l: () => void) => {} },
+        postMessage: (_msg: unknown) => {},
+        disconnect: () => {},
+      }),
+    },
+  })
+  return {
+    resolveAll: (response: unknown) => {
+      for (const l of listeners) l(response)
+    },
+  }
+}
+
 function stubSessionFetch() {
   vi.stubGlobal(
     "fetch",
@@ -229,5 +253,31 @@ describe("SignInControl", () => {
     vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})))
     const { container } = renderControl()
     expect(container.querySelector('[data-state="loading"]')).toBeTruthy()
+  })
+
+  it("disables the sign-in button while a sign-in is in flight", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { nonce: "n1", expiresAt: 1 } }), { status: 200 }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+    const deferred = stubChromePortDeferred()
+    renderControl()
+    const button = await screen.findByRole("button", { name: /sign in/i })
+    expect((button as HTMLButtonElement).disabled).toBe(false)
+    await act(async () => {
+      button.click()
+    })
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(true))
+    await act(async () => {
+      button.click()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      deferred.resolveAll({ ok: false, reason: "USER_CANCELLED" })
+    })
+    const retry = await screen.findByRole("button", { name: /sign in/i })
+    await waitFor(() => expect((retry as HTMLButtonElement).disabled).toBe(false))
   })
 })

--- a/web/src/components/SignInControl.test.tsx
+++ b/web/src/components/SignInControl.test.tsx
@@ -35,7 +35,11 @@ function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
               onMessageListener = l
             },
           },
-          onDisconnect: { addListener: (_l: () => void) => {} },
+          onDisconnect: {
+            addListener: (l: () => void) => {
+              if (info.name === "bl-probe") queueMicrotask(l)
+            },
+          },
           postMessage: (req: { type: string }) => {
             queueMicrotask(() => onMessageListener?.(makeResponse(req)))
           },
@@ -55,10 +59,14 @@ function stubChromePortDeferred(): { resolveAll: (response: unknown) => void } {
         name: info.name,
         onMessage: {
           addListener: (l: (m: unknown) => void) => {
-            listeners.push(l)
+            if (info.name === "bl-auth-site") listeners.push(l)
           },
         },
-        onDisconnect: { addListener: (_l: () => void) => {} },
+        onDisconnect: {
+          addListener: (l: () => void) => {
+            if (info.name === "bl-probe") queueMicrotask(l)
+          },
+        },
         postMessage: (_msg: unknown) => {},
         disconnect: () => {},
       }),

--- a/web/src/components/SignInControl.test.tsx
+++ b/web/src/components/SignInControl.test.tsx
@@ -23,6 +23,30 @@ function renderControl() {
   )
 }
 
+function stubChromePort(makeResponse: (req: { type: string }) => unknown) {
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => {
+        let onMessageListener: ((m: unknown) => void) | null = null
+        const port = {
+          name: info.name,
+          onMessage: {
+            addListener: (l: (m: unknown) => void) => {
+              onMessageListener = l
+            },
+          },
+          onDisconnect: { addListener: (_l: () => void) => {} },
+          postMessage: (req: { type: string }) => {
+            queueMicrotask(() => onMessageListener?.(makeResponse(req)))
+          },
+          disconnect: () => {},
+        }
+        return port
+      },
+    },
+  })
+}
+
 function stubSessionFetch() {
   vi.stubGlobal(
     "fetch",
@@ -68,13 +92,7 @@ describe("SignInControl", () => {
   })
 
   it("shows the sign-in button when the extension is available", async () => {
-    vi.stubGlobal("chrome", {
-      runtime: {
-        async sendMessage() {
-          return { ok: true }
-        },
-      },
-    })
+    stubChromePort(() => ({ ok: true }))
     renderControl()
     await waitFor(() => expect(screen.getByRole("button", { name: /sign in/i })).toBeTruthy())
   })
@@ -96,13 +114,7 @@ describe("SignInControl", () => {
         new Response(JSON.stringify({ success: false, error: "INVALID_TOKEN" }), { status: 401 }),
       ),
     )
-    vi.stubGlobal("chrome", {
-      runtime: {
-        async sendMessage() {
-          return { ok: true }
-        },
-      },
-    })
+    stubChromePort(() => ({ ok: true }))
     renderControl()
     await waitFor(() => expect(screen.getByRole("button", { name: /sign in/i })).toBeTruthy())
   })
@@ -115,15 +127,11 @@ describe("SignInControl", () => {
       )
       .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: valid }), { status: 200 }))
     vi.stubGlobal("fetch", fetchMock)
-    vi.stubGlobal("chrome", {
-      runtime: {
-        async sendMessage(_id: string, msg: { type: string }) {
-          if (msg.type === "bl-auth-request") {
-            return { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
-          }
-          return { ok: true }
-        },
-      },
+    stubChromePort((msg) => {
+      if (msg.type === "bl-auth-request") {
+        return { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
+      }
+      return { ok: true }
     })
     renderControl()
     const button = await screen.findByRole("button", { name: /sign in/i })

--- a/web/src/components/SignInControl.tsx
+++ b/web/src/components/SignInControl.tsx
@@ -1,26 +1,16 @@
+import { useSession } from "@/auth/useSession";
+import { dicebearThumbsDataUri } from "@/lib/avatar";
+import { detectBetterLyrics } from "@/lib/extension";
 import { IconCheck, IconCopy, IconLogout, IconUser } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { useSession } from "@/auth/useSession";
-import { dicebearThumbsDataUri } from "@/lib/avatar";
-import { isExtensionAvailable } from "@/lib/extension";
 
 export function SignInControl() {
   const session = useSession();
-  const [extensionReady, setExtensionReady] = useState<boolean | null>(null);
+  const [extensionReady] = useState<boolean>(() => detectBetterLyrics() === "available");
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    isExtensionAvailable().then((ok) => {
-      if (!cancelled) setExtensionReady(ok);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -134,11 +124,7 @@ export function SignInControl() {
     );
   }
 
-  if (extensionReady === null) {
-    return <div data-state="loading" className="h-8 w-44" />;
-  }
-
-  if (extensionReady === false) {
+  if (!extensionReady) {
     return (
       <a
         href="https://betterlyrics.org"

--- a/web/src/components/SignInControl.tsx
+++ b/web/src/components/SignInControl.tsx
@@ -1,13 +1,11 @@
 import { useSession } from "@/auth/useSession";
 import { dicebearThumbsDataUri } from "@/lib/avatar";
-import { detectBetterLyrics } from "@/lib/extension";
 import { IconCheck, IconCopy, IconLogout, IconUser } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 export function SignInControl() {
   const session = useSession();
-  const [extensionReady] = useState<boolean>(() => detectBetterLyrics() === "available");
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -124,7 +122,7 @@ export function SignInControl() {
     );
   }
 
-  if (!extensionReady) {
+  if (!session.extensionAvailable) {
     return (
       <a
         href="https://betterlyrics.org"
@@ -142,7 +140,8 @@ export function SignInControl() {
     <button
       type="button"
       onClick={session.signIn}
-      className="cursor-pointer rounded-md bg-unison-bg-elevated px-3 py-1.5 text-sm font-medium text-unison-text transition-colors hover:bg-unison-bg-hover"
+      disabled={session.signingIn}
+      className="cursor-pointer rounded-md bg-unison-bg-elevated px-3 py-1.5 text-sm font-medium text-unison-text transition-colors hover:bg-unison-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
       data-state="signed-out"
     >
       Sign in with Better Lyrics

--- a/web/src/lib/extension.test.ts
+++ b/web/src/lib/extension.test.ts
@@ -1,12 +1,84 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { BL_EXTENSION_ID, isExtensionAvailable, requestSignedAssertion } from "./extension"
+import { BL_EXTENSION_ID, detectBetterLyrics, signInWithBetterLyrics } from "./extension"
 
-type SendMessageFn = (id: string, msg: unknown) => Promise<unknown>
+type Listener<T> = (value: T) => void
 
-function installChromeMock(sendMessage: SendMessageFn) {
+interface PortHarness {
+  port: {
+    name: string
+    onMessage: { addListener: (l: Listener<unknown>) => void }
+    onDisconnect: { addListener: (l: Listener<void>) => void }
+    postMessage: (m: unknown) => void
+    disconnect: () => void
+  }
+  sentMessages: unknown[]
+  fireMessage: (m: unknown) => void
+  fireDisconnect: () => void
+  listenerCounts: () => { onMessage: number; onDisconnect: number }
+  isDisconnected: () => boolean
+}
+
+function makePort(name: string): PortHarness {
+  const onMessageListeners: Listener<unknown>[] = []
+  const onDisconnectListeners: Listener<void>[] = []
+  const sentMessages: unknown[] = []
+  let disconnected = false
+  const harness: PortHarness = {
+    port: {
+      name,
+      onMessage: {
+        addListener: (l) => {
+          onMessageListeners.push(l)
+        },
+      },
+      onDisconnect: {
+        addListener: (l) => {
+          onDisconnectListeners.push(l)
+        },
+      },
+      postMessage: (m) => {
+        sentMessages.push(m)
+      },
+      disconnect: () => {
+        disconnected = true
+      },
+    },
+    sentMessages,
+    fireMessage: (m) => {
+      for (const l of onMessageListeners) l(m)
+    },
+    fireDisconnect: () => {
+      for (const l of onDisconnectListeners) l()
+    },
+    listenerCounts: () => ({
+      onMessage: onMessageListeners.length,
+      onDisconnect: onDisconnectListeners.length,
+    }),
+    isDisconnected: () => disconnected,
+  }
+  return harness
+}
+
+interface ConnectCall {
+  extensionId: string
+  info: { name: string }
+}
+
+function installChrome(
+  connect: (id: string, info: { name: string }) => PortHarness["port"],
+  lastError?: { message: string },
+): { connectCalls: ConnectCall[] } {
+  const connectCalls: ConnectCall[] = []
   vi.stubGlobal("chrome", {
-    runtime: { sendMessage },
+    runtime: {
+      connect: (id: string, info: { name: string }) => {
+        connectCalls.push({ extensionId: id, info })
+        return connect(id, info)
+      },
+      lastError,
+    },
   })
+  return { connectCalls }
 }
 
 beforeEach(() => {
@@ -22,58 +94,248 @@ describe("BL_EXTENSION_ID", () => {
   })
 })
 
-describe("isExtensionAvailable", () => {
-  it("returns false when chrome.runtime is not present", async () => {
-    expect(await isExtensionAvailable()).toBe(false)
-  })
-
-  it("returns true when ping succeeds", async () => {
-    installChromeMock(async () => ({ ok: true }))
-    expect(await isExtensionAvailable()).toBe(true)
-  })
-
-  it("returns false when sendMessage rejects", async () => {
-    installChromeMock(async () => {
-      throw new Error("no extension")
+describe("signInWithBetterLyrics", () => {
+  describe("happy paths", () => {
+    it("resolves with the signedBody on an ok response", async () => {
+      const signedBody = {
+        payload: { origin: "x", timestamp: 1, nonce: "n", keyId: "kid" },
+        signature: "sig",
+        publicKey: { kty: "EC" },
+      }
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      harness.fireMessage({ ok: true, signedBody })
+      await expect(promise).resolves.toEqual(signedBody)
     })
-    expect(await isExtensionAvailable()).toBe(false)
+
+    it("sends the documented request message and uses the bl-auth-site port name", async () => {
+      let harness!: PortHarness
+      const { connectCalls } = installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("nonce-xyz")
+      expect(connectCalls[0].extensionId).toBe(BL_EXTENSION_ID)
+      expect(connectCalls[0].info.name).toBe("bl-auth-site")
+      expect(harness.sentMessages).toEqual([
+        { type: "bl-auth-request", nonce: "nonce-xyz", origin: window.location.origin },
+      ])
+      harness.fireMessage({
+        ok: true,
+        signedBody: { payload: {}, signature: "", publicKey: {} },
+      })
+      await promise
+    })
   })
 
-  it("returns false when sendMessage resolves to undefined (extension absent)", async () => {
-    installChromeMock(async () => undefined)
-    expect(await isExtensionAvailable()).toBe(false)
+  describe("error paths", () => {
+    it("rejects with the raw reason on USER_CANCELLED", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      harness.fireMessage({ ok: false, reason: "USER_CANCELLED" })
+      await expect(promise).rejects.toThrow("USER_CANCELLED")
+    })
+
+    it.each(["USER_DISMISSED", "SIGN_FAILED", "ORIGIN_MISMATCH", "INVALID_REQUEST"])(
+      "rejects with the raw reason on %s",
+      async (reason) => {
+        let harness!: PortHarness
+        installChrome((_id, info) => {
+          harness = makePort(info.name)
+          return harness.port
+        })
+        const promise = signInWithBetterLyrics("n")
+        harness.fireMessage({ ok: false, reason })
+        await expect(promise).rejects.toThrow(reason)
+      },
+    )
+
+    it("rejects when chrome is undefined", async () => {
+      await expect(signInWithBetterLyrics("n")).rejects.toThrow("Better Lyrics extension not detected")
+    })
+
+    it("rejects when chrome.runtime.connect is missing", async () => {
+      vi.stubGlobal("chrome", { runtime: {} })
+      await expect(signInWithBetterLyrics("n")).rejects.toThrow("Better Lyrics extension not detected")
+    })
+
+    it("rejects when chrome.runtime.connect throws synchronously", async () => {
+      vi.stubGlobal("chrome", {
+        runtime: {
+          connect: () => {
+            throw new Error("no extension")
+          },
+        },
+      })
+      await expect(signInWithBetterLyrics("n")).rejects.toThrow(
+        "Better Lyrics extension not installed or origin not allowed",
+      )
+    })
+
+    it("rejects with lastError.message when the port disconnects before a response", async () => {
+      let harness!: PortHarness
+      installChrome(
+        (_id, info) => {
+          harness = makePort(info.name)
+          return harness.port
+        },
+        { message: "Could not establish connection. Receiving end does not exist." },
+      )
+      const promise = signInWithBetterLyrics("n")
+      harness.fireDisconnect()
+      await expect(promise).rejects.toThrow("Could not establish connection. Receiving end does not exist.")
+    })
+
+    it("rejects with a generic message when the port disconnects with no lastError", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      harness.fireDisconnect()
+      await expect(promise).rejects.toThrow("Port closed before response")
+    })
+  })
+
+  describe("invariants", () => {
+    it("registers onMessage and onDisconnect listeners before postMessage runs", async () => {
+      let countsAtPost: { onMessage: number; onDisconnect: number } | null = null
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        const original = harness.port.postMessage
+        harness.port.postMessage = (m) => {
+          countsAtPost = harness.listenerCounts()
+          original(m)
+        }
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      expect(countsAtPost).not.toBeNull()
+      expect((countsAtPost as unknown as { onMessage: number }).onMessage).toBeGreaterThanOrEqual(1)
+      expect((countsAtPost as unknown as { onDisconnect: number }).onDisconnect).toBeGreaterThanOrEqual(1)
+      harness.fireMessage({ ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } })
+      await promise
+    })
+
+    it("disconnects the port after a successful response", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      harness.fireMessage({
+        ok: true,
+        signedBody: { payload: {}, signature: "", publicKey: {} },
+      })
+      await promise
+      expect(harness.isDisconnected()).toBe(true)
+    })
+
+    it("disconnects the port after an error response", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      harness.fireMessage({ ok: false, reason: "USER_CANCELLED" })
+      await expect(promise).rejects.toThrow("USER_CANCELLED")
+      expect(harness.isDisconnected()).toBe(true)
+    })
+
+    it("a late onDisconnect after a settled onMessage does not produce an unhandled rejection", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const unhandled: unknown[] = []
+      const onUnhandled = (e: PromiseRejectionEvent) => {
+        unhandled.push(e.reason)
+      }
+      window.addEventListener("unhandledrejection", onUnhandled)
+      try {
+        const promise = signInWithBetterLyrics("n")
+        harness.fireMessage({
+          ok: true,
+          signedBody: { payload: {}, signature: "", publicKey: {} },
+        })
+        await promise
+        harness.fireDisconnect()
+        await new Promise((r) => setTimeout(r, 0))
+        expect(unhandled).toEqual([])
+      } finally {
+        window.removeEventListener("unhandledrejection", onUnhandled)
+      }
+    })
+
+    it("a late onMessage after onDisconnect rejected does not flip the result", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = signInWithBetterLyrics("n")
+      const rejected = promise.catch((e) => e)
+      harness.fireDisconnect()
+      const first = await rejected
+      expect(first).toBeInstanceOf(Error)
+      harness.fireMessage({
+        ok: true,
+        signedBody: { payload: {}, signature: "", publicKey: {} },
+      })
+      const second = await promise.then(
+        () => "resolved",
+        (e) => e,
+      )
+      expect(second).toBe(first)
+    })
   })
 })
 
-describe("requestSignedAssertion", () => {
-  it("returns the signedBody on ok response", async () => {
-    const signedBody = { payload: { nonce: "n" }, signature: "s", publicKey: {} }
-    installChromeMock(async (id, msg) => {
-      expect(id).toBe(BL_EXTENSION_ID)
-      expect(msg).toEqual({ type: "bl-auth-request", nonce: "n", origin: "https://x.test" })
-      return { ok: true, signedBody }
+describe("detectBetterLyrics", () => {
+  it("returns 'unavailable' when chrome is undefined", () => {
+    expect(detectBetterLyrics()).toBe("unavailable")
+  })
+
+  it("returns 'unavailable' when chrome.runtime.connect is missing", () => {
+    vi.stubGlobal("chrome", { runtime: {} })
+    expect(detectBetterLyrics()).toBe("unavailable")
+  })
+
+  it("returns 'unavailable' when chrome.runtime.connect throws", () => {
+    vi.stubGlobal("chrome", {
+      runtime: {
+        connect: () => {
+          throw new Error("no extension")
+        },
+      },
     })
-    await expect(requestSignedAssertion("n", "https://x.test")).resolves.toEqual(signedBody)
+    expect(detectBetterLyrics()).toBe("unavailable")
   })
 
-  it("throws with the documented reason on ok:false", async () => {
-    installChromeMock(async () => ({ ok: false, reason: "USER_CANCELLED" }))
-    await expect(requestSignedAssertion("n", "https://x.test")).rejects.toThrow("USER_CANCELLED")
+  it("returns 'available' when connect returns a port", () => {
+    const harness = makePort("bl-probe")
+    installChrome(() => harness.port)
+    expect(detectBetterLyrics()).toBe("available")
+    expect(harness.isDisconnected()).toBe(true)
   })
 
-  it("throws EXTENSION_UNAVAILABLE when chrome.runtime is missing", async () => {
-    await expect(requestSignedAssertion("n", "https://x.test")).rejects.toThrow("EXTENSION_UNAVAILABLE")
-  })
-
-  it("throws EXTENSION_UNAVAILABLE when sendMessage rejects", async () => {
-    installChromeMock(async () => {
-      throw new Error("disconnected")
-    })
-    await expect(requestSignedAssertion("n", "https://x.test")).rejects.toThrow("EXTENSION_UNAVAILABLE")
-  })
-
-  it("throws SIGN_FAILED when reply is an object missing ok and reason", async () => {
-    installChromeMock(async () => ({}))
-    await expect(requestSignedAssertion("n", "https://x.test")).rejects.toThrow("SIGN_FAILED")
+  it("uses the bl-probe port name (not bl-auth-site)", () => {
+    const harness = makePort("bl-probe")
+    const { connectCalls } = installChrome(() => harness.port)
+    detectBetterLyrics()
+    expect(connectCalls[0].info.name).toBe("bl-probe")
   })
 })

--- a/web/src/lib/extension.test.ts
+++ b/web/src/lib/extension.test.ts
@@ -305,37 +305,91 @@ describe("signInWithBetterLyrics", () => {
 })
 
 describe("detectBetterLyrics", () => {
-  it("returns 'unavailable' when chrome is undefined", () => {
-    expect(detectBetterLyrics()).toBe("unavailable")
-  })
-
-  it("returns 'unavailable' when chrome.runtime.connect is missing", () => {
-    vi.stubGlobal("chrome", { runtime: {} })
-    expect(detectBetterLyrics()).toBe("unavailable")
-  })
-
-  it("returns 'unavailable' when chrome.runtime.connect throws", () => {
-    vi.stubGlobal("chrome", {
-      runtime: {
-        connect: () => {
-          throw new Error("no extension")
-        },
-      },
+  describe("unavailable paths", () => {
+    it("resolves to 'unavailable' when chrome is undefined", async () => {
+      await expect(detectBetterLyrics()).resolves.toBe("unavailable")
     })
-    expect(detectBetterLyrics()).toBe("unavailable")
+
+    it("resolves to 'unavailable' when chrome.runtime.connect is missing", async () => {
+      vi.stubGlobal("chrome", { runtime: {} })
+      await expect(detectBetterLyrics()).resolves.toBe("unavailable")
+    })
+
+    it("resolves to 'unavailable' when chrome.runtime.connect throws synchronously", async () => {
+      vi.stubGlobal("chrome", {
+        runtime: {
+          connect: () => {
+            throw new Error("no extension")
+          },
+        },
+      })
+      await expect(detectBetterLyrics()).resolves.toBe("unavailable")
+    })
+
+    it("resolves to 'unavailable' when the port disconnects with lastError set", async () => {
+      let harness!: PortHarness
+      installChrome(
+        (_id, info) => {
+          harness = makePort(info.name)
+          return harness.port
+        },
+        { message: "Could not establish connection. Receiving end does not exist." },
+      )
+      const promise = detectBetterLyrics()
+      harness.fireDisconnect()
+      await expect(promise).resolves.toBe("unavailable")
+    })
   })
 
-  it("returns 'available' when connect returns a port", () => {
-    const harness = makePort("bl-probe")
-    installChrome(() => harness.port)
-    expect(detectBetterLyrics()).toBe("available")
-    expect(harness.isDisconnected()).toBe(true)
+  describe("available paths", () => {
+    it("resolves to 'available' when the port disconnects with no lastError", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = detectBetterLyrics()
+      harness.fireDisconnect()
+      await expect(promise).resolves.toBe("available")
+    })
+
+    it("resolves to 'available' when no events fire before the timeout", async () => {
+      const harness = makePort("bl-probe")
+      installChrome(() => harness.port)
+      await expect(detectBetterLyrics(5)).resolves.toBe("available")
+    })
   })
 
-  it("uses the bl-probe port name (not bl-auth-site)", () => {
-    const harness = makePort("bl-probe")
-    const { connectCalls } = installChrome(() => harness.port)
-    detectBetterLyrics()
-    expect(connectCalls[0].info.name).toBe("bl-probe")
+  describe("invariants", () => {
+    it("uses the bl-probe port name (not bl-auth-site)", async () => {
+      let harness!: PortHarness
+      const { connectCalls } = installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = detectBetterLyrics()
+      harness.fireDisconnect()
+      await promise
+      expect(connectCalls[0].info.name).toBe("bl-probe")
+    })
+
+    it("disconnects the probe port after settling", async () => {
+      let harness!: PortHarness
+      installChrome((_id, info) => {
+        harness = makePort(info.name)
+        return harness.port
+      })
+      const promise = detectBetterLyrics()
+      harness.fireDisconnect()
+      await promise
+      expect(harness.isDisconnected()).toBe(true)
+    })
+
+    it("disconnects the probe port after the timeout fallback fires", async () => {
+      const harness = makePort("bl-probe")
+      installChrome(() => harness.port)
+      await detectBetterLyrics(5)
+      expect(harness.isDisconnected()).toBe(true)
+    })
   })
 })

--- a/web/src/lib/extension.ts
+++ b/web/src/lib/extension.ts
@@ -68,14 +68,37 @@ export function signInWithBetterLyrics(nonce: string): Promise<SignedBody> {
   })
 }
 
-export function detectBetterLyrics(): "available" | "unavailable" {
-  const runtime = getRuntime()
-  if (!runtime) return "unavailable"
-  try {
-    const port = runtime.connect(BL_EXTENSION_ID, { name: "bl-probe" })
-    port.disconnect()
-    return "available"
-  } catch {
-    return "unavailable"
-  }
+export function detectBetterLyrics(timeoutMs = 200): Promise<"available" | "unavailable"> {
+  return new Promise((resolve) => {
+    const runtime = getRuntime()
+    if (!runtime) {
+      resolve("unavailable")
+      return
+    }
+
+    let port: Port
+    try {
+      port = runtime.connect(BL_EXTENSION_ID, { name: "bl-probe" })
+    } catch {
+      resolve("unavailable")
+      return
+    }
+
+    let settled = false
+    const settle = (result: "available" | "unavailable") => {
+      if (settled) return
+      settled = true
+      try {
+        port.disconnect()
+      } catch {}
+      resolve(result)
+    }
+
+    const timer = setTimeout(() => settle("available"), timeoutMs)
+
+    port.onDisconnect.addListener(() => {
+      clearTimeout(timer)
+      settle(runtime.lastError ? "unavailable" : "available")
+    })
+  })
 }

--- a/web/src/lib/extension.ts
+++ b/web/src/lib/extension.ts
@@ -2,45 +2,80 @@ import type { SignedBody } from "./auth"
 
 export const BL_EXTENSION_ID = "effdbpeggelllpfkjppbokhmmiinhlmg"
 
-type ChromeSendMessage = (id: string, msg: unknown) => Promise<unknown>
+interface Port {
+  onMessage: { addListener: (l: (msg: unknown) => void) => void }
+  onDisconnect: { addListener: (l: () => void) => void }
+  postMessage: (msg: unknown) => void
+  disconnect: () => void
+}
 
 interface ChromeRuntime {
-  sendMessage: ChromeSendMessage
+  connect: (id: string, info: { name: string }) => Port
+  lastError?: { message: string }
 }
 
 function getRuntime(): ChromeRuntime | null {
-  const c = (globalThis as { chrome?: { runtime?: ChromeRuntime } }).chrome
-  if (!c || !c.runtime || typeof c.runtime.sendMessage !== "function") return null
-  return c.runtime
-}
-
-export async function isExtensionAvailable(): Promise<boolean> {
-  const runtime = getRuntime()
-  if (!runtime) return false
-  try {
-    const reply = await runtime.sendMessage(BL_EXTENSION_ID, { type: "bl-ping" })
-    return reply !== undefined && reply !== null
-  } catch {
-    return false
-  }
+  const c = (globalThis as { chrome?: { runtime?: Partial<ChromeRuntime> } }).chrome
+  if (!c || !c.runtime || typeof c.runtime.connect !== "function") return null
+  return c.runtime as ChromeRuntime
 }
 
 type AuthResponse = { ok: true; signedBody: SignedBody } | { ok: false; reason: string }
 
-export async function requestSignedAssertion(nonce: string, origin: string): Promise<SignedBody> {
-  const runtime = getRuntime()
-  if (!runtime) throw new Error("EXTENSION_UNAVAILABLE")
-  let reply: AuthResponse
-  try {
-    reply = (await runtime.sendMessage(BL_EXTENSION_ID, {
+export function signInWithBetterLyrics(nonce: string): Promise<SignedBody> {
+  return new Promise((resolve, reject) => {
+    const runtime = getRuntime()
+    if (!runtime) {
+      reject(new Error("Better Lyrics extension not detected"))
+      return
+    }
+
+    let port: Port
+    try {
+      port = runtime.connect(BL_EXTENSION_ID, { name: "bl-auth-site" })
+    } catch {
+      reject(new Error("Better Lyrics extension not installed or origin not allowed"))
+      return
+    }
+
+    let settled = false
+
+    port.onMessage.addListener((raw) => {
+      if (settled) return
+      settled = true
+      const msg = raw as AuthResponse | null
+      if (msg?.ok) {
+        resolve(msg.signedBody)
+      } else {
+        reject(new Error(msg?.reason ?? "SIGN_FAILED"))
+      }
+      try {
+        port.disconnect()
+      } catch {}
+    })
+
+    port.onDisconnect.addListener(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(runtime.lastError?.message ?? "Port closed before response"))
+    })
+
+    port.postMessage({
       type: "bl-auth-request",
       nonce,
-      origin,
-    })) as AuthResponse
+      origin: window.location.origin,
+    })
+  })
+}
+
+export function detectBetterLyrics(): "available" | "unavailable" {
+  const runtime = getRuntime()
+  if (!runtime) return "unavailable"
+  try {
+    const port = runtime.connect(BL_EXTENSION_ID, { name: "bl-probe" })
+    port.disconnect()
+    return "available"
   } catch {
-    throw new Error("EXTENSION_UNAVAILABLE")
+    return "unavailable"
   }
-  if (!reply || typeof reply !== "object") throw new Error("EXTENSION_UNAVAILABLE")
-  if (!reply.ok) throw new Error(reply.reason || "SIGN_FAILED")
-  return reply.signedBody
 }


### PR DESCRIPTION
## Summary

- Switches the SPA sign-in flow from `chrome.runtime.sendMessage` to `chrome.runtime.connect`. BL extension PR #636 dropped the sendMessage handler, so the old client would hang silently against the next BL release.
- `web/src/lib/extension.ts` exports `signInWithBetterLyrics(nonce)` and a synchronous `detectBetterLyrics()` over a port. Listeners attach before `postMessage` and a `settled` guard blocks double resolution from a late disconnect.
- `AuthProvider` runs detection once on mount, caches `extensionAvailable` on every `SessionState` variant, and `SignInControl` reads from context instead of probing itself.
- A `useRef` lock plus a `signingIn` field on the signed-out and error variants prevents a double-click from opening two ports. The button disables until the promise settles.

## Test plan

- [ ] Sign in against an unpacked PR #636 build, confirm session lands
- [ ] Cancel the consent popup, confirm `USER_CANCELLED` surfaces and the button re-enables
- [ ] X-out the popup, confirm `USER_DISMISSED`
- [ ] Hold the popup open 60+ seconds before approving, confirm the heartbeat keeps the worker alive
- [ ] Disable the extension and reload, confirm the sign-in button is hidden and the Get Better Lyrics link shows