### PR TITLE
feat: detect language via detection-service

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -164,6 +164,28 @@ CREATE INDEX IF NOT EXISTS idx_lyrics_submitter_created
 -- penalty has already been applied for this row.
 ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS reputation_penalized BOOLEAN DEFAULT FALSE;
 
+-- Language detection metadata.
+-- `language` keeps its semantic meaning (NULL = unknown).
+-- `language_source` records whether the language came from the submitter or
+-- from the detection service ('submitter' or 'detector'). NULL means we never
+-- looked at it (legacy rows).
+-- `language_detector_version` records the version of the detection pipeline.
+-- NULL means the detector was unreachable when the row was last touched, so
+-- the backfill should retry. Non-NULL with the current version means the row
+-- is up to date.
+-- `language_detection_attempted_at` records the last attempt timestamp for
+-- observability.
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_source TEXT
+    CHECK (language_source IS NULL OR language_source IN ('submitter', 'detector'));
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_detector_version SMALLINT;
+ALTER TABLE lyrics ADD COLUMN IF NOT EXISTS language_detection_attempted_at TIMESTAMPTZ;
+
+-- Index for backfill sweep: pick up rows where detector wasn't authoritative.
+CREATE INDEX IF NOT EXISTS idx_lyrics_language_backfill
+    ON lyrics(id)
+    WHERE COALESCE(language_source, 'detector') <> 'submitter'
+      AND deleted_at IS NULL;
+
 -- Lyrics requests: demand signal for songs missing synced lyrics
 CREATE TABLE IF NOT EXISTS requested_songs (
     video_id TEXT PRIMARY KEY,

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,6 +1,7 @@
 import { config } from "@/config"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DETECTOR_VERSION } from "@/utils/detect-language"
 import {
 	findBySongArtist,
 	findByVideoId,
@@ -1257,6 +1258,15 @@ function buildSubmission(over: Partial<LyricsSubmission> = {}): LyricsSubmission
 }
 
 describe("submitLyrics fulfillment integration", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })))
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.restoreAllMocks()
+	})
+
 	it("records a fulfillment for synced submissions with live demand", async () => {
 		const db = createMockDB([
 			{ count: 0 },
@@ -1305,6 +1315,103 @@ describe("submitLyrics fulfillment integration", () => {
 
 		const sqls = db.calls.map((c) => c.sql).join("\n")
 		expect(sqls).not.toMatch(/INSERT INTO request_fulfillments/i)
+	})
+})
+
+describe("submitLyrics language detection", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.restoreAllMocks()
+	})
+
+	it("uses submitter-provided language and marks the source as 'submitter'", async () => {
+		const db = createMockDB([{ count: 0 }, { id: 1001 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+
+		await submitLyrics(env, buildSubmission({ language: "ja", syncType: "plain" }), 7)
+
+		expect(fetchSpy).not.toHaveBeenCalled()
+		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
+		expect(insert).toBeDefined()
+		expect(insert!.sql).toMatch(/language_source/i)
+		expect(insert!.params).toContain("ja")
+		expect(insert!.params).toContain("submitter")
+	})
+
+	it("calls the detection service when submitter did not provide a language and stamps the detected language", async () => {
+		vi.stubEnv("DETECTION_URL", "http://detect.test")
+		const db = createMockDB([{ count: 0 }, { id: 1002 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ iso6391: "ko", confidence: 0.92 }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				})
+			)
+		)
+
+		await submitLyrics(
+			env,
+			buildSubmission({
+				language: undefined,
+				syncType: "plain",
+				lyrics: "[00:00.00] 안녕하세요 반갑습니다",
+			}),
+			7
+		)
+
+		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
+		expect(insert).toBeDefined()
+		expect(insert!.params).toContain("ko")
+		expect(insert!.params).toContain("detector")
+		expect(insert!.params).toContain(DETECTOR_VERSION)
+	})
+
+	it("stamps null language with the current detector version when confidence is low", async () => {
+		vi.stubEnv("DETECTION_URL", "http://detect.test")
+		const db = createMockDB([{ count: 0 }, { id: 1003 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ iso6391: "en", confidence: 0.2 }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				})
+			)
+		)
+
+		await submitLyrics(env, buildSubmission({ language: undefined, syncType: "plain" }), 7)
+
+		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
+		expect(insert).toBeDefined()
+		expect(insert!.params).toContain("detector")
+		expect(insert!.params).toContain(DETECTOR_VERSION)
+		expect(insert!.params).not.toContain("en")
+	})
+
+	it("stamps null language and null version when the detection service is unreachable", async () => {
+		vi.stubEnv("DETECTION_URL", "http://detect.test")
+		const db = createMockDB([{ count: 0 }, { id: 1004 }])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+
+		await submitLyrics(env, buildSubmission({ language: undefined, syncType: "plain" }), 7)
+
+		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
+		expect(insert).toBeDefined()
+		expect(insert!.params).toContain("detector")
+		expect(insert!.params).toContain(null)
+		const versionIdx = insert!.sql.toLowerCase().indexOf("language_detector_version")
+		expect(versionIdx).toBeGreaterThanOrEqual(0)
 	})
 })
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1336,9 +1336,10 @@ describe("submitLyrics language detection", () => {
 		expect(fetchSpy).not.toHaveBeenCalled()
 		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
 		expect(insert).toBeDefined()
-		expect(insert!.sql).toMatch(/language_source/i)
-		expect(insert!.params).toContain("ja")
-		expect(insert!.params).toContain("submitter")
+		const params = insert!.params
+		expect(params[11]).toBe("ja")
+		expect(params[15]).toBe("submitter")
+		expect(params[16]).toBeNull()
 	})
 
 	it("calls the detection service when submitter did not provide a language and stamps the detected language", async () => {
@@ -1368,9 +1369,10 @@ describe("submitLyrics language detection", () => {
 
 		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
 		expect(insert).toBeDefined()
-		expect(insert!.params).toContain("ko")
-		expect(insert!.params).toContain("detector")
-		expect(insert!.params).toContain(DETECTOR_VERSION)
+		const params = insert!.params
+		expect(params[11]).toBe("ko")
+		expect(params[15]).toBe("detector")
+		expect(params[16]).toBe(DETECTOR_VERSION)
 	})
 
 	it("stamps null language with the current detector version when confidence is low", async () => {
@@ -1392,9 +1394,10 @@ describe("submitLyrics language detection", () => {
 
 		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
 		expect(insert).toBeDefined()
-		expect(insert!.params).toContain("detector")
-		expect(insert!.params).toContain(DETECTOR_VERSION)
-		expect(insert!.params).not.toContain("en")
+		const params = insert!.params
+		expect(params[11]).toBeNull()
+		expect(params[15]).toBe("detector")
+		expect(params[16]).toBe(DETECTOR_VERSION)
 	})
 
 	it("stamps null language and null version when the detection service is unreachable", async () => {
@@ -1408,10 +1411,10 @@ describe("submitLyrics language detection", () => {
 
 		const insert = db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))
 		expect(insert).toBeDefined()
-		expect(insert!.params).toContain("detector")
-		expect(insert!.params).toContain(null)
-		const versionIdx = insert!.sql.toLowerCase().indexOf("language_detector_version")
-		expect(versionIdx).toBeGreaterThanOrEqual(0)
+		const params = insert!.params
+		expect(params[11]).toBeNull()
+		expect(params[15]).toBe("detector")
+		expect(params[16]).toBeNull()
 	})
 })
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,7 +1,7 @@
 import { config } from "@/config"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { DETECTOR_VERSION } from "@/utils/detect-language"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	findBySongArtist,
 	findByVideoId,

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -10,6 +10,7 @@ import {
 import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
+import { DETECTOR_VERSION, detectLanguage } from "@/utils/detect-language"
 import { extractPlainText } from "@/utils/extract-text"
 import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
@@ -162,14 +163,35 @@ export async function submitLyrics(
 		return { id: -1, created: false }
 	}
 
+	let language: string | null
+	let languageSource: "submitter" | "detector"
+	let languageDetectorVersion: number | null
+	let languageDetectionAttemptedAt: "NOW" | null
+
+	if (submission.language) {
+		language = submission.language
+		languageSource = "submitter"
+		languageDetectorVersion = null
+		languageDetectionAttemptedAt = null
+	} else {
+		const detected = await detectLanguage(plainText)
+		language = detected.language
+		languageSource = "detector"
+		languageDetectorVersion = detected.ready ? DETECTOR_VERSION : null
+		languageDetectionAttemptedAt = "NOW"
+	}
+
 	const result = await env.DB.prepare(
 		`
 		INSERT INTO lyrics (
 			video_id, song, artist, album, isrc,
 			duration, song_norm, artist_norm, album_norm,
 			lyrics, format, language, sync_type, submitter_id,
-			lyrics_text_search
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?))
+			lyrics_text_search,
+			language_source, language_detector_version, language_detection_attempted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, to_tsvector('simple', ?), ?, ?, ${
+			languageDetectionAttemptedAt === "NOW" ? "NOW()" : "NULL"
+		})
 		RETURNING id
 		`
 	)
@@ -185,10 +207,12 @@ export async function submitLyrics(
 			albumNorm,
 			compressedLyrics,
 			submission.format,
-			submission.language || null,
+			language,
 			submission.syncType,
 			submitterId,
-			plainText
+			plainText,
+			languageSource,
+			languageDetectorVersion
 		)
 		.first<{ id: number }>()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { closePool } from "@/infra/database"
 import { createEnv } from "@/infra/env"
 import { Logger, flushLogs } from "@/infra/logger"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
+import { backfillLanguage } from "@/jobs/backfill-language"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
 import { backfillTextSearch } from "@/jobs/backfill-text-search"
 import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
@@ -228,6 +229,12 @@ backfillFormatDetection(env)
 		if (changed > 0) log.info("format backfill complete", { scanned, changed })
 	})
 	.catch((err) => log.error("format backfill failed", { error: (err as Error).message }))
+
+backfillLanguage(env)
+	.then(({ scanned, updated }) => {
+		if (scanned > 0) log.info("language backfill complete", { scanned, updated })
+	})
+	.catch((err) => log.error("language backfill failed", { error: (err as Error).message }))
 
 cleanupFulfilledRequests(env)
 	.then(({ deleted }) => {

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -179,6 +179,26 @@ describe("backfillLanguage", () => {
 		expect(selects).toHaveLength(2)
 	})
 
+	it("bails when every row in a page returns ready: false (service unavailable)", async () => {
+		const db = createPagedDB([
+			[
+				{ id: 1, lyrics: await compressed("hello world hello world"), format: "plain" },
+				{ id: 2, lyrics: await compressed("bonjour le monde"), format: "plain" },
+			],
+			[{ id: 3, lyrics: await compressed("would never be reached"), format: "plain" }],
+		])
+		const env = buildEnv(db)
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+
+		const result = await backfillLanguage(env)
+
+		expect(result).toEqual({ scanned: 2, updated: 0 })
+		const selects = db.calls.filter((c) => /SELECT/i.test(c.sql))
+		expect(selects).toHaveLength(1)
+		const updates = db.calls.filter((c) => /UPDATE lyrics/i.test(c.sql))
+		expect(updates).toHaveLength(2)
+	})
+
 	it("processes multiple non-empty pages before stopping", async () => {
 		const db = createPagedDB([
 			[{ id: 1, lyrics: await compressed("hello world hello world"), format: "plain" }],

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -178,4 +178,40 @@ describe("backfillLanguage", () => {
 		const selects = db.calls.filter((c) => /SELECT/i.test(c.sql))
 		expect(selects).toHaveLength(2)
 	})
+
+	it("processes multiple non-empty pages before stopping", async () => {
+		const db = createPagedDB([
+			[{ id: 1, lyrics: await compressed("hello world hello world"), format: "plain" }],
+			[{ id: 2, lyrics: await compressed("bonjour le monde bonjour"), format: "plain" }],
+			[],
+		])
+		const env = buildEnv(db)
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({ results: [{ iso6391: "en", confidence: 0.99 }] }),
+						{ status: 200, headers: { "content-type": "application/json" } }
+					)
+				)
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({ results: [{ iso6391: "fr", confidence: 0.92 }] }),
+						{ status: 200, headers: { "content-type": "application/json" } }
+					)
+				)
+		)
+
+		const result = await backfillLanguage(env)
+
+		expect(result).toEqual({ scanned: 2, updated: 2 })
+		const selects = db.calls.filter((c) => /SELECT/i.test(c.sql))
+		expect(selects).toHaveLength(3)
+		const updates = db.calls.filter((c) => /UPDATE lyrics/i.test(c.sql))
+		expect(updates).toHaveLength(2)
+		expect(updates[0].params).toContain("en")
+		expect(updates[1].params).toContain("fr")
+	})
 })

