### PR TITLE
fix: offload /detect to blocking pool, add request tracing

### DIFF
--- a/detection-service/Cargo.lock
+++ b/detection-service/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1604,6 +1605,22 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/detection-service/Cargo.toml
+++ b/detection-service/Cargo.toml
@@ -21,6 +21,7 @@ lingua = "1.8"
 rayon = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tower-http = { version = "0.6", features = ["trace"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/detection-service/src/lib.rs
+++ b/detection-service/src/lib.rs
@@ -10,6 +10,8 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
+use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
+use tracing::Level;
 
 const MAX_BATCH_SIZE: usize = 200;
 
@@ -45,6 +47,11 @@ pub fn build_app(detector: Arc<LanguageDetector>) -> Router {
         .route("/health", get(health))
         .route("/detect", post(detect))
         .route("/detect/batch", post(detect_batch))
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_response(DefaultOnResponse::new().level(Level::INFO)),
+        )
         .with_state(state)
 }
 
@@ -73,7 +80,11 @@ async fn detect(
         )
             .into_response();
     }
-    let result = detect_one(&state.detector, &req.text);
+    let detector = state.detector.clone();
+    let text = req.text;
+    let result = tokio::task::spawn_blocking(move || detect_one(&detector, &text))
+        .await
+        .expect("detection task panicked");
     (StatusCode::OK, Json(result)).into_response()
 }
 


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #37:

1. `/detect` now wraps its detection call in `tokio::task::spawn_blocking`, matching `/detect/batch`. Belt-and-suspenders against runtime starvation under concurrent load.
2. Adds `tower-http::trace::TraceLayer` at INFO level so per-request logs (method, path, status, latency) show up in Railway logs alongside the existing startup events.

No behavior change visible to clients. All 13 tests still pass.

## Test plan

- [ ] Service redeploys clean on Railway
- [ ] `curl /health` still works
- [ ] Logs now show one INFO line per request with status + latency