### PR TITLE
detect lyrics language on submit and backfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ wrangler.toml
 
 # CLI utils
 cli/
+
+# Local audit scripts (uncommitted, run against prod)
+scripts/audit-language.ts

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "@elysiajs/node": "^1.3.3",
     "elysia": "^1.3.3",
     "fast-xml-parser": "^5.5.5",
+    "franc": "^6.2.0",
     "ioredis": "^5.4.0",
+    "iso-639-3": "^3.0.1",
     "obscenity": "^0.4.6",
     "pg": "^8.13.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,15 @@ importers:
       fast-xml-parser:
         specifier: ^5.5.5
         version: 5.5.5
+      franc:
+        specifier: ^6.2.0
+        version: 6.2.0
       ioredis:
         specifier: ^5.4.0
         version: 5.10.0
+      iso-639-3:
+        specifier: ^3.0.1
+        version: 3.0.1
       obscenity:
         specifier: ^0.4.6
         version: 0.4.6
@@ -918,6 +924,9 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1027,6 +1036,9 @@ packages:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
 
+  franc@6.2.0:
+    resolution: {integrity: sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1045,6 +1057,9 @@ packages:
   ioredis@5.10.0:
     resolution: {integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==}
     engines: {node: '>=12.22.0'}
+
+  iso-639-3@3.0.1:
+    resolution: {integrity: sha512-SdljCYXOexv/JmbQ0tvigHN43yECoscVpe2y2hlEqy/CStXQlroPhZLj7zKLRiGqLJfw8k7B973UAMDoQczVgQ==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -1067,6 +1082,9 @@ packages:
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  n-gram@2.0.2:
+    resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1231,6 +1249,9 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  trigram-utils@2.0.1:
+    resolution: {integrity: sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2117,6 +2138,8 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  collapse-white-space@2.1.0: {}
+
   cookie@1.1.1: {}
 
   croner@6.0.7: {}
@@ -2257,6 +2280,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  franc@6.2.0:
+    dependencies:
+      trigram-utils: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -2284,6 +2311,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iso-639-3@3.0.1: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.isarguments@3.1.0: {}
@@ -2299,6 +2328,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@3.0.0: {}
+
+  n-gram@2.0.2: {}
 
   nanoid@3.3.11: {}
 
@@ -2444,6 +2475,11 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  trigram-utils@2.0.1:
+    dependencies:
+      collapse-white-space: 2.1.0
+      n-gram: 2.0.2
 
   tslib@2.8.1: {}
 

--- a/schema.sql
+++ b/schema.sql
@@ -123,6 +123,11 @@ CREATE INDEX IF NOT EXISTS idx_lyrics_album_norm_trgm ON lyrics USING GIN (album
 ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS lyrics_text_search tsvector;
 CREATE INDEX IF NOT EXISTS idx_lyrics_text_search ON lyrics USING GIN (lyrics_text_search);
 
+-- Language auto-detection: tracks whether we have attempted detection
+-- on this row, so the backfill job stays idempotent and the column
+-- `language` keeps its semantic meaning (NULL = unknown).
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_detection_attempted_at TIMESTAMPTZ;
+
 -- Multi-variant lyrics: allow multiple entries per video_id
 -- Drop the unique constraint so multiple submissions can coexist
 ALTER TABLE lyrics DROP CONSTRAINT IF EXISTS lyrics_video_id_key;

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,4 +1,5 @@
 import { config } from "@/config"
+import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
@@ -594,9 +595,7 @@ describe("invalidateCacheAfterDelete", () => {
 
 describe("invalidateCacheForSubmitter", () => {
 	it("deletes v:<videoId> for every row returned by the join", async () => {
-		const db = createMockDB([
-			[{ video_id: "vA" }, { video_id: "vB" }, { video_id: "vC" }],
-		])
+		const db = createMockDB([[{ video_id: "vA" }, { video_id: "vB" }, { video_id: "vC" }]])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
@@ -1291,13 +1290,7 @@ describe("submitLyrics fulfillment integration", () => {
 	})
 
 	it("skips fulfillment when a prior synced variant exists", async () => {
-		const db = createMockDB([
-			{ count: 0 },
-			{ id: 557 },
-			{ key_id: "k1" },
-			null,
-			{ "1": 1 },
-		])
+		const db = createMockDB([{ count: 0 }, { id: 557 }, { key_id: "k1" }, null, { "1": 1 }])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
@@ -1357,9 +1350,11 @@ describe("submitLyrics language detection", () => {
 		expect(insertCall!.sql).toContain("language")
 		expect(insertCall!.sql).toContain("language_detection_attempted_at")
 		expect(insertCall!.params).toContain("en")
+		expect(insertCall!.params).toHaveLength(15)
 	})
 
 	it("preserves submitter language even when detection disagrees", async () => {
+		const warnSpy = vi.spyOn(Logger.prototype, "warn")
 		const db = createMockDB([{ count: 0 }, { id: 43 }])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
@@ -1380,6 +1375,11 @@ describe("submitLyrics language detection", () => {
 		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
 		expect(insertCall!.params).toContain("es")
 		expect(insertCall!.params).not.toContain("en")
+		expect(warnSpy).toHaveBeenCalledWith(
+			"language mismatch",
+			expect.objectContaining({ submitted: "es", detected: "en" })
+		)
+		warnSpy.mockRestore()
 	})
 
 	it("stores null language when detection cannot confidently identify a language", async () => {

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1326,3 +1326,81 @@ describe("submitLyrics variant cap", () => {
 		expect(countCall!.sql).toMatch(/deleted_at\s+IS\s+NULL/i)
 	})
 })
+
+describe("submitLyrics language detection", () => {
+	const ENGLISH_LYRICS_SAMPLE = [
+		"In your arms I find the answer to every question",
+		"You whisper softly and the world begins to spin",
+		"Holding on tight to the moments we have together",
+		"Every heartbeat is a song that only we can hear",
+	].join("\n")
+
+	it("auto-detects language when submitter omits it", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 42 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid42",
+			song: "Test",
+			artist: "Tester",
+			duration: 200,
+			lyrics: ENGLISH_LYRICS_SAMPLE,
+			format: "plain",
+			syncType: "plain",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		expect(insertCall).toBeDefined()
+		expect(insertCall!.sql).toContain("language")
+		expect(insertCall!.sql).toContain("language_detection_attempted_at")
+		expect(insertCall!.params).toContain("en")
+	})
+
+	it("preserves submitter language even when detection disagrees", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 43 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid43",
+			song: "Test",
+			artist: "Tester",
+			duration: 200,
+			lyrics: ENGLISH_LYRICS_SAMPLE,
+			format: "plain",
+			syncType: "plain",
+			language: "es",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		expect(insertCall!.params).toContain("es")
+		expect(insertCall!.params).not.toContain("en")
+	})
+
+	it("stores null language when detection cannot confidently identify a language", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 44 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid44",
+			song: "Instrumental",
+			artist: "Tester",
+			duration: 200,
+			lyrics: "oh oh oh",
+			format: "plain",
+			syncType: "plain",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		expect(insertCall!.sql).toContain("language_detection_attempted_at")
+		expect(insertCall!.params).toContain(null)
+	})
+})

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -10,6 +10,7 @@ import {
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
+import { detectLanguage } from "@/utils/detect-language"
 import { extractPlainText } from "@/utils/extract-text"
 import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
@@ -140,6 +141,22 @@ export async function submitLyrics(
 ): Promise<{ id: number; created: boolean }> {
 	const compressedLyrics = await compress(submission.lyrics)
 	const plainText = extractPlainText(submission.lyrics, submission.format)
+	const detected = detectLanguage(submission.lyrics, submission.format, plainText)
+	const submitted = submission.language?.trim() || null
+	let finalLanguage: string | null
+	if (submitted) {
+		finalLanguage = submitted
+		if (detected && detected !== submitted) {
+			log.warn("language mismatch", {
+				videoId: submission.videoId,
+				submitter_id: submitterId,
+				submitted,
+				detected,
+			})
+		}
+	} else {
+		finalLanguage = detected
+	}
 	const songNorm = normalizeSong(submission.song)
 	const artistNorm = normalizeArtist(submission.artist)
 	const albumNorm = submission.album ? normalize(submission.album) : null
@@ -168,8 +185,8 @@ export async function submitLyrics(
 			video_id, song, artist, album, isrc,
 			duration, song_norm, artist_norm, album_norm,
 			lyrics, format, language, sync_type, submitter_id,
-			lyrics_text_search
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?))
+			lyrics_text_search, language_detection_attempted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?), NOW())
 		RETURNING id
 		`
 	)
@@ -185,7 +202,7 @@ export async function submitLyrics(
 			albumNorm,
 			compressedLyrics,
 			submission.format,
-			submission.language || null,
+			finalLanguage,
 			submission.syncType,
 			submitterId,
 			plainText

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { closePool } from "@/infra/database"
 import { createEnv } from "@/infra/env"
 import { Logger, flushLogs } from "@/infra/logger"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
+import { backfillLanguage } from "@/jobs/backfill-language"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
 import { backfillTextSearch } from "@/jobs/backfill-text-search"
 import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
@@ -228,6 +229,12 @@ backfillFormatDetection(env)
 		if (changed > 0) log.info("format backfill complete", { scanned, changed })
 	})
 	.catch((err) => log.error("format backfill failed", { error: (err as Error).message }))
+
+backfillLanguage(env)
+	.then(({ scanned, updated }) => {
+		if (updated > 0) log.info("language backfill complete", { scanned, updated })
+	})
+	.catch((err) => log.error("language backfill failed", { error: (err as Error).message }))
 
 cleanupFulfilledRequests(env)
 	.then(({ deleted }) => {

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -89,11 +89,7 @@ const ENGLISH_LYRICS_SAMPLE = [
 
 describe("backfillLanguage", () => {
 	it("selects only rows where language and language_detection_attempted_at are NULL and the row is not deleted", async () => {
-		const db = makeMockDB([
-			[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
-			null,
-			[],
-		])
+		const db = makeMockDB([[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
@@ -105,11 +101,7 @@ describe("backfillLanguage", () => {
 	})
 
 	it("stamps language and language_detection_attempted_at on successful detection", async () => {
-		const db = makeMockDB([
-			[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
-			null,
-			[],
-		])
+		const db = makeMockDB([[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
@@ -150,5 +142,33 @@ describe("backfillLanguage", () => {
 
 		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
 		expect(updateCall!.params).toContain("en")
+	})
+
+	it("continues processing and stamps attempted_at when a row throws on decompress", async () => {
+		const valid = await compress(ENGLISH_LYRICS_SAMPLE)
+		const corruptedButLooksCompressed = "H4sIAAAAAA_NOTVALIDBASE64DATA"
+		const db = makeMockDB([
+			[
+				{ id: 100, lyrics: corruptedButLooksCompressed, format: "plain" },
+				{ id: 101, lyrics: valid, format: "plain" },
+			],
+			null,
+			null,
+			[],
+		])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updates = db.calls.filter((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updates.length).toBeGreaterThanOrEqual(2)
+
+		const errStamp = updates.find((c) => c.params.includes(100))
+		expect(errStamp).toBeDefined()
+		expect(errStamp!.sql).toContain("language_detection_attempted_at = NOW()")
+
+		const successUpdate = updates.find((c) => c.params.includes(101))
+		expect(successUpdate).toBeDefined()
+		expect(successUpdate!.params).toContain("en")
 	})
 })

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -1,0 +1,154 @@
+import type { Env } from "@/types"
+import { compress } from "@/utils/compression"
+import { describe, expect, it } from "vitest"
+import { backfillLanguage } from "./backfill-language"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(scripted: Array<unknown[] | unknown>) {
+	const calls: DBCall[] = []
+	const queue = [...scripted]
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							const next = queue.shift()
+							return (next as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							const next = queue.shift()
+							return { results: (next as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+	}
+	return db
+}
+
+function makeMockCache(initial: Record<string, string> = {}) {
+	const store = new Map(Object.entries(initial))
+	const deleteCalls: string[] = []
+	const keysCalls: string[] = []
+	return {
+		store,
+		deleteCalls,
+		keysCalls,
+		async get(key: string) {
+			return store.get(key) ?? null
+		},
+		async put() {},
+		async delete(key: string) {
+			deleteCalls.push(key)
+			store.delete(key)
+		},
+		async keys(pattern: string) {
+			keysCalls.push(pattern)
+			const re = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`)
+			return [...store.keys()].filter((k) => re.test(k))
+		},
+		async setNX() {
+			return true
+		},
+	}
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>, cache: ReturnType<typeof makeMockCache>): Env {
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		RATE_LIMITER: {} as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+	}
+}
+
+const ENGLISH_LYRICS_SAMPLE = [
+	"In your arms I find the answer to every question",
+	"You whisper softly and the world begins to spin",
+	"Holding on tight to the moments we have together",
+	"Every heartbeat is a song that only we can hear",
+].join("\n")
+
+describe("backfillLanguage", () => {
+	it("selects only rows where language and language_detection_attempted_at are NULL and the row is not deleted", async () => {
+		const db = makeMockDB([
+			[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
+			null,
+			[],
+		])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const selectCall = db.calls.find((c) => c.sql.includes("SELECT"))
+		expect(selectCall!.sql).toContain("language IS NULL")
+		expect(selectCall!.sql).toContain("language_detection_attempted_at IS NULL")
+		expect(selectCall!.sql).toContain("deleted_at IS NULL")
+	})
+
+	it("stamps language and language_detection_attempted_at on successful detection", async () => {
+		const db = makeMockDB([
+			[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
+			null,
+			[],
+		])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updateCall!.sql).toContain("language = ")
+		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(updateCall!.params).toContain("en")
+		expect(updateCall!.params).toContain(7)
+	})
+
+	it("stamps language_detection_attempted_at even when detection returns null", async () => {
+		const db = makeMockDB([[{ id: 8, lyrics: "oh oh", format: "plain" }], null, []])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(updateCall!.params).toContain(null)
+	})
+
+	it("is a no-op (no UPDATE) when there are no candidate rows", async () => {
+		const db = makeMockDB([[]])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		expect(db.calls.some((c) => c.sql.includes("UPDATE lyrics"))).toBe(false)
+	})
+
+	it("decompresses compressed lyrics before detection", async () => {
+		const compressed = await compress(ENGLISH_LYRICS_SAMPLE)
+		const db = makeMockDB([[{ id: 9, lyrics: compressed, format: "plain" }], null, []])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updateCall!.params).toContain("en")
+	})
+})

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -1,0 +1,51 @@
+import { Logger } from "@/infra/logger"
+import type { Env, LyricsFormat } from "@/types"
+import { decompress, isCompressed } from "@/utils/compression"
+import { detectLanguage } from "@/utils/detect-language"
+
+const log = new Logger("backfill")
+const BATCH_SIZE = 100
+
+export async function backfillLanguage(env: Env): Promise<{ scanned: number; updated: number }> {
+	let scanned = 0
+	let updated = 0
+
+	while (true) {
+		const batch = await env.DB.prepare(
+			`SELECT id, lyrics, format FROM lyrics
+			 WHERE language IS NULL
+			   AND language_detection_attempted_at IS NULL
+			   AND deleted_at IS NULL
+			 ORDER BY id ASC
+			 LIMIT ?`,
+		)
+			.bind(BATCH_SIZE)
+			.all<{ id: number; lyrics: string; format: LyricsFormat }>()
+
+		const rows = batch.results || []
+		if (rows.length === 0) break
+
+		for (const row of rows) {
+			scanned++
+			try {
+				const content = isCompressed(row.lyrics) ? await decompress(row.lyrics) : row.lyrics
+				const detected = detectLanguage(content, row.format)
+				await env.DB.prepare(
+					`UPDATE lyrics
+					 SET language = COALESCE(?, language),
+					     language_detection_attempted_at = NOW()
+					 WHERE id = ?`,
+				)
+					.bind(detected, row.id)
+					.run()
+				if (detected) updated++
+			} catch (err) {
+				log.warn("failed to backfill row", { id: row.id, error: (err as Error).message })
+			}
+		}
+
+		log.info("language backfill batch complete", { batch: rows.length, scanned, updated })
+	}
+
+	return { scanned, updated }
+}

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -17,7 +17,7 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 			   AND language_detection_attempted_at IS NULL
 			   AND deleted_at IS NULL
 			 ORDER BY id ASC
-			 LIMIT ?`,
+			 LIMIT ?`
 		)
 			.bind(BATCH_SIZE)
 			.all<{ id: number; lyrics: string; format: LyricsFormat }>()
@@ -34,13 +34,25 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 					`UPDATE lyrics
 					 SET language = COALESCE(?, language),
 					     language_detection_attempted_at = NOW()
-					 WHERE id = ?`,
+					 WHERE id = ?`
 				)
 					.bind(detected, row.id)
 					.run()
 				if (detected) updated++
 			} catch (err) {
 				log.warn("failed to backfill row", { id: row.id, error: (err as Error).message })
+				try {
+					await env.DB.prepare(
+						"UPDATE lyrics SET language_detection_attempted_at = NOW() WHERE id = ?"
+					)
+						.bind(row.id)
+						.run()
+				} catch (stampErr) {
+					log.warn("failed to stamp attempted_at on errored row", {
+						id: row.id,
+						error: (stampErr as Error).message,
+					})
+				}
 			}
 		}
 

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { extractTtmlLang, mapTo639_1 } from "./detect-language"
+import { detectLanguage, extractTtmlLang, mapTo639_1 } from "./detect-language"
 
 describe("mapTo639_1", () => {
 	describe("happy paths", () => {
@@ -94,6 +94,105 @@ describe("extractTtmlLang", () => {
 		it("is deterministic", () => {
 			const ttml = `<tt xml:lang="ja"><body><div><p>x</p></div></body></tt>`
 			expect(extractTtmlLang(ttml)).toBe(extractTtmlLang(ttml))
+		})
+	})
+})
+
+const ENGLISH_LYRICS = [
+	"In your arms I find the answer to every question",
+	"You whisper softly and the world begins to spin",
+	"Holding on tight to the moments we have together",
+	"Every heartbeat is a song that only we can hear",
+].join("\n")
+
+const JAPANESE_LYRICS = [
+	"あなたの腕の中で答えを見つけた",
+	"小さな声で囁いて世界が回り始める",
+	"二人の時間をしっかり抱きしめて",
+	"鼓動の音は二人だけの歌になる",
+].join("\n")
+
+const KOREAN_LYRICS = [
+	"네 품 안에서 모든 답을 찾았어",
+	"부드러운 속삭임에 세상이 돌기 시작해",
+	"우리가 함께한 순간들을 꼭 붙잡고",
+	"심장 소리는 우리만의 노래가 되어",
+].join("\n")
+
+const ENGLISH_TTML_WITH_LANG = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en"><body><div><p>${ENGLISH_LYRICS}</p></div></body></tt>`
+
+const ENGLISH_TTML_NO_LANG = `<tt xmlns="http://www.w3.org/ns/ttml"><body><div>${ENGLISH_LYRICS
+	.split("\n")
+	.map((line) => `<p>${line}</p>`)
+	.join("")}</div></body></tt>`
+
+const ENGLISH_LRC = ENGLISH_LYRICS
+	.split("\n")
+	.map((line, i) => `[00:${String(i * 5).padStart(2, "0")}.00]${line}`)
+	.join("\n")
+
+describe("detectLanguage", () => {
+	describe("happy paths", () => {
+		it("returns en from TTML xml:lang metadata", () => {
+			expect(detectLanguage(ENGLISH_TTML_WITH_LANG, "ttml")).toBe("en")
+		})
+
+		it("falls through to detection when TTML root has no xml:lang", () => {
+			expect(detectLanguage(ENGLISH_TTML_NO_LANG, "ttml")).toBe("en")
+		})
+
+		it("detects Japanese plain lyrics", () => {
+			expect(detectLanguage(JAPANESE_LYRICS, "plain")).toBe("ja")
+		})
+
+		it("detects Korean plain lyrics", () => {
+			expect(detectLanguage(KOREAN_LYRICS, "plain")).toBe("ko")
+		})
+
+		it("strips LRC timestamps before detection", () => {
+			expect(detectLanguage(ENGLISH_LRC, "lrc")).toBe("en")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns null for empty input", () => {
+			expect(detectLanguage("", "plain")).toBeNull()
+		})
+
+		it("returns null for input shorter than the minimum length", () => {
+			expect(detectLanguage("oh oh la", "plain")).toBeNull()
+		})
+
+		it("returns null for repetitive non-linguistic input", () => {
+			expect(detectLanguage("ooooohhhhhhh ahhhhhhhh ooooohhhhhhh", "plain")).toBeNull()
+		})
+
+		it("ignores TTML xml:lang and falls through when it is empty", () => {
+			const ttml = `<tt xml:lang=""><body><div><p>${ENGLISH_LYRICS}</p></div></body></tt>`
+			expect(detectLanguage(ttml, "ttml")).toBe("en")
+		})
+
+		it("accepts a precomputed plainText argument and uses it directly", () => {
+			expect(detectLanguage("ignored", "plain", JAPANESE_LYRICS)).toBe("ja")
+		})
+	})
+
+	describe("invariants", () => {
+		it("is deterministic", () => {
+			expect(detectLanguage(JAPANESE_LYRICS, "plain")).toBe(
+				detectLanguage(JAPANESE_LYRICS, "plain"),
+			)
+		})
+
+		it("never returns an uppercase code", () => {
+			const result = detectLanguage(ENGLISH_LYRICS, "plain")
+			expect(result).toBe(result?.toLowerCase())
+		})
+	})
+
+	describe("regressions", () => {
+		it("returns en for representative English lyrics (row 818 motivation)", () => {
+			expect(detectLanguage(ENGLISH_LYRICS, "plain")).toBe("en")
 		})
 	})
 })

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { mapTo639_1 } from "./detect-language"
+import { extractTtmlLang, mapTo639_1 } from "./detect-language"
 
 describe("mapTo639_1", () => {
 	describe("happy paths", () => {
@@ -42,6 +42,58 @@ describe("mapTo639_1", () => {
 	describe("invariants", () => {
 		it("is deterministic", () => {
 			expect(mapTo639_1("eng")).toBe(mapTo639_1("eng"))
+		})
+	})
+})
+
+describe("extractTtmlLang", () => {
+	describe("happy paths", () => {
+		it("returns the base language tag from xml:lang on the root tt", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en"><body><div><p>hello</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("en")
+		})
+
+		it("lowercases the language tag", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="EN"><body><div><p>hello</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("en")
+		})
+
+		it("strips a script subtag and returns only the base language", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="zh-Hant"><body><div><p>你好</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("zh")
+		})
+
+		it("strips a region subtag and returns only the base language", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="pt-BR"><body><div><p>olá</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("pt")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns null when root tt has no xml:lang", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml"><body><div><p>hello</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBeNull()
+		})
+
+		it("returns null when xml:lang is empty", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang=""><body><div><p>hi</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBeNull()
+		})
+
+		it("returns null when the input is not valid XML", () => {
+			expect(extractTtmlLang("not xml at all")).toBeNull()
+		})
+
+		it("returns null when the root is not tt", () => {
+			const xml = `<root xml:lang="en"><body/></root>`
+			expect(extractTtmlLang(xml)).toBeNull()
+		})
+	})
+
+	describe("invariants", () => {
+		it("is deterministic", () => {
+			const ttml = `<tt xml:lang="ja"><body><div><p>x</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe(extractTtmlLang(ttml))
 		})
 	})
 })

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { mapTo639_1 } from "./detect-language"
+
+describe("mapTo639_1", () => {
+	describe("happy paths", () => {
+		it("maps eng to en", () => {
+			expect(mapTo639_1("eng")).toBe("en")
+		})
+
+		it("maps jpn to ja", () => {
+			expect(mapTo639_1("jpn")).toBe("ja")
+		})
+
+		it("maps cmn (Mandarin) to zh", () => {
+			expect(mapTo639_1("cmn")).toBe("zh")
+		})
+
+		it("maps kor to ko", () => {
+			expect(mapTo639_1("kor")).toBe("ko")
+		})
+
+		it("maps spa to es", () => {
+			expect(mapTo639_1("spa")).toBe("es")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns null for the franc 'und' marker", () => {
+			expect(mapTo639_1("und")).toBeNull()
+		})
+
+		it("returns null for empty string", () => {
+			expect(mapTo639_1("")).toBeNull()
+		})
+
+		it("returns the 639-3 code as-is when no 639-1 mapping exists", () => {
+			// xxx is a private-use code with no ISO 639-1 form.
+			expect(mapTo639_1("xxx")).toBe("xxx")
+		})
+	})
+
+	describe("invariants", () => {
+		it("is deterministic", () => {
+			expect(mapTo639_1("eng")).toBe(mapTo639_1("eng"))
+		})
+	})
+})

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -33,7 +33,7 @@ export function extractTtmlLang(ttml: string): string | null {
 		if (!("tt" in rootEl)) continue
 
 		const attrs = rootEl[":@"]
-		const raw = attrs?.["@_lang"] ?? attrs?.["@_xml:lang"]
+		const raw = attrs?.["@_lang"]
 		if (typeof raw !== "string") return null
 
 		const trimmed = raw.trim().toLowerCase()

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,0 +1,15 @@
+import { iso6393To1 } from "iso-639-3"
+
+const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
+	cmn: "zh",
+	arb: "ar",
+	pes: "fa",
+}
+
+export function mapTo639_1(code639_3: string): string | null {
+	if (!code639_3 || code639_3 === "und") return null
+	const override = FRANC_INDIVIDUAL_TO_639_1[code639_3]
+	if (override) return override
+	const mapped = iso6393To1[code639_3]
+	return mapped ?? code639_3
+}

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,4 +1,5 @@
 import { iso6393To1 } from "iso-639-3"
+import { ttmlParser } from "@/utils/extract-text"
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -12,4 +13,33 @@ export function mapTo639_1(code639_3: string): string | null {
 	if (override) return override
 	const mapped = iso6393To1[code639_3]
 	return mapped ?? code639_3
+}
+
+export function extractTtmlLang(ttml: string): string | null {
+	let parsed: unknown
+	try {
+		parsed = ttmlParser.parse(ttml)
+	} catch {
+		return null
+	}
+
+	if (!Array.isArray(parsed)) return null
+
+	for (const root of parsed) {
+		if (typeof root !== "object" || root === null) continue
+		const rootEl = root as Record<string, unknown> & { ":@"?: Record<string, string> }
+		if (!("tt" in rootEl)) continue
+
+		const attrs = rootEl[":@"]
+		const raw = attrs?.["@_lang"] ?? attrs?.["@_xml:lang"]
+		if (typeof raw !== "string") return null
+
+		const trimmed = raw.trim().toLowerCase()
+		if (!trimmed) return null
+
+		const base = trimmed.split("-")[0]
+		return base || null
+	}
+
+	return null
 }

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,7 +1,7 @@
-import { francAll } from "franc"
-import { iso6393To1 } from "iso-639-3"
 import type { LyricsFormat } from "@/types"
 import { extractPlainText, ttmlParser } from "@/utils/extract-text"
+import { francAll } from "franc"
+import { iso6393To1 } from "iso-639-3"
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -52,7 +52,7 @@ const MIN_CONFIDENCE = 0.5
 export function detectLanguage(
 	lyrics: string,
 	format: LyricsFormat,
-	plainText?: string,
+	plainText?: string
 ): string | null {
 	if (format === "ttml") {
 		const meta = extractTtmlLang(lyrics)

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,5 +1,7 @@
+import { francAll } from "franc"
 import { iso6393To1 } from "iso-639-3"
-import { ttmlParser } from "@/utils/extract-text"
+import type { LyricsFormat } from "@/types"
+import { extractPlainText, ttmlParser } from "@/utils/extract-text"
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -42,4 +44,30 @@ export function extractTtmlLang(ttml: string): string | null {
 	}
 
 	return null
+}
+
+const MIN_LENGTH = 30
+const MIN_CONFIDENCE = 0.5
+
+export function detectLanguage(
+	lyrics: string,
+	format: LyricsFormat,
+	plainText?: string,
+): string | null {
+	if (format === "ttml") {
+		const meta = extractTtmlLang(lyrics)
+		if (meta) return meta
+	}
+
+	const text = plainText ?? extractPlainText(lyrics, format)
+	if (text.length < MIN_LENGTH) return null
+
+	const distinctChars = new Set(text.replace(/\s+/g, "")).size
+	if (distinctChars < 8) return null
+
+	const ranked = francAll(text, { minLength: MIN_LENGTH })
+	const [topCode, topScore] = ranked[0] ?? ["und", 0]
+	if (topCode === "und" || topScore < MIN_CONFIDENCE) return null
+
+	return mapTo639_1(topCode)
 }

--- a/src/utils/extract-text.ts
+++ b/src/utils/extract-text.ts
@@ -2,7 +2,7 @@ import { XMLParser } from "fast-xml-parser"
 import type { LyricsFormat } from "@/types"
 import { parseLrc } from "@/utils/lrc"
 
-const parser = new XMLParser({
+export const ttmlParser = new XMLParser({
 	ignoreAttributes: false,
 	attributeNamePrefix: "@_",
 	textNodeName: "#text",
@@ -17,7 +17,7 @@ const parser = new XMLParser({
 type ParsedNode = Record<string, unknown>
 
 function extractTtmlText(ttml: string): string {
-	const parsed = parser.parse(ttml) as unknown[]
+	const parsed = ttmlParser.parse(ttml) as unknown[]
 	const lines: string[] = []
 
 	// Concatenate all text within a node tree, preserving whitespace between spans


### PR DESCRIPTION
## Summary
- `lyrics.language` was only populated when the submitter sent it. Most rows are null, so the language filter on `/feed` and the profile route is mostly empty (row 818 is English but returns null).
- On submit: try `xml:lang` from the TTML root first, then `franc` on extracted plain text. Submitter value wins on mismatch; the disagreement is logged as a warn.
- Backfill job runs once at startup, walks rows where both `language` and the new `language_detection_attempted_at` column are null, stamps the timestamp on both success and null detection so the predicate empties out and stays empty.

## Test plan
- [ ] Submit English lyrics with no `language`; row stores `en`
- [ ] Submit `language=es` on English lyrics; row keeps `es`, warn fires
- [ ] Watch startup logs for the `language backfill batch complete` lines until they stop firing