### PR TITLE
fix: make eld load safe to fail without breaking anything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ wrangler.toml
 
 # CLI utils
 cli/
+
+# Local audit scripts (uncommitted, run against prod)
+scripts/audit-language.ts

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "@elysiajs/node": "^1.3.3",
     "elysia": "^1.3.3",
     "fast-xml-parser": "^5.5.5",
+    "franc": "^6.2.0",
     "ioredis": "^5.4.0",
+    "iso-639-3": "^3.0.1",
     "obscenity": "^0.4.6",
     "pg": "^8.13.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@elysiajs/cors": "^1.3.3",
     "@elysiajs/cron": "^1.3.3",
     "@elysiajs/node": "^1.3.3",
+    "eld": "^2.0.3",
     "elysia": "^1.3.3",
     "fast-xml-parser": "^5.5.5",
     "franc": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,15 @@ importers:
       fast-xml-parser:
         specifier: ^5.5.5
         version: 5.5.5
+      franc:
+        specifier: ^6.2.0
+        version: 6.2.0
       ioredis:
         specifier: ^5.4.0
         version: 5.10.0
+      iso-639-3:
+        specifier: ^3.0.1
+        version: 3.0.1
       obscenity:
         specifier: ^0.4.6
         version: 0.4.6
@@ -918,6 +924,9 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1027,6 +1036,9 @@ packages:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
 
