### PR TITLE
fix: load eld via static entry to avoid silent backfill hang

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ backfillFormatDetection(env)
 loadEld()
 	.then(() => backfillLanguage(env))
 	.then(({ scanned, updated }) => {
-		if (updated > 0) log.info("language backfill complete", { scanned, updated })
+		log.info("language backfill complete", { scanned, updated })
 	})
 	.catch((err) => log.error("language backfill failed", { error: (err as Error).message }))
 

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,33 +1,42 @@
+import { Logger } from "@/infra/logger"
 import type { LyricsFormat } from "@/types"
 import { extractDetectionText, ttmlParser } from "@/utils/extract-text"
 import { francAll } from "franc"
 import { iso6393To1 } from "iso-639-3"
+
+const log = new Logger("detect-language")
 
 export const DETECTOR_VERSION = 3
 
 type EldDetector = {
 	detect(text: string): { language: string; isReliable(): boolean }
 	enableTextCleanup(enabled: boolean): void
-	load(name: string): Promise<boolean>
 }
 let eldInstance: EldDetector | null = null
 let eldLoadPromise: Promise<EldDetector> | null = null
 
-// Indirect to keep the import path opaque to Vite's static analysis. eld ships
-// a 4.4 MB ngrams file that breaks the test runner's dependency optimizer when
-// referenced directly.
-const ELD_MODULE = "eld"
+// Indirect path defeats Vite's static-analysis pre-bundler in the test runner.
+// "eld/large" is the static entry: all ngrams are imported at module-load time
+// so there is no runtime `import('../ngrams/...')` inside eld.load() that
+// could hang under tsx + Node ESM resolution on a Railway container.
+const ELD_MODULE = "eld/large"
 
 export function loadEld(): Promise<EldDetector> {
 	if (eldInstance) return Promise.resolve(eldInstance)
 	if (!eldLoadPromise) {
 		eldLoadPromise = (async () => {
+			const t0 = Date.now()
+			log.info("eld loading")
 			const mod = (await import(ELD_MODULE)) as { eld: EldDetector }
-			await mod.eld.load("large")
 			mod.eld.enableTextCleanup(true)
 			eldInstance = mod.eld
+			log.info("eld loaded", { ms: Date.now() - t0 })
 			return eldInstance
 		})()
+		eldLoadPromise.catch((err) => {
+			log.error("eld load failed", { error: (err as Error).message })
+			eldLoadPromise = null
+		})
 	}
 	return eldLoadPromise
 }


### PR DESCRIPTION
## Summary

Prod audit after PR #34 deployed showed the language backfill never ran — all the original misclassifications (Korean tagged en, Hebrew tagged en, `sco` codes, etc.) were still in the DB. Railway logs showed `listening on port 8080` but no `language backfill complete` line and no error log either: the chain was hanging silently.

Root cause: `loadEld()` used the dynamic entry `import("eld")` followed by `await eld.load("large")`. eld's `load()` function internally runs a runtime `import('../ngrams/' + filename + '.js')` against a relative path resolved from the package's module URL. Under tsx + Node ESM on the Railway container, this runtime relative import was hanging without resolving or rejecting, so `loadEld()` never settled and `.then(backfillLanguage)` never fired.

This PR:

- Switches to the static entry `import("eld/large")`. All ngrams are statically imported at module load time, so there is no runtime relative import inside eld at all.
- Always logs `language backfill complete` regardless of how many rows changed — the previous `if (updated > 0)` swallowed the no-op case.
- Logs eld load start, success (with elapsed ms), and failure, so future regressions surface in the deploy log instead of vanishing.
- Adds a `.catch` on the load promise that clears `eldLoadPromise` on failure, so a subsequent retry can re-attempt rather than hand back the rejected promise forever.

## Test plan

- [x] 767 vitest tests pass, tsc clean, biome clean on touched files
- [x] Local smoke (`pnpm tsx`) confirms `loadEld()` resolves in ~600ms and correctly detects ko / vi / es / he on the audit's failure cases
- [ ] After merge: verify Railway deploy log shows `eld loaded ms=...` followed by `language backfill complete scanned=... updated=...`
- [ ] Re-run the audit script and confirm Korean/Hebrew/Vietnamese/Indonesian rows are no longer tagged en, no `sco` codes remain