--- a/src/jobs/backfill-language.test.ts
+++ b/src/jobs/backfill-language.test.ts
@@ -1,0 +1,181 @@
+import type { Env, LyricsFormat } from "@/types"
+import { compress } from "@/utils/compression"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { backfillLanguage } from "./backfill-language"
+
+interface Recorded {
+	sql: string
+	params: unknown[]
+}
+
+function createPagedDB(pages: Array<Array<{ id: number; lyrics: string; format: LyricsFormat }>>) {
+	const calls: Recorded[] = []
+	let pageIndex = 0
+	return {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...params: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params })
+							return null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params })
+							if (/SELECT/i.test(sql) && /lyrics/i.test(sql)) {
+								const page = pages[pageIndex++] ?? []
+								return { results: page as unknown as T[] }
+							}
+							return { results: [] as T[] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params })
+						},
+					}
+				},
+			}
+		},
+	}
+}
+
+function buildEnv(db: ReturnType<typeof createPagedDB>): Env {
+	return {
+		DB: db,
+		CACHE: {
+			get: async () => null,
+			put: async () => undefined,
+			delete: async () => undefined,
+			keys: async () => [],
+		},
+		CACHE_TTL_SECONDS: "0",
+		RATE_LIMITER: { check: async () => ({ ok: true, remaining: 0 }) },
+	} as unknown as Env
+}
+
+async function compressed(text: string): Promise<string> {
+	return compress(text)
+}
+
+describe("backfillLanguage", () => {
+	beforeEach(() => {
+		vi.stubEnv("DETECTION_URL", "http://detect.test")
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.restoreAllMocks()
+	})
+
+	it("returns 0/0 and logs a warning when DETECTION_URL is unset", async () => {
+		vi.unstubAllEnvs()
+		const db = createPagedDB([])
+		const env = buildEnv(db)
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+
+		const result = await backfillLanguage(env)
+
+		expect(result).toEqual({ scanned: 0, updated: 0 })
+		expect(fetchSpy).not.toHaveBeenCalled()
+		const select = db.calls.find((c) => /SELECT/i.test(c.sql))
+		expect(select).toBeUndefined()
+	})
+
+	it("stamps detected language and version when the service answers", async () => {
+		const db = createPagedDB([
+			[
+				{
+					id: 1,
+					lyrics: await compressed("안녕하세요 반갑습니다 좋은 하루 되세요"),
+					format: "plain",
+				},
+				{ id: 2, lyrics: await compressed("hello world hello world hello world"), format: "plain" },
+			],
+		])
+		const env = buildEnv(db)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						results: [
+							{ iso6391: "ko", confidence: 0.93 },
+							{ iso6391: "en", confidence: 0.99 },
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } }
+				)
+			)
+		)
+
+		const result = await backfillLanguage(env)
+
+		expect(result).toEqual({ scanned: 2, updated: 2 })
+		const updates = db.calls.filter((c) => /UPDATE lyrics/i.test(c.sql))
+		expect(updates).toHaveLength(2)
+		expect(updates[0].params).toContain("ko")
+		expect(updates[1].params).toContain("en")
+		expect(updates[0].sql).toMatch(/language_source/i)
+		expect(updates[0].sql).toMatch(/language_detector_version/i)
+	})
+
+	it("stamps null language with the current version when confidence is low", async () => {
+		const db = createPagedDB([[{ id: 7, lyrics: await compressed("???"), format: "plain" }]])
+		const env = buildEnv(db)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ results: [{ iso6391: "und", confidence: 0.1 }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				})
+			)
+		)
+
+		const result = await backfillLanguage(env)
+
+		expect(result).toEqual({ scanned: 1, updated: 0 })
+		const update = db.calls.find((c) => /UPDATE lyrics/i.test(c.sql))
+		expect(update).toBeDefined()
+		expect(update!.params[0]).toBeNull()
+	})
+
+	it("stamps null language and null version when the batch errors", async () => {
+		const db = createPagedDB([
+			[{ id: 9, lyrics: await compressed("some text some text some text"), format: "plain" }],
+		])
+		const env = buildEnv(db)
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+
+		const result = await backfillLanguage(env)
+
+		expect(result).toEqual({ scanned: 1, updated: 0 })
+		const update = db.calls.find((c) => /UPDATE lyrics/i.test(c.sql))
+		expect(update).toBeDefined()
+		expect(update!.params.slice(0, 2)).toEqual([null, null])
+	})
+
+	it("stops when a page comes back empty", async () => {
+		const db = createPagedDB([
+			[{ id: 1, lyrics: await compressed("hello world hello world"), format: "plain" }],
+			[],
+		])
+		const env = buildEnv(db)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ results: [{ iso6391: "en", confidence: 0.99 }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				})
+			)
+		)
+
+		const result = await backfillLanguage(env)
+
+		expect(result.scanned).toBe(1)
+		const selects = db.calls.filter((c) => /SELECT/i.test(c.sql))
+		expect(selects).toHaveLength(2)
+	})
+})

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -74,6 +74,12 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 
 		log.info("backfill batch complete", { batch: rows.length, scanned, updated })
 