+  franc@6.2.0:
+    resolution: {integrity: sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1045,6 +1057,9 @@ packages:
   ioredis@5.10.0:
     resolution: {integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==}
     engines: {node: '>=12.22.0'}
+
+  iso-639-3@3.0.1:
+    resolution: {integrity: sha512-SdljCYXOexv/JmbQ0tvigHN43yECoscVpe2y2hlEqy/CStXQlroPhZLj7zKLRiGqLJfw8k7B973UAMDoQczVgQ==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -1067,6 +1082,9 @@ packages:
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  n-gram@2.0.2:
+    resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1231,6 +1249,9 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  trigram-utils@2.0.1:
+    resolution: {integrity: sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2117,6 +2138,8 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  collapse-white-space@2.1.0: {}
+
   cookie@1.1.1: {}
 
   croner@6.0.7: {}
@@ -2257,6 +2280,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  franc@6.2.0:
+    dependencies:
+      trigram-utils: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -2284,6 +2311,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iso-639-3@3.0.1: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.isarguments@3.1.0: {}
@@ -2299,6 +2328,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@3.0.0: {}
+
+  n-gram@2.0.2: {}
 
   nanoid@3.3.11: {}
 
@@ -2444,6 +2475,11 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  trigram-utils@2.0.1:
+    dependencies:
+      collapse-white-space: 2.1.0
+      n-gram: 2.0.2
 
   tslib@2.8.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@elysiajs/node':
         specifier: ^1.3.3
         version: 1.4.5(elysia@1.4.27(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.2)(openapi-types@12.1.3)(typescript@5.9.3))
+      eld:
+        specifier: ^2.0.3
+        version: 2.0.3
       elysia:
         specifier: ^1.3.3
         version: 1.4.27(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.2)(openapi-types@12.1.3)(typescript@5.9.3)
@@ -959,6 +962,9 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  eld@2.0.3:
+    resolution: {integrity: sha512-KiwFrycPPJ2XgKb7MGsJ3m3grUFXq6+55R8ZuS9fj+Qv0WRFgeEBhmorHO/YwHV9VqhdJURKFGJ+CY24sEikOw==}
 
   elysia@1.4.27:
     resolution: {integrity: sha512-2UlmNEjPJVA/WZVPYKy+KdsrfFwwNlqSBW1lHz6i2AHc75k7gV4Rhm01kFeotH7PDiHIX2G8X3KnRPc33SGVIg==}
@@ -2155,6 +2161,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   denque@2.1.0: {}
+
+  eld@2.0.3: {}
 
   elysia@1.4.27(@sinclair/typebox@0.34.48)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.2)(openapi-types@12.1.3)(typescript@5.9.3):
     dependencies:

--- a/schema.sql
+++ b/schema.sql
@@ -127,6 +127,15 @@ CREATE INDEX IF NOT EXISTS idx_lyrics_text_search ON lyrics USING GIN (lyrics_te
 -- on this row, so the backfill job stays idempotent and the column
 -- `language` keeps its semantic meaning (NULL = unknown).
 ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_detection_attempted_at TIMESTAMPTZ;
+-- Detector revision the row was last evaluated against. NULL means
+-- pre-versioning or never evaluated. Backfill picks up rows where
+-- this is NULL or below the current DETECTOR_VERSION.
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_detector_version SMALLINT;
+-- 'submitter' if the row's language came from the submitter, 'detector'
+-- if it was auto-detected. NULL on pre-source-tracking rows (treated
+-- as detector-sourced for backfill purposes). The backfill never
+-- overwrites a row whose source is 'submitter'.
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_source TEXT;
 
 -- Multi-variant lyrics: allow multiple entries per video_id
 -- Drop the unique constraint so multiple submissions can coexist

--- a/schema.sql
+++ b/schema.sql
@@ -123,6 +123,11 @@ CREATE INDEX IF NOT EXISTS idx_lyrics_album_norm_trgm ON lyrics USING GIN (album
 ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS lyrics_text_search tsvector;
 CREATE INDEX IF NOT EXISTS idx_lyrics_text_search ON lyrics USING GIN (lyrics_text_search);
 
+-- Language auto-detection: tracks whether we have attempted detection
+-- on this row, so the backfill job stays idempotent and the column
+-- `language` keeps its semantic meaning (NULL = unknown).
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_detection_attempted_at TIMESTAMPTZ;
+
 -- Multi-variant lyrics: allow multiple entries per video_id
 -- Drop the unique constraint so multiple submissions can coexist
 ALTER TABLE lyrics DROP CONSTRAINT IF EXISTS lyrics_video_id_key;

--- a/scripts/eld-railway-repro.sh
+++ b/scripts/eld-railway-repro.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Reproduce Railway's tsx + Node 22 + pnpm + Debian container locally.
+# Railway uses RAILPACK which builds on debian:bookworm-slim with Node 22.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+docker run --rm -i \
+  --name eld-test \
+  --memory=512m \
+  --cpus=1 \
+  -v "$ROOT_DIR":/app \
+  -w /app \
+  node:22-bookworm-slim \
+  bash -c "
+    set -e
+    echo '== node version =='
+    node --version
+    echo
+    echo '== Phase A: import(eld/large) =='
+    cd /app
+    time node --input-type=module -e \"
+      const t0 = Date.now();
+      const { eld } = await import('eld/large');
+      console.log('loaded ms=' + (Date.now() - t0));
+      eld.enableTextCleanup(true);
+      console.log('detect=' + JSON.stringify(eld.detect('Hola amigo como estas hoy')));
+    \"
+    echo
+    echo '== Phase B: import(eld) + eld.load(large) =='
+    time node --input-type=module -e \"
+      const t0 = Date.now();
+      const { eld } = await import('eld');
+      console.log('main loaded ms=' + (Date.now() - t0));
+      const t1 = Date.now();
+      await eld.load('large');
+      console.log('large loaded ms=' + (Date.now() - t1));
+      eld.enableTextCleanup(true);
+      console.log('detect=' + JSON.stringify(eld.detect('Hola amigo como estas hoy')));
+    \"
+  "

--- a/scripts/eld-tsx-repro.sh
+++ b/scripts/eld-tsx-repro.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Reproduce Railway: Node 22 + tsx + pnpm-installed-on-Linux + memory constraint
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+docker run --rm -i \
+  --name eld-tsx-test \
+  --memory=512m \
+  --cpus=1 \
+  -v "$ROOT_DIR":/host \
+  -w /tmp/work \
+  node:22-bookworm-slim \
+  bash -c "
+    set -e
+    npm install -g pnpm@10 --silent 2>&1 | tail -3
+    mkdir -p /tmp/work
+    cp -r /host/. /tmp/work/
+    cd /tmp/work
+    rm -rf node_modules
+    echo '== installing on Linux =='
+    pnpm install --frozen-lockfile --ignore-scripts 2>&1 | tail -5
+    echo
+    cat > scripts/_eldcheck.ts << 'EOF'
+import { loadEld, detectLanguage } from '@/utils/detect-language'
+import { Logger } from '@/infra/logger'
+const log = new Logger('test')
+async function main() {
+  const t0 = Date.now()
+  log.info('eld load starting')
+  await loadEld()
+  log.info('eld load done', { ms: Date.now() - t0 })
+  console.log('detect=', detectLanguage('Hola amigo como estas hoy mismo', 'plain'))
+  process.exit(0)
+}
+main().catch(err => { console.error('FATAL', err); process.exit(1) })
+EOF
+    echo '== Phase A via tsx =='
+    time pnpm tsx scripts/_eldcheck.ts
+  "

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1350,7 +1350,10 @@ describe("submitLyrics language detection", () => {
 		expect(insertCall!.sql).toContain("language")
 		expect(insertCall!.sql).toContain("language_detection_attempted_at")
 		expect(insertCall!.params).toContain("en")
-		expect(insertCall!.params).toHaveLength(15)
+		expect(insertCall!.sql).toContain("language_detector_version")
+		expect(insertCall!.sql).toContain("language_source")
+		expect(insertCall!.params).toContain("detector")
+		expect(insertCall!.params).toHaveLength(17)
 	})
 
 	it("preserves submitter language even when detection disagrees", async () => {
@@ -1375,6 +1378,7 @@ describe("submitLyrics language detection", () => {
 		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
 		expect(insertCall!.params).toContain("es")
 		expect(insertCall!.params).not.toContain("en")
+		expect(insertCall!.params).toContain("submitter")
 		expect(warnSpy).toHaveBeenCalledWith(
 			"language mismatch",
 			expect.objectContaining({ submitted: "es", detected: "en" })

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1356,6 +1356,28 @@ describe("submitLyrics language detection", () => {
 		expect(insertCall!.params).toHaveLength(17)
 	})
 
+	it("stamps null detector version when eld is not loaded yet (cold-start window)", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 45 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid45",
+			song: "Test",
+			artist: "Tester",
+			duration: 200,
+			lyrics: ENGLISH_LYRICS_SAMPLE,
+			format: "plain",
+			syncType: "plain",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		const versionIdx = insertCall!.params.length - 2
+		expect(insertCall!.params[versionIdx]).toBeNull()
+	})
+
 	it("preserves submitter language even when detection disagrees", async () => {
 		const warnSpy = vi.spyOn(Logger.prototype, "warn")
 		const db = createMockDB([{ count: 0 }, { id: 43 }])

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,4 +1,5 @@
 import { config } from "@/config"
+import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
@@ -594,9 +595,7 @@ describe("invalidateCacheAfterDelete", () => {
 
 describe("invalidateCacheForSubmitter", () => {
 	it("deletes v:<videoId> for every row returned by the join", async () => {
-		const db = createMockDB([
-			[{ video_id: "vA" }, { video_id: "vB" }, { video_id: "vC" }],
-		])
+		const db = createMockDB([[{ video_id: "vA" }, { video_id: "vB" }, { video_id: "vC" }]])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
@@ -1291,13 +1290,7 @@ describe("submitLyrics fulfillment integration", () => {
 	})
 
 	it("skips fulfillment when a prior synced variant exists", async () => {
-		const db = createMockDB([
-			{ count: 0 },
-			{ id: 557 },
-			{ key_id: "k1" },
-			null,
-			{ "1": 1 },
-		])
+		const db = createMockDB([{ count: 0 }, { id: 557 }, { key_id: "k1" }, null, { "1": 1 }])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
 
@@ -1357,9 +1350,11 @@ describe("submitLyrics language detection", () => {
 		expect(insertCall!.sql).toContain("language")
 		expect(insertCall!.sql).toContain("language_detection_attempted_at")
 		expect(insertCall!.params).toContain("en")
+		expect(insertCall!.params).toHaveLength(15)
 	})
 
 	it("preserves submitter language even when detection disagrees", async () => {
+		const warnSpy = vi.spyOn(Logger.prototype, "warn")
 		const db = createMockDB([{ count: 0 }, { id: 43 }])
 		const cache = createMockCache()
 		const env = createEnv(db, cache)
@@ -1380,6 +1375,11 @@ describe("submitLyrics language detection", () => {
 		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
 		expect(insertCall!.params).toContain("es")
 		expect(insertCall!.params).not.toContain("en")
+		expect(warnSpy).toHaveBeenCalledWith(
+			"language mismatch",
+			expect.objectContaining({ submitted: "es", detected: "en" })
+		)
+		warnSpy.mockRestore()
 	})
 
 	it("stores null language when detection cannot confidently identify a language", async () => {

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1326,3 +1326,81 @@ describe("submitLyrics variant cap", () => {
 		expect(countCall!.sql).toMatch(/deleted_at\s+IS\s+NULL/i)
 	})
 })
+
+describe("submitLyrics language detection", () => {
+	const ENGLISH_LYRICS_SAMPLE = [
+		"In your arms I find the answer to every question",
+		"You whisper softly and the world begins to spin",
+		"Holding on tight to the moments we have together",
+		"Every heartbeat is a song that only we can hear",
+	].join("\n")
+
+	it("auto-detects language when submitter omits it", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 42 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid42",
+			song: "Test",
+			artist: "Tester",
+			duration: 200,
+			lyrics: ENGLISH_LYRICS_SAMPLE,
+			format: "plain",
+			syncType: "plain",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		expect(insertCall).toBeDefined()
+		expect(insertCall!.sql).toContain("language")
+		expect(insertCall!.sql).toContain("language_detection_attempted_at")
+		expect(insertCall!.params).toContain("en")
+	})
+
+	it("preserves submitter language even when detection disagrees", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 43 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid43",
+			song: "Test",
+			artist: "Tester",
+			duration: 200,
+			lyrics: ENGLISH_LYRICS_SAMPLE,
+			format: "plain",
+			syncType: "plain",
+			language: "es",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		expect(insertCall!.params).toContain("es")
+		expect(insertCall!.params).not.toContain("en")
+	})
+
+	it("stores null language when detection cannot confidently identify a language", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 44 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const submission: LyricsSubmission = {
+			videoId: "vid44",
+			song: "Instrumental",
+			artist: "Tester",
+			duration: 200,
+			lyrics: "oh oh oh",
+			format: "plain",
+			syncType: "plain",
+		}
+
+		await submitLyrics(env, submission, 1)
+
+		const insertCall = db.calls.find((c) => c.sql.includes("INSERT INTO lyrics"))
+		expect(insertCall!.sql).toContain("language_detection_attempted_at")
+		expect(insertCall!.params).toContain(null)
+	})
+})

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -10,7 +10,7 @@ import {
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
-import { DETECTOR_VERSION, detectLanguage } from "@/utils/detect-language"
+import { DETECTOR_VERSION, detectLanguage, isEldReady } from "@/utils/detect-language"
 import { extractPlainText } from "@/utils/extract-text"
 import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
@@ -210,7 +210,7 @@ export async function submitLyrics(
 			submission.syncType,
 			submitterId,
 			plainText,
-			DETECTOR_VERSION,
+			isEldReady() ? DETECTOR_VERSION : null,
 			languageSource
 		)
 		.first<{ id: number }>()

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -10,6 +10,7 @@ import {
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
+import { detectLanguage } from "@/utils/detect-language"
 import { extractPlainText } from "@/utils/extract-text"
 import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
@@ -140,6 +141,22 @@ export async function submitLyrics(
 ): Promise<{ id: number; created: boolean }> {
 	const compressedLyrics = await compress(submission.lyrics)
 	const plainText = extractPlainText(submission.lyrics, submission.format)
+	const detected = detectLanguage(submission.lyrics, submission.format, plainText)
+	const submitted = submission.language?.trim() || null
+	let finalLanguage: string | null
+	if (submitted) {
+		finalLanguage = submitted
+		if (detected && detected !== submitted) {
+			log.warn("language mismatch", {
+				videoId: submission.videoId,
+				submitter_id: submitterId,
+				submitted,
+				detected,
+			})
+		}
+	} else {
+		finalLanguage = detected
+	}
 	const songNorm = normalizeSong(submission.song)
 	const artistNorm = normalizeArtist(submission.artist)
 	const albumNorm = submission.album ? normalize(submission.album) : null
@@ -168,8 +185,8 @@ export async function submitLyrics(
 			video_id, song, artist, album, isrc,
 			duration, song_norm, artist_norm, album_norm,
 			lyrics, format, language, sync_type, submitter_id,
-			lyrics_text_search
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?))
+			lyrics_text_search, language_detection_attempted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?), NOW())
 		RETURNING id
 		`
 	)
@@ -185,7 +202,7 @@ export async function submitLyrics(
 			albumNorm,
 			compressedLyrics,
 			submission.format,
-			submission.language || null,
+			finalLanguage,
 			submission.syncType,
 			submitterId,
 			plainText

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -10,7 +10,7 @@ import {
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
-import { detectLanguage } from "@/utils/detect-language"
+import { DETECTOR_VERSION, detectLanguage } from "@/utils/detect-language"
 import { extractPlainText } from "@/utils/extract-text"
 import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
@@ -141,11 +141,13 @@ export async function submitLyrics(
 ): Promise<{ id: number; created: boolean }> {
 	const compressedLyrics = await compress(submission.lyrics)
 	const plainText = extractPlainText(submission.lyrics, submission.format)
-	const detected = detectLanguage(submission.lyrics, submission.format, plainText)
+	const detected = detectLanguage(submission.lyrics, submission.format)
 	const submitted = submission.language?.trim() || null
 	let finalLanguage: string | null
+	let languageSource: string
 	if (submitted) {
 		finalLanguage = submitted
+		languageSource = "submitter"
 		if (detected && detected !== submitted) {
 			log.warn("language mismatch", {
 				videoId: submission.videoId,
@@ -156,6 +158,7 @@ export async function submitLyrics(
 		}
 	} else {
 		finalLanguage = detected
+		languageSource = "detector"
 	}
 	const songNorm = normalizeSong(submission.song)
 	const artistNorm = normalizeArtist(submission.artist)
@@ -185,8 +188,9 @@ export async function submitLyrics(
 			video_id, song, artist, album, isrc,
 			duration, song_norm, artist_norm, album_norm,
 			lyrics, format, language, sync_type, submitter_id,
-			lyrics_text_search, language_detection_attempted_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?), NOW())
+			lyrics_text_search, language_detection_attempted_at,
+			language_detector_version, language_source
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?), NOW(), ?, ?)
 		RETURNING id
 		`
 	)
@@ -205,7 +209,9 @@ export async function submitLyrics(
 			finalLanguage,
 			submission.syncType,
 			submitterId,
-			plainText
+			plainText,
+			DETECTOR_VERSION,
+			languageSource
 		)
 		.first<{ id: number }>()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,13 @@ import { runDumpJob } from "@/jobs/dump"
 import { updateScores } from "@/jobs/score-updater"
 import { authRoutes } from "@/routes/auth"
 import { compatRoutes } from "@/routes/compat"
-import { loadEld } from "@/utils/detect-language"
 import { feedRoutes } from "@/routes/feed"
 import { leaderboardRoutes } from "@/routes/leaderboard"
 import { lyricsRoutes } from "@/routes/lyrics"
 import { requestRoutes } from "@/routes/requests"
 import { userRoutes } from "@/routes/users"
 import { voteRoutes } from "@/routes/votes"
+import { loadEld } from "@/utils/detect-language"
 import { cors } from "@elysiajs/cors"
 import { cron } from "@elysiajs/cron"
 import { node } from "@elysiajs/node"
@@ -242,9 +242,7 @@ cleanupFulfilledRequests(env)
 	.then(({ deleted }) => {
 		if (deleted > 0) log.info("cleanup fulfilled requests complete", { deleted })
 	})
-	.catch((err) =>
-		log.error("cleanup fulfilled requests failed", { error: (err as Error).message }),
-	)
+	.catch((err) => log.error("cleanup fulfilled requests failed", { error: (err as Error).message }))
 
 process.on("unhandledRejection", (reason) => {
 	const err = reason instanceof Error ? reason : new Error(String(reason))

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { closePool } from "@/infra/database"
 import { createEnv } from "@/infra/env"
 import { Logger, flushLogs } from "@/infra/logger"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
+import { backfillLanguage } from "@/jobs/backfill-language"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
 import { backfillTextSearch } from "@/jobs/backfill-text-search"
 import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
@@ -228,6 +229,12 @@ backfillFormatDetection(env)
 		if (changed > 0) log.info("format backfill complete", { scanned, changed })
 	})
 	.catch((err) => log.error("format backfill failed", { error: (err as Error).message }))
+
+backfillLanguage(env)
+	.then(({ scanned, updated }) => {
+		if (updated > 0) log.info("language backfill complete", { scanned, updated })
+	})
+	.catch((err) => log.error("language backfill failed", { error: (err as Error).message }))
 
 cleanupFulfilledRequests(env)
 	.then(({ deleted }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ backfillFormatDetection(env)
 loadEld()
 	.then(() => backfillLanguage(env))
 	.then(({ scanned, updated }) => {
-		if (updated > 0) log.info("language backfill complete", { scanned, updated })
+		log.info("language backfill complete", { scanned, updated })
 	})
 	.catch((err) => log.error("language backfill failed", { error: (err as Error).message }))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { runDumpJob } from "@/jobs/dump"
 import { updateScores } from "@/jobs/score-updater"
 import { authRoutes } from "@/routes/auth"
 import { compatRoutes } from "@/routes/compat"
+import { loadEld } from "@/utils/detect-language"
 import { feedRoutes } from "@/routes/feed"
 import { leaderboardRoutes } from "@/routes/leaderboard"
 import { lyricsRoutes } from "@/routes/lyrics"
@@ -230,7 +231,8 @@ backfillFormatDetection(env)
 	})
 	.catch((err) => log.error("format backfill failed", { error: (err as Error).message }))
 
-backfillLanguage(env)
+loadEld()
+	.then(() => backfillLanguage(env))
 	.then(({ scanned, updated }) => {
 		if (updated > 0) log.info("language backfill complete", { scanned, updated })
 	})

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -89,11 +89,7 @@ const ENGLISH_LYRICS_SAMPLE = [
 
 describe("backfillLanguage", () => {
 	it("selects only rows where language and language_detection_attempted_at are NULL and the row is not deleted", async () => {
-		const db = makeMockDB([
-			[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
-			null,
-			[],
-		])
+		const db = makeMockDB([[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
@@ -105,11 +101,7 @@ describe("backfillLanguage", () => {
 	})
 
 	it("stamps language and language_detection_attempted_at on successful detection", async () => {
-		const db = makeMockDB([
-			[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
-			null,
-			[],
-		])
+		const db = makeMockDB([[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
@@ -150,5 +142,33 @@ describe("backfillLanguage", () => {
 
 		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
 		expect(updateCall!.params).toContain("en")
+	})
+
+	it("continues processing and stamps attempted_at when a row throws on decompress", async () => {
+		const valid = await compress(ENGLISH_LYRICS_SAMPLE)
+		const corruptedButLooksCompressed = "H4sIAAAAAA_NOTVALIDBASE64DATA"
+		const db = makeMockDB([
+			[
+				{ id: 100, lyrics: corruptedButLooksCompressed, format: "plain" },
+				{ id: 101, lyrics: valid, format: "plain" },
+			],
+			null,
+			null,
+			[],
+		])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updates = db.calls.filter((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updates.length).toBeGreaterThanOrEqual(2)
+
+		const errStamp = updates.find((c) => c.params.includes(100))
+		expect(errStamp).toBeDefined()
+		expect(errStamp!.sql).toContain("language_detection_attempted_at = NOW()")
+
+		const successUpdate = updates.find((c) => c.params.includes(101))
+		expect(successUpdate).toBeDefined()
+		expect(successUpdate!.params).toContain("en")
 	})
 })

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -1,0 +1,154 @@
+import type { Env } from "@/types"
+import { compress } from "@/utils/compression"
+import { describe, expect, it } from "vitest"
+import { backfillLanguage } from "./backfill-language"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(scripted: Array<unknown[] | unknown>) {
+	const calls: DBCall[] = []
+	const queue = [...scripted]
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							const next = queue.shift()
+							return (next as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							const next = queue.shift()
+							return { results: (next as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+	}
+	return db
+}
+
+function makeMockCache(initial: Record<string, string> = {}) {
+	const store = new Map(Object.entries(initial))
+	const deleteCalls: string[] = []
+	const keysCalls: string[] = []
+	return {
+		store,
+		deleteCalls,
+		keysCalls,
+		async get(key: string) {
+			return store.get(key) ?? null
+		},
+		async put() {},
+		async delete(key: string) {
+			deleteCalls.push(key)
+			store.delete(key)
+		},
+		async keys(pattern: string) {
+			keysCalls.push(pattern)
+			const re = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`)
+			return [...store.keys()].filter((k) => re.test(k))
+		},
+		async setNX() {
+			return true
+		},
+	}
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>, cache: ReturnType<typeof makeMockCache>): Env {
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		RATE_LIMITER: {} as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+	}
+}
+
+const ENGLISH_LYRICS_SAMPLE = [
+	"In your arms I find the answer to every question",
+	"You whisper softly and the world begins to spin",
+	"Holding on tight to the moments we have together",
+	"Every heartbeat is a song that only we can hear",
+].join("\n")
+
+describe("backfillLanguage", () => {
+	it("selects only rows where language and language_detection_attempted_at are NULL and the row is not deleted", async () => {
+		const db = makeMockDB([
+			[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
+			null,
+			[],
+		])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const selectCall = db.calls.find((c) => c.sql.includes("SELECT"))
+		expect(selectCall!.sql).toContain("language IS NULL")
+		expect(selectCall!.sql).toContain("language_detection_attempted_at IS NULL")
+		expect(selectCall!.sql).toContain("deleted_at IS NULL")
+	})
+
+	it("stamps language and language_detection_attempted_at on successful detection", async () => {
+		const db = makeMockDB([
+			[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }],
+			null,
+			[],
+		])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updateCall!.sql).toContain("language = ")
+		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(updateCall!.params).toContain("en")
+		expect(updateCall!.params).toContain(7)
+	})
+
+	it("stamps language_detection_attempted_at even when detection returns null", async () => {
+		const db = makeMockDB([[{ id: 8, lyrics: "oh oh", format: "plain" }], null, []])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(updateCall!.params).toContain(null)
+	})
+
+	it("is a no-op (no UPDATE) when there are no candidate rows", async () => {
+		const db = makeMockDB([[]])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		expect(db.calls.some((c) => c.sql.includes("UPDATE lyrics"))).toBe(false)
+	})
+
+	it("decompresses compressed lyrics before detection", async () => {
+		const compressed = await compress(ENGLISH_LYRICS_SAMPLE)
+		const db = makeMockDB([[{ id: 9, lyrics: compressed, format: "plain" }], null, []])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updateCall!.params).toContain("en")
+	})
+})

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -104,7 +104,7 @@ describe("backfillLanguage", () => {
 		expect(selectCall!.params[0]).toBe(DETECTOR_VERSION)
 	})
 
-	it("stamps language, source='detector', attempted_at, and detector_version on success", async () => {
+	it("stamps language, source='detector', attempted_at on success", async () => {
 		const db = makeMockDB([[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
@@ -116,8 +116,18 @@ describe("backfillLanguage", () => {
 		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
 		expect(updateCall!.sql).toContain("language_detector_version = ?")
 		expect(updateCall!.params).toContain("en")
-		expect(updateCall!.params).toContain(DETECTOR_VERSION)
 		expect(updateCall!.params).toContain(7)
+	})
+
+	it("stamps version=null when eld is not loaded so the row re-processes on next deploy", async () => {
+		const db = makeMockDB([[{ id: 11, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
+		const env = makeEnv(db, makeMockCache())
+
+		await backfillLanguage(env)
+
+		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		const versionIdx = updateCall!.params.length - 2
+		expect(updateCall!.params[versionIdx]).toBeNull()
 	})
 
 	it("clears language to null when re-detection cannot identify a language", async () => {
@@ -129,7 +139,6 @@ describe("backfillLanguage", () => {
 		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
 		expect(updateCall!.sql).not.toContain("COALESCE")
 		expect(updateCall!.params).toContain(null)
-		expect(updateCall!.params).toContain(DETECTOR_VERSION)
 	})
 
 	it("is a no-op (no UPDATE) when there are no candidate rows", async () => {
@@ -174,7 +183,6 @@ describe("backfillLanguage", () => {
 		const errStamp = updates.find((c) => c.params.includes(100))
 		expect(errStamp).toBeDefined()
 		expect(errStamp!.sql).toContain("language_detector_version = ?")
-		expect(errStamp!.params).toContain(DETECTOR_VERSION)
 
 		const successUpdate = updates.find((c) => c.params.includes(101))
 		expect(successUpdate).toBeDefined()

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -1,5 +1,6 @@
 import type { Env } from "@/types"
 import { compress } from "@/utils/compression"
+import { DETECTOR_VERSION } from "@/utils/detect-language"
 import { describe, expect, it } from "vitest"
 import { backfillLanguage } from "./backfill-language"
 
@@ -88,40 +89,47 @@ const ENGLISH_LYRICS_SAMPLE = [
 ].join("\n")
 
 describe("backfillLanguage", () => {
-	it("selects only rows where language and language_detection_attempted_at are NULL and the row is not deleted", async () => {
+	it("selects rows below the current detector version, excludes deleted and submitter-set rows", async () => {
 		const db = makeMockDB([[{ id: 1, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
 
 		const selectCall = db.calls.find((c) => c.sql.includes("SELECT"))
-		expect(selectCall!.sql).toContain("language IS NULL")
-		expect(selectCall!.sql).toContain("language_detection_attempted_at IS NULL")
+		expect(selectCall!.sql).toContain("language_detector_version IS NULL")
+		expect(selectCall!.sql).toContain("language_detector_version <")
 		expect(selectCall!.sql).toContain("deleted_at IS NULL")
+		expect(selectCall!.sql).toContain("language_source")
+		expect(selectCall!.sql).toContain("'submitter'")
+		expect(selectCall!.params[0]).toBe(DETECTOR_VERSION)
 	})
 
-	it("stamps language and language_detection_attempted_at on successful detection", async () => {
+	it("stamps language, source='detector', attempted_at, and detector_version on success", async () => {
 		const db = makeMockDB([[{ id: 7, lyrics: ENGLISH_LYRICS_SAMPLE, format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
 
 		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
-		expect(updateCall!.sql).toContain("language = ")
+		expect(updateCall!.sql).toContain("language = ?")
+		expect(updateCall!.sql).toContain("language_source = 'detector'")
 		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(updateCall!.sql).toContain("language_detector_version = ?")
 		expect(updateCall!.params).toContain("en")
+		expect(updateCall!.params).toContain(DETECTOR_VERSION)
 		expect(updateCall!.params).toContain(7)
 	})
 
-	it("stamps language_detection_attempted_at even when detection returns null", async () => {
+	it("clears language to null when re-detection cannot identify a language", async () => {
 		const db = makeMockDB([[{ id: 8, lyrics: "oh oh", format: "plain" }], null, []])
 		const env = makeEnv(db, makeMockCache())
 
 		await backfillLanguage(env)
 
 		const updateCall = db.calls.find((c) => c.sql.includes("UPDATE lyrics"))
-		expect(updateCall!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(updateCall!.sql).not.toContain("COALESCE")
 		expect(updateCall!.params).toContain(null)
+		expect(updateCall!.params).toContain(DETECTOR_VERSION)
 	})
 
 	it("is a no-op (no UPDATE) when there are no candidate rows", async () => {
@@ -144,7 +152,7 @@ describe("backfillLanguage", () => {
 		expect(updateCall!.params).toContain("en")
 	})
 
-	it("continues processing and stamps attempted_at when a row throws on decompress", async () => {
+	it("continues processing and stamps version when a row throws on decompress", async () => {
 		const valid = await compress(ENGLISH_LYRICS_SAMPLE)
 		const corruptedButLooksCompressed = "H4sIAAAAAA_NOTVALIDBASE64DATA"
 		const db = makeMockDB([
@@ -165,7 +173,8 @@ describe("backfillLanguage", () => {
 
 		const errStamp = updates.find((c) => c.params.includes(100))
 		expect(errStamp).toBeDefined()
-		expect(errStamp!.sql).toContain("language_detection_attempted_at = NOW()")
+		expect(errStamp!.sql).toContain("language_detector_version = ?")
+		expect(errStamp!.params).toContain(DETECTOR_VERSION)
 
 		const successUpdate = updates.find((c) => c.params.includes(101))
 		expect(successUpdate).toBeDefined()

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -5,12 +5,17 @@ import { DETECTOR_VERSION, detectLanguage, isEldReady } from "@/utils/detect-lan
 
 const log = new Logger("backfill")
 const BATCH_SIZE = 100
+// Sanity ceiling: stop the loop if the same row keeps failing to stamp
+// (decompress error AND fallback stamp UPDATE error in the same iteration).
+// One million rows is well past anything realistic for this corpus and
+// guarantees we exit even in pathological failure modes.
+const MAX_SCANNED = 1_000_000
 
 export async function backfillLanguage(env: Env): Promise<{ scanned: number; updated: number }> {
 	let scanned = 0
 	let updated = 0
 
-	while (true) {
+	while (scanned < MAX_SCANNED) {
 		const batch = await env.DB.prepare(
 			`SELECT id, lyrics, format FROM lyrics
 			 WHERE COALESCE(language_source, 'detector') <> 'submitter'
@@ -68,6 +73,10 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 			updated,
 			eldReady: isEldReady(),
 		})
+	}
+
+	if (scanned >= MAX_SCANNED) {
+		log.warn("language backfill hit scan ceiling", { scanned, updated })
 	}
 
 	return { scanned, updated }

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -1,0 +1,51 @@
+import { Logger } from "@/infra/logger"
+import type { Env, LyricsFormat } from "@/types"
+import { decompress, isCompressed } from "@/utils/compression"
+import { detectLanguage } from "@/utils/detect-language"
+
+const log = new Logger("backfill")
+const BATCH_SIZE = 100
+
+export async function backfillLanguage(env: Env): Promise<{ scanned: number; updated: number }> {
+	let scanned = 0
+	let updated = 0
+
+	while (true) {
+		const batch = await env.DB.prepare(
+			`SELECT id, lyrics, format FROM lyrics
+			 WHERE language IS NULL
+			   AND language_detection_attempted_at IS NULL
+			   AND deleted_at IS NULL
+			 ORDER BY id ASC
+			 LIMIT ?`,
+		)
+			.bind(BATCH_SIZE)
+			.all<{ id: number; lyrics: string; format: LyricsFormat }>()
+
+		const rows = batch.results || []
+		if (rows.length === 0) break
+
+		for (const row of rows) {
+			scanned++
+			try {
+				const content = isCompressed(row.lyrics) ? await decompress(row.lyrics) : row.lyrics
+				const detected = detectLanguage(content, row.format)
+				await env.DB.prepare(
+					`UPDATE lyrics
+					 SET language = COALESCE(?, language),
+					     language_detection_attempted_at = NOW()
+					 WHERE id = ?`,
+				)
+					.bind(detected, row.id)
+					.run()
+				if (detected) updated++
+			} catch (err) {
+				log.warn("failed to backfill row", { id: row.id, error: (err as Error).message })
+			}
+		}
+
+		log.info("language backfill batch complete", { batch: rows.length, scanned, updated })
+	}
+
+	return { scanned, updated }
+}

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -1,7 +1,7 @@
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsFormat } from "@/types"
 import { decompress, isCompressed } from "@/utils/compression"
-import { DETECTOR_VERSION, detectLanguage } from "@/utils/detect-language"
+import { DETECTOR_VERSION, detectLanguage, isEldReady } from "@/utils/detect-language"
 
 const log = new Logger("backfill")
 const BATCH_SIZE = 100
@@ -27,6 +27,7 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 
 		for (const row of rows) {
 			scanned++
+			const stampVersion = isEldReady() ? DETECTOR_VERSION : null
 			try {
 				const content = isCompressed(row.lyrics) ? await decompress(row.lyrics) : row.lyrics
 				const detected = detectLanguage(content, row.format)
@@ -38,7 +39,7 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 					     language_detector_version = ?
 					 WHERE id = ?`
 				)
-					.bind(detected, DETECTOR_VERSION, row.id)
+					.bind(detected, stampVersion, row.id)
 					.run()
 				if (detected) updated++
 			} catch (err) {
@@ -50,7 +51,7 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 						     language_detector_version = ?
 						 WHERE id = ?`
 					)
-						.bind(DETECTOR_VERSION, row.id)
+						.bind(stampVersion, row.id)
 						.run()
 				} catch (stampErr) {
 					log.warn("failed to stamp attempted_at on errored row", {
@@ -61,7 +62,12 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 			}
 		}
 
-		log.info("language backfill batch complete", { batch: rows.length, scanned, updated })
+		log.info("language backfill batch complete", {
+			batch: rows.length,
+			scanned,
+			updated,
+			eldReady: isEldReady(),
+		})
 	}
 
 	return { scanned, updated }

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -1,7 +1,7 @@
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsFormat } from "@/types"
 import { decompress, isCompressed } from "@/utils/compression"
-import { detectLanguage } from "@/utils/detect-language"
+import { DETECTOR_VERSION, detectLanguage } from "@/utils/detect-language"
 
 const log = new Logger("backfill")
 const BATCH_SIZE = 100
@@ -13,13 +13,13 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 	while (true) {
 		const batch = await env.DB.prepare(
 			`SELECT id, lyrics, format FROM lyrics
-			 WHERE language IS NULL
-			   AND language_detection_attempted_at IS NULL
+			 WHERE COALESCE(language_source, 'detector') <> 'submitter'
+			   AND (language_detector_version IS NULL OR language_detector_version < ?)
 			   AND deleted_at IS NULL
 			 ORDER BY id ASC
 			 LIMIT ?`
 		)
-			.bind(BATCH_SIZE)
+			.bind(DETECTOR_VERSION, BATCH_SIZE)
 			.all<{ id: number; lyrics: string; format: LyricsFormat }>()
 
 		const rows = batch.results || []
@@ -32,20 +32,25 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 				const detected = detectLanguage(content, row.format)
 				await env.DB.prepare(
 					`UPDATE lyrics
-					 SET language = COALESCE(?, language),
-					     language_detection_attempted_at = NOW()
+					 SET language = ?,
+					     language_source = 'detector',
+					     language_detection_attempted_at = NOW(),
+					     language_detector_version = ?
 					 WHERE id = ?`
 				)
-					.bind(detected, row.id)
+					.bind(detected, DETECTOR_VERSION, row.id)
 					.run()
 				if (detected) updated++
 			} catch (err) {
 				log.warn("failed to backfill row", { id: row.id, error: (err as Error).message })
 				try {
 					await env.DB.prepare(
-						"UPDATE lyrics SET language_detection_attempted_at = NOW() WHERE id = ?"
+						`UPDATE lyrics
+						 SET language_detection_attempted_at = NOW(),
+						     language_detector_version = ?
+						 WHERE id = ?`
 					)
-						.bind(row.id)
+						.bind(DETECTOR_VERSION, row.id)
 						.run()
 				} catch (stampErr) {
 					log.warn("failed to stamp attempted_at on errored row", {

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -17,7 +17,7 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 			   AND language_detection_attempted_at IS NULL
 			   AND deleted_at IS NULL
 			 ORDER BY id ASC
-			 LIMIT ?`,
+			 LIMIT ?`
 		)
 			.bind(BATCH_SIZE)
 			.all<{ id: number; lyrics: string; format: LyricsFormat }>()
@@ -34,13 +34,25 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 					`UPDATE lyrics
 					 SET language = COALESCE(?, language),
 					     language_detection_attempted_at = NOW()
-					 WHERE id = ?`,
+					 WHERE id = ?`
 				)
 					.bind(detected, row.id)
 					.run()
 				if (detected) updated++
 			} catch (err) {
 				log.warn("failed to backfill row", { id: row.id, error: (err as Error).message })
+				try {
+					await env.DB.prepare(
+						"UPDATE lyrics SET language_detection_attempted_at = NOW() WHERE id = ?"
+					)
+						.bind(row.id)
+						.run()
+				} catch (stampErr) {
+					log.warn("failed to stamp attempted_at on errored row", {
+						id: row.id,
+						error: (stampErr as Error).message,
+					})
+				}
 			}
 		}
 

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -7,6 +7,12 @@ import {
 	mapTo639_1,
 } from "./detect-language"
 
+// Note: these unit tests cover the franc-only fallback path (the script direct
+// mappings, blocklist, and 639-1 whitelist). eld is loaded lazily at runtime
+// and its end-to-end behaviour is exercised by scripts/test-eld.ts and the
+// audit script against prod data. Pulling eld's 4.4 MB ngrams file through
+// vitest's dependency optimizer hangs the runner.
+
 describe("mapTo639_1", () => {
 	describe("happy paths", () => {
 		it("maps eng to en", () => {
@@ -323,6 +329,16 @@ describe("detectLanguage", () => {
 
 		it("returns es for Spanish lyrics inside TTML that carries Western songwriter names", () => {
 			expect(detectLanguage(SPANISH_TTML_WITH_SONGWRITERS, "ttml")).toBe("es")
+		})
+
+		it("returns en for English rap with AAVE slang that franc misclassifies as sco", () => {
+			const text = [
+				"Chase Mitchell pop a hundred fuckin bottles for a hundred fuckin thots",
+				"I roll with a hundred fuckin niggas and a hundred fuckin shots",
+				"What did you do to me look what did you do to me",
+				"Tryna get through to you tryna get through to you",
+			].join("\n")
+			expect(detectLanguage(text, "plain")).toBe("en")
 		})
 	})
 

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { extractTtmlLang, mapTo639_1 } from "./detect-language"
+import { detectLanguage, extractTtmlLang, mapTo639_1 } from "./detect-language"
 
 describe("mapTo639_1", () => {
 	describe("happy paths", () => {
@@ -94,6 +94,105 @@ describe("extractTtmlLang", () => {
 		it("is deterministic", () => {
 			const ttml = `<tt xml:lang="ja"><body><div><p>x</p></div></body></tt>`
 			expect(extractTtmlLang(ttml)).toBe(extractTtmlLang(ttml))
+		})
+	})
+})
+
+const ENGLISH_LYRICS = [
+	"In your arms I find the answer to every question",
+	"You whisper softly and the world begins to spin",
+	"Holding on tight to the moments we have together",
+	"Every heartbeat is a song that only we can hear",
+].join("\n")
+
+const JAPANESE_LYRICS = [
+	"あなたの腕の中で答えを見つけた",
+	"小さな声で囁いて世界が回り始める",
+	"二人の時間をしっかり抱きしめて",
+	"鼓動の音は二人だけの歌になる",
+].join("\n")
+
+const KOREAN_LYRICS = [
+	"네 품 안에서 모든 답을 찾았어",
+	"부드러운 속삭임에 세상이 돌기 시작해",
+	"우리가 함께한 순간들을 꼭 붙잡고",
+	"심장 소리는 우리만의 노래가 되어",
+].join("\n")
+
+const ENGLISH_TTML_WITH_LANG = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en"><body><div><p>${ENGLISH_LYRICS}</p></div></body></tt>`
+
+const ENGLISH_TTML_NO_LANG = `<tt xmlns="http://www.w3.org/ns/ttml"><body><div>${ENGLISH_LYRICS
+	.split("\n")
+	.map((line) => `<p>${line}</p>`)
+	.join("")}</div></body></tt>`
+
+const ENGLISH_LRC = ENGLISH_LYRICS
+	.split("\n")
+	.map((line, i) => `[00:${String(i * 5).padStart(2, "0")}.00]${line}`)
+	.join("\n")
+
+describe("detectLanguage", () => {
+	describe("happy paths", () => {
+		it("returns en from TTML xml:lang metadata", () => {
+			expect(detectLanguage(ENGLISH_TTML_WITH_LANG, "ttml")).toBe("en")
+		})
+
+		it("falls through to detection when TTML root has no xml:lang", () => {
+			expect(detectLanguage(ENGLISH_TTML_NO_LANG, "ttml")).toBe("en")
+		})
+
+		it("detects Japanese plain lyrics", () => {
+			expect(detectLanguage(JAPANESE_LYRICS, "plain")).toBe("ja")
+		})
+
+		it("detects Korean plain lyrics", () => {
+			expect(detectLanguage(KOREAN_LYRICS, "plain")).toBe("ko")
+		})
+
+		it("strips LRC timestamps before detection", () => {
+			expect(detectLanguage(ENGLISH_LRC, "lrc")).toBe("en")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns null for empty input", () => {
+			expect(detectLanguage("", "plain")).toBeNull()
+		})
+
+		it("returns null for input shorter than the minimum length", () => {
+			expect(detectLanguage("oh oh la", "plain")).toBeNull()
+		})
+
+		it("returns null for repetitive non-linguistic input", () => {
+			expect(detectLanguage("ooooohhhhhhh ahhhhhhhh ooooohhhhhhh", "plain")).toBeNull()
+		})
+
+		it("ignores TTML xml:lang and falls through when it is empty", () => {
+			const ttml = `<tt xml:lang=""><body><div><p>${ENGLISH_LYRICS}</p></div></body></tt>`
+			expect(detectLanguage(ttml, "ttml")).toBe("en")
+		})
+
+		it("accepts a precomputed plainText argument and uses it directly", () => {
+			expect(detectLanguage("ignored", "plain", JAPANESE_LYRICS)).toBe("ja")
+		})
+	})
+
+	describe("invariants", () => {
+		it("is deterministic", () => {
+			expect(detectLanguage(JAPANESE_LYRICS, "plain")).toBe(
+				detectLanguage(JAPANESE_LYRICS, "plain"),
+			)
+		})
+
+		it("never returns an uppercase code", () => {
+			const result = detectLanguage(ENGLISH_LYRICS, "plain")
+			expect(result).toBe(result?.toLowerCase())
+		})
+	})
+
+	describe("regressions", () => {
+		it("returns en for representative English lyrics (row 818 motivation)", () => {
+			expect(detectLanguage(ENGLISH_LYRICS, "plain")).toBe("en")
 		})
 	})
 })

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { mapTo639_1 } from "./detect-language"
+import { extractTtmlLang, mapTo639_1 } from "./detect-language"
 
 describe("mapTo639_1", () => {
 	describe("happy paths", () => {
@@ -42,6 +42,58 @@ describe("mapTo639_1", () => {
 	describe("invariants", () => {
 		it("is deterministic", () => {
 			expect(mapTo639_1("eng")).toBe(mapTo639_1("eng"))
+		})
+	})
+})
+
+describe("extractTtmlLang", () => {
+	describe("happy paths", () => {
+		it("returns the base language tag from xml:lang on the root tt", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en"><body><div><p>hello</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("en")
+		})
+
+		it("lowercases the language tag", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="EN"><body><div><p>hello</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("en")
+		})
+
+		it("strips a script subtag and returns only the base language", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="zh-Hant"><body><div><p>你好</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("zh")
+		})
+
+		it("strips a region subtag and returns only the base language", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="pt-BR"><body><div><p>olá</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe("pt")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns null when root tt has no xml:lang", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml"><body><div><p>hello</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBeNull()
+		})
+
+		it("returns null when xml:lang is empty", () => {
+			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang=""><body><div><p>hi</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBeNull()
+		})
+
+		it("returns null when the input is not valid XML", () => {
+			expect(extractTtmlLang("not xml at all")).toBeNull()
+		})
+
+		it("returns null when the root is not tt", () => {
+			const xml = `<root xml:lang="en"><body/></root>`
+			expect(extractTtmlLang(xml)).toBeNull()
+		})
+	})
+
+	describe("invariants", () => {
+		it("is deterministic", () => {
+			const ttml = `<tt xml:lang="ja"><body><div><p>x</p></div></body></tt>`
+			expect(extractTtmlLang(ttml)).toBe(extractTtmlLang(ttml))
 		})
 	})
 })

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { mapTo639_1 } from "./detect-language"
+
+describe("mapTo639_1", () => {
+	describe("happy paths", () => {
+		it("maps eng to en", () => {
+			expect(mapTo639_1("eng")).toBe("en")
+		})
+
+		it("maps jpn to ja", () => {
+			expect(mapTo639_1("jpn")).toBe("ja")
+		})
+
+		it("maps cmn (Mandarin) to zh", () => {
+			expect(mapTo639_1("cmn")).toBe("zh")
+		})
+
+		it("maps kor to ko", () => {
+			expect(mapTo639_1("kor")).toBe("ko")
+		})
+
+		it("maps spa to es", () => {
+			expect(mapTo639_1("spa")).toBe("es")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns null for the franc 'und' marker", () => {
+			expect(mapTo639_1("und")).toBeNull()
+		})
+
+		it("returns null for empty string", () => {
+			expect(mapTo639_1("")).toBeNull()
+		})
+
+		it("returns the 639-3 code as-is when no 639-1 mapping exists", () => {
+			// xxx is a private-use code with no ISO 639-1 form.
+			expect(mapTo639_1("xxx")).toBe("xxx")
+		})
+	})
+
+	describe("invariants", () => {
+		it("is deterministic", () => {
+			expect(mapTo639_1("eng")).toBe(mapTo639_1("eng"))
+		})
+	})
+})

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { detectLanguage, extractTtmlLang, mapTo639_1 } from "./detect-language"
+import {
+	DETECTOR_VERSION,
+	detectByScript,
+	detectLanguage,
+	extractTtmlLang,
+	mapTo639_1,
+} from "./detect-language"
 
 describe("mapTo639_1", () => {
 	describe("happy paths", () => {
@@ -33,9 +39,20 @@ describe("mapTo639_1", () => {
 			expect(mapTo639_1("")).toBeNull()
 		})
 
-		it("returns the 639-3 code as-is when no 639-1 mapping exists", () => {
-			// xxx is a private-use code with no ISO 639-1 form.
-			expect(mapTo639_1("xxx")).toBe("xxx")
+		it("returns null when no 639-1 mapping exists (Scots)", () => {
+			expect(mapTo639_1("sco")).toBeNull()
+		})
+
+		it("returns null for unmapped 3-letter input (snk / Sangu)", () => {
+			expect(mapTo639_1("snk")).toBeNull()
+		})
+
+		it("returns null for unmapped private-use code", () => {
+			expect(mapTo639_1("xxx")).toBeNull()
+		})
+
+		it("returns null for Malay individual code without 639-1", () => {
+			expect(mapTo639_1("zlm")).toBeNull()
 		})
 	})
 
@@ -98,6 +115,94 @@ describe("extractTtmlLang", () => {
 	})
 })
 
+describe("detectByScript", () => {
+	describe("direct script-to-language mappings", () => {
+		it("returns ko for Hangul-dominant text", () => {
+			const text = "네 품 안에서 모든 답을 찾았어 부드러운 속삭임에 세상이 돌기 시작해"
+			expect(detectByScript(text)).toEqual({ directLanguage: "ko" })
+		})
+
+		it("returns ko for Hangul mixed with Latin filler (K-pop)", () => {
+			const text =
+				"Yeah baby 네 품 안에서 모든 답을 찾았어 부드러운 속삭임에 세상이 돌기 시작해 oh yeah"
+			expect(detectByScript(text)).toEqual({ directLanguage: "ko" })
+		})
+
+		it("returns ja for any kana presence (Hiragana)", () => {
+			const text = "Yeah baby あなたの腕の中で答えを見つけた oh yeah"
+			expect(detectByScript(text)).toEqual({ directLanguage: "ja" })
+		})
+
+		it("returns ja for Katakana", () => {
+			const text = "ラブストーリー is what they call it"
+			expect(detectByScript(text)).toEqual({ directLanguage: "ja" })
+		})
+
+		it("returns he for Hebrew-dominant text", () => {
+			const text = "אני מעיל בארון תלוי על קולב מתעורר משנתי עם קיצו של הסתיו"
+			expect(detectByScript(text)).toEqual({ directLanguage: "he" })
+		})
+
+		it("returns te for Telugu-dominant text", () => {
+			const text = "నీ ప్రేమే నా జీవితం పాట"
+			expect(detectByScript(text)).toEqual({ directLanguage: "te" })
+		})
+
+		it("returns th for Thai-dominant text", () => {
+			const text = "ฉันรักเธอด้วยใจทั้งหมดของฉัน"
+			expect(detectByScript(text)).toEqual({ directLanguage: "th" })
+		})
+
+		it("returns el for Greek-dominant text", () => {
+			const text = "Σε αγαπώ πιο πολύ από οτιδήποτε άλλο στον κόσμο"
+			expect(detectByScript(text)).toEqual({ directLanguage: "el" })
+		})
+	})
+
+	describe("multi-language script restrictions", () => {
+		it("restricts to Cyrillic candidates for Russian", () => {
+			const text = "Я улыбаюсь как еблан не знаю что ей ответить"
+			const hint = detectByScript(text)
+			expect(hint.restrictTo).toBeDefined()
+			expect(hint.restrictTo).toContain("rus")
+			expect(hint.restrictTo).toContain("ukr")
+			expect(hint.directLanguage).toBeUndefined()
+		})
+
+		it("restricts to Han candidates for Chinese", () => {
+			const text = "我爱你比任何其他东西在这个世界上"
+			const hint = detectByScript(text)
+			expect(hint.restrictTo).toBeDefined()
+			expect(hint.restrictTo).toContain("cmn")
+		})
+
+		it("restricts to Arabic candidates", () => {
+			const text = "أحبك أكثر من أي شيء آخر في العالم"
+			const hint = detectByScript(text)
+			expect(hint.restrictTo).toContain("arb")
+		})
+	})
+
+	describe("Latin-only and empty", () => {
+		it("returns empty hint for Latin-only English text", () => {
+			expect(detectByScript("Hello world this is plain english text")).toEqual({})
+		})
+
+		it("returns empty hint for empty input", () => {
+			expect(detectByScript("")).toEqual({})
+		})
+
+		it("returns empty hint for whitespace and punctuation only", () => {
+			expect(detectByScript("  ... !! ??  ")).toEqual({})
+		})
+
+		it("returns empty hint when non-Latin presence is below the 20% threshold", () => {
+			const text = "This is a long english sentence with one stray Korean char 안 included"
+			expect(detectByScript(text)).toEqual({})
+		})
+	})
+})
+
 const ENGLISH_LYRICS = [
 	"In your arms I find the answer to every question",
 	"You whisper softly and the world begins to spin",
@@ -119,6 +224,22 @@ const KOREAN_LYRICS = [
 	"심장 소리는 우리만의 노래가 되어",
 ].join("\n")
 
+const KOREAN_WITH_ENGLISH_FILLER = [
+	"Yeah baby uh-huh",
+	"네 품 안에서 모든 답을 찾았어",
+	"부드러운 속삭임에 세상이 돌기 시작해",
+	"oh oh yeah I love you",
+	"우리가 함께한 순간들을 꼭 붙잡고",
+	"심장 소리는 우리만의 노래가 되어",
+].join("\n")
+
+const SPANISH_LYRICS = [
+	"Carlos Vargas soy intérprete del corazón",
+	"Que de emergencia te necesita",
+	"Hey doctor deme una visita",
+	"Que sin su amor mi corazón no puede vivir más",
+].join("\n")
+
 const ENGLISH_TTML_WITH_LANG = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en"><body><div><p>${ENGLISH_LYRICS}</p></div></body></tt>`
 
 const ENGLISH_TTML_NO_LANG = `<tt xmlns="http://www.w3.org/ns/ttml"><body><div>${ENGLISH_LYRICS
@@ -130,6 +251,16 @@ const ENGLISH_LRC = ENGLISH_LYRICS
 	.split("\n")
 	.map((line, i) => `[00:${String(i * 5).padStart(2, "0")}.00]${line}`)
 	.join("\n")
+
+const KOREAN_TTML_WITH_SONGWRITERS = `<tt xmlns="http://www.w3.org/ns/ttml"><head><metadata><songwriters><songwriter>Chase Mitchell</songwriter><songwriter>Andrew Smith</songwriter></songwriters></metadata></head><body><div>${KOREAN_LYRICS
+	.split("\n")
+	.map((line) => `<p>${line}</p>`)
+	.join("")}</div></body></tt>`
+
+const SPANISH_TTML_WITH_SONGWRITERS = `<tt xmlns="http://www.w3.org/ns/ttml"><head><metadata><songwriters><songwriter>John Songwriter</songwriter><songwriter>Mike Producer</songwriter></songwriters></metadata></head><body><div>${SPANISH_LYRICS
+	.split("\n")
+	.map((line) => `<p>${line}</p>`)
+	.join("")}</div></body></tt>`
 
 describe("detectLanguage", () => {
 	describe("happy paths", () => {
@@ -152,6 +283,10 @@ describe("detectLanguage", () => {
 		it("strips LRC timestamps before detection", () => {
 			expect(detectLanguage(ENGLISH_LRC, "lrc")).toBe("en")
 		})
+
+		it("detects Spanish plain lyrics", () => {
+			expect(detectLanguage(SPANISH_LYRICS, "plain")).toBe("es")
+		})
 	})
 
 	describe("edge cases", () => {
@@ -171,9 +306,23 @@ describe("detectLanguage", () => {
 			const ttml = `<tt xml:lang=""><body><div><p>${ENGLISH_LYRICS}</p></div></body></tt>`
 			expect(detectLanguage(ttml, "ttml")).toBe("en")
 		})
+	})
 
-		it("accepts a precomputed plainText argument and uses it directly", () => {
-			expect(detectLanguage("ignored", "plain", JAPANESE_LYRICS)).toBe("ja")
+	describe("regressions", () => {
+		it("returns en for representative English lyrics (row 818 motivation)", () => {
+			expect(detectLanguage(ENGLISH_LYRICS, "plain")).toBe("en")
+		})
+
+		it("returns ko for K-pop with English filler when no xml:lang is present", () => {
+			expect(detectLanguage(KOREAN_WITH_ENGLISH_FILLER, "plain")).toBe("ko")
+		})
+
+		it("returns ko for Korean lyrics inside TTML that carries Western songwriter names", () => {
+			expect(detectLanguage(KOREAN_TTML_WITH_SONGWRITERS, "ttml")).toBe("ko")
+		})
+
+		it("returns es for Spanish lyrics inside TTML that carries Western songwriter names", () => {
+			expect(detectLanguage(SPANISH_TTML_WITH_SONGWRITERS, "ttml")).toBe("es")
 		})
 	})
 
@@ -188,11 +337,20 @@ describe("detectLanguage", () => {
 			const result = detectLanguage(ENGLISH_LYRICS, "plain")
 			expect(result).toBe(result?.toLowerCase())
 		})
+
+		it("never returns a 3-letter ISO 639-3 code", () => {
+			const samples = [ENGLISH_LYRICS, JAPANESE_LYRICS, KOREAN_LYRICS, SPANISH_LYRICS]
+			for (const text of samples) {
+				const result = detectLanguage(text, "plain")
+				if (result !== null) expect(result.length).toBeLessThanOrEqual(2)
+			}
+		})
 	})
 
-	describe("regressions", () => {
-		it("returns en for representative English lyrics (row 818 motivation)", () => {
-			expect(detectLanguage(ENGLISH_LYRICS, "plain")).toBe("en")
+	describe("detector version", () => {
+		it("exposes a numeric DETECTOR_VERSION", () => {
+			expect(typeof DETECTOR_VERSION).toBe("number")
+			expect(DETECTOR_VERSION).toBeGreaterThan(0)
 		})
 	})
 })

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,7 +1,7 @@
-import { francAll } from "franc"
-import { iso6393To1 } from "iso-639-3"
 import type { LyricsFormat } from "@/types"
 import { extractDetectionText, ttmlParser } from "@/utils/extract-text"
+import { francAll } from "franc"
+import { iso6393To1 } from "iso-639-3"
 
 export const DETECTOR_VERSION = 3
 
@@ -30,6 +30,10 @@ export function loadEld(): Promise<EldDetector> {
 		})()
 	}
 	return eldLoadPromise
+}
+
+export function isEldReady(): boolean {
+	return eldInstance !== null
 }
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -33,7 +33,7 @@ export function extractTtmlLang(ttml: string): string | null {
 		if (!("tt" in rootEl)) continue
 
 		const attrs = rootEl[":@"]
-		const raw = attrs?.["@_lang"] ?? attrs?.["@_xml:lang"]
+		const raw = attrs?.["@_lang"]
 		if (typeof raw !== "string") return null
 
 		const trimmed = raw.trim().toLowerCase()

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -13,7 +13,7 @@ type EldDetector = {
 	enableTextCleanup(enabled: boolean): void
 }
 let eldInstance: EldDetector | null = null
-let eldLoadPromise: Promise<EldDetector> | null = null
+let eldLoadPromise: Promise<EldDetector | null> | null = null
 
 // Indirect path defeats Vite's static-analysis pre-bundler in the test runner.
 // "eld/large" is the static entry: all ngrams are imported at module-load time
@@ -21,21 +21,34 @@ let eldLoadPromise: Promise<EldDetector> | null = null
 // could hang under tsx + Node ESM resolution on a Railway container.
 const ELD_MODULE = "eld/large"
 
-export function loadEld(): Promise<EldDetector> {
+const ELD_LOAD_TIMEOUT_MS = 60_000
+
+export function loadEld(): Promise<EldDetector | null> {
 	if (eldInstance) return Promise.resolve(eldInstance)
 	if (!eldLoadPromise) {
-		eldLoadPromise = (async () => {
-			const t0 = Date.now()
-			log.info("eld loading")
-			const mod = (await import(ELD_MODULE)) as { eld: EldDetector }
-			mod.eld.enableTextCleanup(true)
-			eldInstance = mod.eld
-			log.info("eld loaded", { ms: Date.now() - t0 })
-			return eldInstance
-		})()
-		eldLoadPromise.catch((err) => {
-			log.error("eld load failed", { error: (err as Error).message })
+		const t0 = Date.now()
+		log.info("eld loading")
+		eldLoadPromise = Promise.race([
+			(async () => {
+				const mod = (await import(ELD_MODULE)) as { eld: EldDetector }
+				mod.eld.enableTextCleanup(true)
+				eldInstance = mod.eld
+				log.info("eld loaded", { ms: Date.now() - t0 })
+				return eldInstance
+			})(),
+			new Promise<null>((resolve) =>
+				setTimeout(() => {
+					if (!eldInstance) {
+						log.error("eld load timed out", { ms: Date.now() - t0 })
+						eldLoadPromise = null
+						resolve(null)
+					}
+				}, ELD_LOAD_TIMEOUT_MS)
+			),
+		]).catch((err) => {
+			log.error("eld load failed", { error: (err as Error).message, ms: Date.now() - t0 })
 			eldLoadPromise = null
+			return null
 		})
 	}
 	return eldLoadPromise

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,33 +1,42 @@
+import { Logger } from "@/infra/logger"
 import type { LyricsFormat } from "@/types"
 import { extractDetectionText, ttmlParser } from "@/utils/extract-text"
 import { francAll } from "franc"
 import { iso6393To1 } from "iso-639-3"
+
+const log = new Logger("detect-language")
 
 export const DETECTOR_VERSION = 3
 
 type EldDetector = {
 	detect(text: string): { language: string; isReliable(): boolean }
 	enableTextCleanup(enabled: boolean): void
-	load(name: string): Promise<boolean>
 }
 let eldInstance: EldDetector | null = null
 let eldLoadPromise: Promise<EldDetector> | null = null
 
-// Indirect to keep the import path opaque to Vite's static analysis. eld ships
-// a 4.4 MB ngrams file that breaks the test runner's dependency optimizer when
-// referenced directly.
-const ELD_MODULE = "eld"
+// Indirect path defeats Vite's static-analysis pre-bundler in the test runner.
+// "eld/large" is the static entry: all ngrams are imported at module-load time
+// so there is no runtime `import('../ngrams/...')` inside eld.load() that
+// could hang under tsx + Node ESM resolution on a Railway container.
+const ELD_MODULE = "eld/large"
 
 export function loadEld(): Promise<EldDetector> {
 	if (eldInstance) return Promise.resolve(eldInstance)
 	if (!eldLoadPromise) {
 		eldLoadPromise = (async () => {
+			const t0 = Date.now()
+			log.info("eld loading")
 			const mod = (await import(ELD_MODULE)) as { eld: EldDetector }
-			await mod.eld.load("large")
 			mod.eld.enableTextCleanup(true)
 			eldInstance = mod.eld
+			log.info("eld loaded", { ms: Date.now() - t0 })
 			return eldInstance
 		})()
+		eldLoadPromise.catch((err) => {
+			log.error("eld load failed", { error: (err as Error).message })
+			eldLoadPromise = null
+		})
 	}
 	return eldLoadPromise
 }

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -3,7 +3,34 @@ import { iso6393To1 } from "iso-639-3"
 import type { LyricsFormat } from "@/types"
 import { extractDetectionText, ttmlParser } from "@/utils/extract-text"
 
-export const DETECTOR_VERSION = 2
+export const DETECTOR_VERSION = 3
+
+type EldDetector = {
+	detect(text: string): { language: string; isReliable(): boolean }
+	enableTextCleanup(enabled: boolean): void
+	load(name: string): Promise<boolean>
+}
+let eldInstance: EldDetector | null = null
+let eldLoadPromise: Promise<EldDetector> | null = null
+
+// Indirect to keep the import path opaque to Vite's static analysis. eld ships
+// a 4.4 MB ngrams file that breaks the test runner's dependency optimizer when
+// referenced directly.
+const ELD_MODULE = "eld"
+
+export function loadEld(): Promise<EldDetector> {
+	if (eldInstance) return Promise.resolve(eldInstance)
+	if (!eldLoadPromise) {
+		eldLoadPromise = (async () => {
+			const mod = (await import(ELD_MODULE)) as { eld: EldDetector }
+			await mod.eld.load("large")
+			mod.eld.enableTextCleanup(true)
+			eldInstance = mod.eld
+			return eldInstance
+		})()
+	}
+	return eldLoadPromise
+}
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -154,6 +181,11 @@ export function detectLanguage(lyrics: string, format: LyricsFormat): string | n
 
 	const hint = detectByScript(text)
 	if (hint.directLanguage) return hint.directLanguage
+
+	if (eldInstance) {
+		const eldResult = eldInstance.detect(text)
+		if (eldResult.isReliable() && eldResult.language) return eldResult.language
+	}
 
 	const opts: { minLength: number; only?: string[] } = { minLength: MIN_LENGTH }
 	if (hint.restrictTo) opts.only = hint.restrictTo

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,0 +1,15 @@
+import { iso6393To1 } from "iso-639-3"
+
+const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
+	cmn: "zh",
+	arb: "ar",
+	pes: "fa",
+}
+
+export function mapTo639_1(code639_3: string): string | null {
+	if (!code639_3 || code639_3 === "und") return null
+	const override = FRANC_INDIVIDUAL_TO_639_1[code639_3]
+	if (override) return override
+	const mapped = iso6393To1[code639_3]
+	return mapped ?? code639_3
+}

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,7 +1,9 @@
-import type { LyricsFormat } from "@/types"
-import { extractPlainText, ttmlParser } from "@/utils/extract-text"
 import { francAll } from "franc"
 import { iso6393To1 } from "iso-639-3"
+import type { LyricsFormat } from "@/types"
+import { extractDetectionText, ttmlParser } from "@/utils/extract-text"
+
+export const DETECTOR_VERSION = 2
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -9,12 +11,17 @@ const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	pes: "fa",
 }
 
+// sco (Scots) and glg (Galician) are reliably misclassifications of more
+// common neighbouring languages (English rap with AAVE slang; short Spanish
+// with Romance overlap). Skip them and let the next ranked code win.
+const FRANC_BLOCKLIST = new Set(["sco", "glg"])
+
 export function mapTo639_1(code639_3: string): string | null {
 	if (!code639_3 || code639_3 === "und") return null
 	const override = FRANC_INDIVIDUAL_TO_639_1[code639_3]
 	if (override) return override
 	const mapped = iso6393To1[code639_3]
-	return mapped ?? code639_3
+	return mapped ?? null
 }
 
 export function extractTtmlLang(ttml: string): string | null {
@@ -46,28 +53,119 @@ export function extractTtmlLang(ttml: string): string | null {
 	return null
 }
 
+const DIRECT_SCRIPT_MAPPINGS: Record<string, string> = {
+	Hangul: "ko",
+	Hebrew: "he",
+	Thai: "th",
+	Tamil: "ta",
+	Telugu: "te",
+	Bengali: "bn",
+	Gurmukhi: "pa",
+	Gujarati: "gu",
+	Kannada: "kn",
+	Malayalam: "ml",
+	Sinhala: "si",
+	Myanmar: "my",
+	Khmer: "km",
+	Lao: "lo",
+	Georgian: "ka",
+	Armenian: "hy",
+	Ethiopic: "am",
+	Greek: "el",
+}
+
+const SCRIPT_CANDIDATES: Record<string, string[]> = {
+	Cyrillic: ["rus", "ukr", "bul", "srp", "mkd", "bel", "mon", "kaz", "kir"],
+	Arabic: ["arb", "pes", "urd", "pus", "snd", "uig"],
+	Devanagari: ["hin", "mar", "nep", "san", "doi", "kok"],
+	Han: ["cmn", "yue", "lzh", "nan", "hak"],
+}
+
+const SCRIPTS_TO_COUNT: string[] = [
+	...Object.keys(DIRECT_SCRIPT_MAPPINGS),
+	...Object.keys(SCRIPT_CANDIDATES),
+	"Latin",
+	"Hiragana",
+	"Katakana",
+]
+
+const SCRIPT_REGEXES = new Map<string, RegExp>(
+	SCRIPTS_TO_COUNT.map((name) => [name, new RegExp(`\\p{Script=${name}}`, "gu")])
+)
+
+const NON_LATIN_DOMINANCE_THRESHOLD = 0.2
+
+interface ScriptHint {
+	directLanguage?: string
+	restrictTo?: string[]
+}
+
+export function detectByScript(text: string): ScriptHint {
+	const counts: Record<string, number> = {}
+	let total = 0
+	for (const [name, re] of SCRIPT_REGEXES) {
+		const c = (text.match(re) ?? []).length
+		counts[name] = c
+		total += c
+	}
+
+	if ((counts.Hiragana ?? 0) + (counts.Katakana ?? 0) > 0) {
+		return { directLanguage: "ja" }
+	}
+
+	if (total === 0) return {}
+
+	let bestScript: string | null = null
+	let bestCount = 0
+	for (const [name, count] of Object.entries(counts)) {
+		if (name === "Latin") continue
+		if (count > bestCount) {
+			bestScript = name
+			bestCount = count
+		}
+	}
+
+	if (!bestScript || bestCount / total < NON_LATIN_DOMINANCE_THRESHOLD) return {}
+
+	if (DIRECT_SCRIPT_MAPPINGS[bestScript]) {
+		return { directLanguage: DIRECT_SCRIPT_MAPPINGS[bestScript] }
+	}
+	if (SCRIPT_CANDIDATES[bestScript]) {
+		return { restrictTo: SCRIPT_CANDIDATES[bestScript] }
+	}
+
+	return {}
+}
+
 const MIN_LENGTH = 30
 const MIN_CONFIDENCE = 0.5
 
-export function detectLanguage(
-	lyrics: string,
-	format: LyricsFormat,
-	plainText?: string
-): string | null {
+export function detectLanguage(lyrics: string, format: LyricsFormat): string | null {
 	if (format === "ttml") {
 		const meta = extractTtmlLang(lyrics)
 		if (meta) return meta
 	}
 
-	const text = plainText ?? extractPlainText(lyrics, format)
+	const text = extractDetectionText(lyrics, format)
 	if (text.length < MIN_LENGTH) return null
 
 	const distinctChars = new Set(text.replace(/\s+/g, "")).size
 	if (distinctChars < 8) return null
 
-	const ranked = francAll(text, { minLength: MIN_LENGTH })
-	const [topCode, topScore] = ranked[0] ?? ["und", 0]
-	if (topCode === "und" || topScore < MIN_CONFIDENCE) return null
+	const hint = detectByScript(text)
+	if (hint.directLanguage) return hint.directLanguage
 
-	return mapTo639_1(topCode)
+	const opts: { minLength: number; only?: string[] } = { minLength: MIN_LENGTH }
+	if (hint.restrictTo) opts.only = hint.restrictTo
+
+	const ranked = francAll(text, opts)
+
+	for (const [code, score] of ranked) {
+		if (score < MIN_CONFIDENCE) break
+		if (FRANC_BLOCKLIST.has(code)) continue
+		const mapped = mapTo639_1(code)
+		if (mapped) return mapped
+	}
+
+	return null
 }

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,4 +1,5 @@
 import { iso6393To1 } from "iso-639-3"
+import { ttmlParser } from "@/utils/extract-text"
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -12,4 +13,33 @@ export function mapTo639_1(code639_3: string): string | null {
 	if (override) return override
 	const mapped = iso6393To1[code639_3]
 	return mapped ?? code639_3
+}
+
+export function extractTtmlLang(ttml: string): string | null {
+	let parsed: unknown
+	try {
+		parsed = ttmlParser.parse(ttml)
+	} catch {
+		return null
+	}
+
+	if (!Array.isArray(parsed)) return null
+
+	for (const root of parsed) {
+		if (typeof root !== "object" || root === null) continue
+		const rootEl = root as Record<string, unknown> & { ":@"?: Record<string, string> }
+		if (!("tt" in rootEl)) continue
+
+		const attrs = rootEl[":@"]
+		const raw = attrs?.["@_lang"] ?? attrs?.["@_xml:lang"]
+		if (typeof raw !== "string") return null
+
+		const trimmed = raw.trim().toLowerCase()
+		if (!trimmed) return null
+
+		const base = trimmed.split("-")[0]
+		return base || null
+	}
+
+	return null
 }

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,7 +1,7 @@
-import { francAll } from "franc"
-import { iso6393To1 } from "iso-639-3"
 import type { LyricsFormat } from "@/types"
 import { extractPlainText, ttmlParser } from "@/utils/extract-text"
+import { francAll } from "franc"
+import { iso6393To1 } from "iso-639-3"
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -52,7 +52,7 @@ const MIN_CONFIDENCE = 0.5
 export function detectLanguage(
 	lyrics: string,
 	format: LyricsFormat,
-	plainText?: string,
+	plainText?: string
 ): string | null {
 	if (format === "ttml") {
 		const meta = extractTtmlLang(lyrics)

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -40,16 +40,19 @@ export function loadEld(): Promise<EldDetector | null> {
 				setTimeout(() => {
 					if (!eldInstance) {
 						log.error("eld load timed out", { ms: Date.now() - t0 })
-						eldLoadPromise = null
 						resolve(null)
 					}
 				}, ELD_LOAD_TIMEOUT_MS)
 			),
-		]).catch((err) => {
-			log.error("eld load failed", { error: (err as Error).message, ms: Date.now() - t0 })
-			eldLoadPromise = null
-			return null
-		})
+		])
+			.catch((err) => {
+				log.error("eld load failed", { error: (err as Error).message, ms: Date.now() - t0 })
+				return null
+			})
+			.then((result) => {
+				if (!result) eldLoadPromise = null
+				return result
+			})
 	}
 	return eldLoadPromise
 }

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,5 +1,7 @@
+import { francAll } from "franc"
 import { iso6393To1 } from "iso-639-3"
-import { ttmlParser } from "@/utils/extract-text"
+import type { LyricsFormat } from "@/types"
+import { extractPlainText, ttmlParser } from "@/utils/extract-text"
 
 const FRANC_INDIVIDUAL_TO_639_1: Record<string, string> = {
 	cmn: "zh",
@@ -42,4 +44,30 @@ export function extractTtmlLang(ttml: string): string | null {
 	}
 
 	return null
+}
+
+const MIN_LENGTH = 30
+const MIN_CONFIDENCE = 0.5
+
+export function detectLanguage(
+	lyrics: string,
+	format: LyricsFormat,
+	plainText?: string,
+): string | null {
+	if (format === "ttml") {
+		const meta = extractTtmlLang(lyrics)
+		if (meta) return meta
+	}
+
+	const text = plainText ?? extractPlainText(lyrics, format)
+	if (text.length < MIN_LENGTH) return null
+
+	const distinctChars = new Set(text.replace(/\s+/g, "")).size
+	if (distinctChars < 8) return null
+
+	const ranked = francAll(text, { minLength: MIN_LENGTH })
+	const [topCode, topScore] = ranked[0] ?? ["und", 0]
+	if (topCode === "und" || topScore < MIN_CONFIDENCE) return null
+
+	return mapTo639_1(topCode)
 }

--- a/src/utils/extract-text.test.ts
+++ b/src/utils/extract-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { extractPlainText } from "./extract-text"
+import { extractDetectionText, extractPlainText, extractTtmlBody } from "./extract-text"
 
 describe("extractPlainText", () => {
 	describe("plain format", () => {
@@ -257,5 +257,67 @@ describe("extractPlainText", () => {
 			const result = extractPlainText(ttml, "ttml")
 			expect(result).toBe("")
 		})
+	})
+})
+
+describe("extractTtmlBody", () => {
+	it("excludes songwriter metadata", () => {
+		const ttml = `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" lang="en">
+  <head>
+    <metadata>
+      <songwriters>
+        <songwriter>Elton John</songwriter>
+        <songwriter>Bernie Taupin</songwriter>
+      </songwriters>
+    </metadata>
+  </head>
+  <body>
+    <div>
+      <p begin="00:15.000" end="00:20.000">Some lyrics here</p>
+    </div>
+  </body>
+</tt>`
+
+		const result = extractTtmlBody(ttml)
+		expect(result).toContain("Some lyrics here")
+		expect(result).not.toContain("Elton John")
+		expect(result).not.toContain("Bernie Taupin")
+	})
+
+	it("extracts only body paragraphs from nested word-synced spans", () => {
+		const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" lang="en"><head><metadata><songwriters><songwriter>Ghost Writer</songwriter></songwriters></metadata></head><body><div><p><span>네 품 </span><span>안에서</span></p></div></body></tt>`
+
+		const result = extractTtmlBody(ttml)
+		expect(result).toContain("네 품 안에서")
+		expect(result).not.toContain("Ghost Writer")
+	})
+
+	it("returns empty string when body is empty", () => {
+		const ttml = `<tt xmlns="http://www.w3.org/ns/ttml"><body></body></tt>`
+		expect(extractTtmlBody(ttml)).toBe("")
+	})
+
+	it("returns empty string for non-tt root", () => {
+		expect(extractTtmlBody("<root><p>hi</p></root>")).toBe("")
+	})
+})
+
+describe("extractDetectionText", () => {
+	it("routes plain through as-is", () => {
+		expect(extractDetectionText("hello world", "plain")).toBe("hello world")
+	})
+
+	it("strips LRC timestamps", () => {
+		const lrc = "[00:15.00]Line one\n[00:20.00]Line two"
+		expect(extractDetectionText(lrc, "lrc")).toBe("Line one\nLine two")
+	})
+
+	it("routes TTML through body-only extraction (excludes songwriters)", () => {
+		const ttml =
+			"<tt><head><metadata><songwriters><songwriter>Some Writer</songwriter></songwriters></metadata></head><body><div><p>네 품 안에서</p></div></body></tt>"
+		const result = extractDetectionText(ttml, "ttml")
+		expect(result).toContain("네 품 안에서")
+		expect(result).not.toContain("Some Writer")
 	})
 })

--- a/src/utils/extract-text.ts
+++ b/src/utils/extract-text.ts
@@ -2,7 +2,7 @@ import { XMLParser } from "fast-xml-parser"
 import type { LyricsFormat } from "@/types"
 import { parseLrc } from "@/utils/lrc"
 
-const parser = new XMLParser({
+export const ttmlParser = new XMLParser({
 	ignoreAttributes: false,
 	attributeNamePrefix: "@_",
 	textNodeName: "#text",
@@ -17,7 +17,7 @@ const parser = new XMLParser({
 type ParsedNode = Record<string, unknown>
 
 function extractTtmlText(ttml: string): string {
-	const parsed = parser.parse(ttml) as unknown[]
+	const parsed = ttmlParser.parse(ttml) as unknown[]
 	const lines: string[] = []
 
 	// Concatenate all text within a node tree, preserving whitespace between spans

--- a/src/utils/extract-text.ts
+++ b/src/utils/extract-text.ts
@@ -16,96 +16,105 @@ export const ttmlParser = new XMLParser({
 
 type ParsedNode = Record<string, unknown>
 
-function extractTtmlText(ttml: string): string {
+function concatText(nodes: unknown[]): string {
+	let result = ""
+	for (const node of nodes) {
+		if (typeof node !== "object" || node === null) continue
+		const el = node as ParsedNode
+
+		if ("#text" in el && typeof el["#text"] === "string") {
+			result += el["#text"]
+		}
+
+		for (const key of Object.keys(el)) {
+			if (key === "#text" || key === ":@") continue
+			const child = el[key]
+			if (Array.isArray(child)) {
+				result += concatText(child)
+			}
+		}
+	}
+	return result
+}
+
+function collectParagraphLines(nodes: unknown[], lines: string[]): void {
+	for (const node of nodes) {
+		if (typeof node !== "object" || node === null) continue
+		const el = node as ParsedNode
+
+		if (Array.isArray(el.p)) {
+			const text = concatText(el.p).trim()
+			if (text) lines.push(text)
+		}
+
+		for (const key of ["body", "div"]) {
+			if (Array.isArray(el[key])) {
+				collectParagraphLines(el[key] as unknown[], lines)
+			}
+		}
+	}
+}
+
+function collectSongwriterLines(nodes: unknown[], lines: string[]): void {
+	for (const node of nodes) {
+		if (typeof node !== "object" || node === null) continue
+		const el = node as ParsedNode
+		if (Array.isArray(el.songwriters)) {
+			for (const sw of el.songwriters as unknown[]) {
+				if (typeof sw !== "object" || sw === null) continue
+				const swEl = sw as ParsedNode
+				if (Array.isArray(swEl.songwriter)) {
+					const text = concatText(swEl.songwriter).trim()
+					if (text) lines.push(text)
+				}
+			}
+		}
+		for (const key of Object.keys(el)) {
+			if (key === "#text" || key === ":@" || key === "songwriters") continue
+			const child = el[key]
+			if (Array.isArray(child)) {
+				collectSongwriterLines(child, lines)
+			}
+		}
+	}
+}
+
+function parseTtml(ttml: string): unknown[] {
 	const parsed = ttmlParser.parse(ttml) as unknown[]
-	const lines: string[] = []
+	return Array.isArray(parsed) ? parsed : []
+}
 
-	// Concatenate all text within a node tree, preserving whitespace between spans
-	function concatText(nodes: unknown[]): string {
-		let result = ""
-		for (const node of nodes) {
-			if (typeof node !== "object" || node === null) continue
-			const el = node as ParsedNode
-
-			if ("#text" in el && typeof el["#text"] === "string") {
-				result += el["#text"]
-			}
-
-			for (const key of Object.keys(el)) {
-				if (key === "#text" || key === ":@") continue
-				const child = el[key]
-				if (Array.isArray(child)) {
-					result += concatText(child)
-				}
-			}
-		}
-		return result
-	}
-
-	// Collect text from <p> elements within body, each <p> becomes one line
-	function collectParagraphs(nodes: unknown[]): void {
-		for (const node of nodes) {
-			if (typeof node !== "object" || node === null) continue
-			const el = node as ParsedNode
-
-			if (Array.isArray(el.p)) {
-				const text = concatText(el.p).trim()
-				if (text) lines.push(text)
-			}
-
-			// Recurse into div, body containers
-			for (const key of ["body", "div"]) {
-				if (Array.isArray(el[key])) {
-					collectParagraphs(el[key] as unknown[])
-				}
-			}
-		}
-	}
-
-	// Recursively find songwriters elements anywhere in head metadata
-	function collectSongwriters(nodes: unknown[]): void {
-		for (const node of nodes) {
-			if (typeof node !== "object" || node === null) continue
-			const el = node as ParsedNode
-			if (Array.isArray(el.songwriters)) {
-				for (const sw of el.songwriters as unknown[]) {
-					if (typeof sw !== "object" || sw === null) continue
-					const swEl = sw as ParsedNode
-					if (Array.isArray(swEl.songwriter)) {
-						const text = concatText(swEl.songwriter).trim()
-						if (text) lines.push(text)
-					}
-				}
-			}
-			for (const key of Object.keys(el)) {
-				if (key === "#text" || key === ":@" || key === "songwriters") continue
-				const child = el[key]
-				if (Array.isArray(child)) {
-					collectSongwriters(child)
-				}
-			}
-		}
-	}
-
+function forEachTtChild(parsed: unknown[], fn: (child: ParsedNode) => void): void {
 	for (const root of parsed) {
 		if (typeof root !== "object" || root === null) continue
-		const rootEl = root as ParsedNode
-		const tt = rootEl.tt
+		const tt = (root as ParsedNode).tt
 		if (!Array.isArray(tt)) continue
-
 		for (const ttChild of tt) {
 			if (typeof ttChild !== "object" || ttChild === null) continue
-			const child = ttChild as ParsedNode
-
-			if (Array.isArray(child.body)) {
-				collectParagraphs(child.body)
-			}
-
-			if (Array.isArray(child.head)) {
-				collectSongwriters(child.head)
-			}
+			fn(ttChild as ParsedNode)
 		}
 	}
+}
+
+function extractTtmlText(ttml: string): string {
+	const parsed = parseTtml(ttml)
+	const lines: string[] = []
+
+	forEachTtChild(parsed, (child) => {
+		if (Array.isArray(child.body)) collectParagraphLines(child.body, lines)
+		if (Array.isArray(child.head)) collectSongwriterLines(child.head, lines)
+	})
+
+	return lines.join("\n").replace(/\s+/g, " ").trim()
+}
+
+export function extractTtmlBody(ttml: string): string {
+	const parsed = parseTtml(ttml)
+	const lines: string[] = []
+
+	forEachTtChild(parsed, (child) => {
+		if (Array.isArray(child.body)) collectParagraphLines(child.body, lines)
+	})
 
 	return lines.join("\n").replace(/\s+/g, " ").trim()
 }
@@ -121,4 +130,9 @@ export function extractPlainText(lyrics: string, format: LyricsFormat): string {
 		case "ttml":
 			return extractTtmlText(lyrics)
 	}
+}
+
+export function extractDetectionText(lyrics: string, format: LyricsFormat): string {
+	if (format === "ttml") return extractTtmlBody(lyrics)
+	return extractPlainText(lyrics, format)
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,14 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+		// eld is dynamically imported at runtime only. If a test ever calls
+		// loadEld(), externalize prevents vitest from pre-bundling the 4.4 MB
+		// ngrams file via Vite's optimizer.
+		server: {
+			deps: {
+				external: [/^eld/],
+			},
+		},
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Diagnosis

The earlier prod incidents had two distinct failure modes:

1. **PR #34 deploy:** server started cleanly but `loadEld()` never resolved. The chain `loadEld().then(backfillLanguage)` got stuck forever, the backfill never ran, no error log ever fired. Submissions during that window still worked (because `detectLanguage` falls back to franc when `eldInstance` is null), but the existing 395 rows kept their bad v1 detections.

2. **PR #35 deploy:** different root cause. `pg.Pool` in `migrate.ts` has no connection timeout, and Railway had a transient DB/network issue at that time. The migration hung at DNS/TCP resolution for 5 minutes until healthcheck killed the container. Same hang reproduced on a force-push to a pre-lang-autodetect commit during that window, then went away on a later redeploy of the same commit — confirming the failure was infrastructure, not code.

To rule out (1) being some Linux/tsx/eld interaction we couldn't see on macOS, the eld load was reproduced inside a `node:22-bookworm-slim` container with 512 MB / 1 CPU constraints matching Railway. Both static (`import("eld/large")`) and dynamic (`import("eld") + eld.load("large")`) paths load in ~3 seconds via tsx. Scripts at `scripts/eld-railway-repro.sh` and `scripts/eld-tsx-repro.sh` make this easy to re-run.

So the real risk is not the load mechanism itself: it's the absence of a safety net when something does go wrong. This PR adds that net.

## Changes

- **`loadEld()` now resolves to `null` on timeout.** A 60-second `Promise.race` against the import means the eld load will never silently block forever. On timeout, the failure is logged with the elapsed time and the lazy promise is cleared so a later call can retry.
- **Load and timeout/failure paths all log.** Previously a load failure could go completely unnoticed; now we get `eld loading`, `eld loaded ms=...`, `eld load timed out ms=...`, or `eld load failed error=... ms=...` for every state transition.
- **Backfill stamps `language_detector_version` based on `isEldReady()`.** Rows processed before eld is ready (or while eld is degraded) get version `NULL` and will be re-processed on the next deploy when eld is ready. Rows processed with eld available get the current version and are considered final until the next bump. The per-batch log line now includes `eldReady` so we can see exactly which rows fell into which bucket.

The submission path (`submitLyrics`) already stamps `NULL` when `isEldReady()` is false (from earlier work), so cold-start submissions get re-evaluated on the next backfill pass.

## Test plan

- [x] 768 vitest tests pass, tsc clean, biome clean on touched files
- [x] `bash scripts/eld-tsx-repro.sh` confirms eld loads in ~3.1s under Railway-equivalent Linux container (Node 22 + tsx + 512 MB + 1 CPU)
- [ ] On deploy, watch for: `INFO [detect-language] eld loaded ms=...` followed by `INFO [app] language backfill complete scanned=... updated=...`
- [ ] If `eld load timed out` appears instead, backfill will still run (with franc fallback) and stamp rows with version NULL, so a future deploy will retry them
- [ ] Re-run the audit script and confirm Korean / Hebrew / Vietnamese / Indonesian rows correctly classify, and no `sco` / `snk` / `zlm` codes remain