+		const allFailed = results.every((r) => !r.ready)
+		if (allFailed) {
+			log.warn("detection unavailable, bailing out", { scanned, updated })
+			break
+		}
+
 		await new Promise((resolve) => setImmediate(resolve))
 	}
 

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -6,7 +6,6 @@ import { extractPlainText } from "@/utils/extract-text"
 
 const log = new Logger("backfill-language")
 const BATCH_SIZE = 50
-const MAX_SCANNED = 1_000_000
 
 interface Row {
 	id: number
@@ -23,7 +22,7 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 	let scanned = 0
 	let updated = 0
 
-	while (scanned < MAX_SCANNED) {
+	while (true) {
 		const batch = await env.DB.prepare(
 			`SELECT id, lyrics, format FROM lyrics
 			 WHERE COALESCE(language_source, 'detector') <> 'submitter'
@@ -76,10 +75,6 @@ export async function backfillLanguage(env: Env): Promise<{ scanned: number; upd
 		log.info("backfill batch complete", { batch: rows.length, scanned, updated })
 
 		await new Promise((resolve) => setImmediate(resolve))
-	}
-
-	if (scanned >= MAX_SCANNED) {
-		log.warn("backfill hit scan ceiling", { scanned, updated })
 	}
 
 	return { scanned, updated }

--- a/src/jobs/backfill-language.ts
+++ b/src/jobs/backfill-language.ts
@@ -1,0 +1,86 @@
+import { Logger } from "@/infra/logger"
+import type { Env, LyricsFormat } from "@/types"
+import { decompress, isCompressed } from "@/utils/compression"
+import { DETECTOR_VERSION, detectLanguageBatch } from "@/utils/detect-language"
+import { extractPlainText } from "@/utils/extract-text"
+
+const log = new Logger("backfill-language")
+const BATCH_SIZE = 50
+const MAX_SCANNED = 1_000_000
+
+interface Row {
+	id: number
+	lyrics: string
+	format: LyricsFormat
+}
+
+export async function backfillLanguage(env: Env): Promise<{ scanned: number; updated: number }> {
+	if (!process.env.DETECTION_URL) {
+		log.warn("DETECTION_URL unset, skipping backfill")
+		return { scanned: 0, updated: 0 }
+	}
+
+	let scanned = 0
+	let updated = 0
+
+	while (scanned < MAX_SCANNED) {
+		const batch = await env.DB.prepare(
+			`SELECT id, lyrics, format FROM lyrics
+			 WHERE COALESCE(language_source, 'detector') <> 'submitter'
+			   AND (language_detector_version IS NULL OR language_detector_version < ?)
+			   AND deleted_at IS NULL
+			 ORDER BY id ASC
+			 LIMIT ?`
+		)
+			.bind(DETECTOR_VERSION, BATCH_SIZE)
+			.all<Row>()
+
+		const rows = batch.results || []
+		if (rows.length === 0) break
+
+		const texts: string[] = []
+		for (const row of rows) {
+			try {
+				const content = isCompressed(row.lyrics) ? await decompress(row.lyrics) : row.lyrics
+				texts.push(extractPlainText(content, row.format))
+			} catch (err) {
+				log.warn("decompress/extract failed", { id: row.id, error: (err as Error).message })
+				texts.push("")
+			}
+		}
+
+		const results = await detectLanguageBatch(texts)
+
+		for (let i = 0; i < rows.length; i++) {
+			scanned++
+			const row = rows[i]
+			const result = results[i]
+			const stampVersion = result.ready ? DETECTOR_VERSION : null
+			try {
+				await env.DB.prepare(
+					`UPDATE lyrics
+					 SET language = ?,
+					     language_detector_version = ?,
+					     language_source = 'detector',
+					     language_detection_attempted_at = NOW()
+					 WHERE id = ?`
+				)
+					.bind(result.language, stampVersion, row.id)
+					.run()
+				if (result.language) updated++
+			} catch (err) {
+				log.warn("update failed", { id: row.id, error: (err as Error).message })
+			}
+		}
+
+		log.info("backfill batch complete", { batch: rows.length, scanned, updated })
+
+		await new Promise((resolve) => setImmediate(resolve))
+	}
+
+	if (scanned >= MAX_SCANNED) {
+		log.warn("backfill hit scan ceiling", { scanned, updated })
+	}
+
+	return { scanned, updated }
+}

--- a/src/utils/detect-language.test.ts
+++ b/src/utils/detect-language.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DETECTOR_VERSION, detectLanguage, detectLanguageBatch } from "./detect-language"
+
+const URL = "http://detect.test"
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	})
+}
+
+describe("detectLanguage", () => {
+	beforeEach(() => {
+		vi.stubEnv("DETECTION_URL", URL)
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.restoreAllMocks()
+	})
+
+	it("returns the iso6391 code when confidence is at or above 0.5", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(jsonResponse({ iso6391: "ko", confidence: 0.91 }))
+		)
+
+		const result = await detectLanguage("안녕하세요 반갑습니다")
+
+		expect(result).toEqual({ language: "ko", ready: true })
+	})
+
+	it("returns null language when confidence is below 0.5 but the service answered", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(jsonResponse({ iso6391: "vi", confidence: 0.34 }))
+		)
+
+		const result = await detectLanguage("xin chao")
+
+		expect(result).toEqual({ language: null, ready: true })
+	})
+
+	it("returns null language when the service returns iso6391: null", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(jsonResponse({ iso6391: null, confidence: 0.0 }))
+		)
+
+		const result = await detectLanguage("...")
+
+		expect(result).toEqual({ language: null, ready: true })
+	})
+
+	it("returns ready: false on non-2xx", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "missing text" }, 400)))
+
+		const result = await detectLanguage("hi")
+
+		expect(result).toEqual({ language: null, ready: false })
+	})
+
+	it("returns ready: false on network error", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+
+		const result = await detectLanguage("hi")
+
+		expect(result).toEqual({ language: null, ready: false })
+	})
+
+	it("returns ready: false on abort/timeout", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockRejectedValue(Object.assign(new Error("aborted"), { name: "TimeoutError" }))
+		)
+
+		const result = await detectLanguage("hi")
+
+		expect(result).toEqual({ language: null, ready: false })
+	})
+
+	it("returns ready: false without a fetch call when DETECTION_URL is unset", async () => {
+		vi.unstubAllEnvs()
+		vi.stubEnv("DETECTION_URL", "")
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+
+		const result = await detectLanguage("hi")
+
+		expect(result).toEqual({ language: null, ready: false })
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("returns ready: true with null language for empty input without calling fetch", async () => {
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+
+		expect(await detectLanguage("")).toEqual({ language: null, ready: true })
+		expect(await detectLanguage("   \n\t ")).toEqual({ language: null, ready: true })
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("POSTs text as JSON to /detect", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(jsonResponse({ iso6391: "en", confidence: 0.99 }))
+		vi.stubGlobal("fetch", fetchSpy)
+
+		await detectLanguage("hello there")
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		const [calledUrl, init] = fetchSpy.mock.calls[0]
+		expect(calledUrl).toBe(`${URL}/detect`)
+		expect(init.method).toBe("POST")
+		expect(init.headers["content-type"]).toBe("application/json")
+		expect(JSON.parse(init.body)).toEqual({ text: "hello there" })
+		expect(init.signal).toBeInstanceOf(AbortSignal)
+	})
+})
+
+describe("detectLanguageBatch", () => {
+	beforeEach(() => {
+		vi.stubEnv("DETECTION_URL", URL)
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.restoreAllMocks()
+	})
+
+	it("returns per-item results in input order with threshold applied", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				jsonResponse({
+					results: [
+						{ iso6391: "ko", confidence: 0.9 },
+						{ iso6391: "en", confidence: 0.3 },
+						{ iso6391: null, confidence: 0.0 },
+					],
+				})
+			)
+		)
+
+		const results = await detectLanguageBatch(["안녕", "hi", ""])
+
+		expect(results).toEqual([
+			{ language: "ko", ready: true },
+			{ language: null, ready: true },
+			{ language: null, ready: true },
+		])
+	})
+
+	it("returns an empty array for empty input without calling fetch", async () => {
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+
+		expect(await detectLanguageBatch([])).toEqual([])
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("returns ready: false for every item on non-2xx", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "boom" }, 500)))
+
+		const results = await detectLanguageBatch(["a", "b", "c"])
+
+		expect(results).toEqual([
+			{ language: null, ready: false },
+			{ language: null, ready: false },
+			{ language: null, ready: false },
+		])
+	})
+
+	it("returns ready: false for every item on network error", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")))
+
+		const results = await detectLanguageBatch(["a", "b"])
+
+		expect(results).toEqual([
+			{ language: null, ready: false },
+			{ language: null, ready: false },
+		])
+	})
+
+	it("returns ready: false for every item when DETECTION_URL is unset", async () => {
+		vi.unstubAllEnvs()
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+
+		const results = await detectLanguageBatch(["a", "b"])
+
+		expect(results).toEqual([
+			{ language: null, ready: false },
+			{ language: null, ready: false },
+		])
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("POSTs texts as JSON to /detect/batch with a 30s timeout signal", async () => {
+		const fetchSpy = vi
+			.fn()
+			.mockResolvedValue(jsonResponse({ results: [{ iso6391: "en", confidence: 0.99 }] }))
+		vi.stubGlobal("fetch", fetchSpy)
+
+		await detectLanguageBatch(["hello"])
+
+		const [calledUrl, init] = fetchSpy.mock.calls[0]
+		expect(calledUrl).toBe(`${URL}/detect/batch`)
+		expect(init.method).toBe("POST")
+		expect(JSON.parse(init.body)).toEqual({ texts: ["hello"] })
+		expect(init.signal).toBeInstanceOf(AbortSignal)
+	})
+})
+
+describe("DETECTOR_VERSION", () => {
+	it("is the integer 3", () => {
+		expect(DETECTOR_VERSION).toBe(3)
+	})
+})

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,0 +1,84 @@
+import { Logger } from "@/infra/logger"
+
+const log = new Logger("detect-language")
+
+export const DETECTOR_VERSION = 3
+
+const SINGLE_TIMEOUT_MS = 2_000
+const BATCH_TIMEOUT_MS = 30_000
+const CONFIDENCE_THRESHOLD = 0.5
+
+export interface DetectResult {
+	language: string | null
+	ready: boolean
+}
+
+interface DetectResponse {
+	iso6391: string | null
+	confidence: number
+}
+
+interface BatchResponse {
+	results: DetectResponse[]
+}
+
+function gate(resp: DetectResponse): DetectResult {
+	if (resp.iso6391 && resp.confidence >= CONFIDENCE_THRESHOLD) {
+		return { language: resp.iso6391, ready: true }
+	}
+	return { language: null, ready: true }
+}
+
+function unreachable(count: number): DetectResult[] {
+	return Array.from({ length: count }, () => ({ language: null, ready: false }))
+}
+
+export async function detectLanguage(text: string): Promise<DetectResult> {
+	if (!text.trim()) return { language: null, ready: true }
+
+	const url = process.env.DETECTION_URL
+	if (!url) return { language: null, ready: false }
+
+	try {
+		const res = await fetch(`${url}/detect`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ text }),
+			signal: AbortSignal.timeout(SINGLE_TIMEOUT_MS),
+		})
+		if (!res.ok) {
+			log.warn("detect non-2xx", { status: res.status })
+			return { language: null, ready: false }
+		}
+		const body = (await res.json()) as DetectResponse
+		return gate(body)
+	} catch (err) {
+		log.warn("detect failed", { error: (err as Error).message })
+		return { language: null, ready: false }
+	}
+}
+
+export async function detectLanguageBatch(texts: string[]): Promise<DetectResult[]> {
+	if (texts.length === 0) return []
+
+	const url = process.env.DETECTION_URL
+	if (!url) return unreachable(texts.length)
+
+	try {
+		const res = await fetch(`${url}/detect/batch`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ texts }),
+			signal: AbortSignal.timeout(BATCH_TIMEOUT_MS),
+		})
+		if (!res.ok) {
+			log.warn("batch non-2xx", { status: res.status, n: texts.length })
+			return unreachable(texts.length)
+		}
+		const body = (await res.json()) as BatchResponse
+		return body.results.map(gate)
+	} catch (err) {
+		log.warn("batch failed", { error: (err as Error).message, n: texts.length })
+		return unreachable(texts.length)
+	}
+}


### PR DESCRIPTION
## Summary

Wires the main API to the detection-service deployed in phase 1. New submissions get a language stamp inline, and a startup backfill sweeps existing rows in batches of 50. Failures stamp version NULL so they retry next run, and the backfill bails out on a fully failed page so a degraded service can't hot-loop Postgres.

## Test plan

- [ ] Submit a row with no language, confirm `language_source='detector'` and `language_detector_version=3` in the DB
- [ ] Submit a row with explicit language, confirm `language_source='submitter'` and `version=NULL`
- [ ] Watch startup logs for `language backfill complete { scanned, updated }`