### PR TITLE
Cold-start exploration slot for lyric submissions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,14 @@ export const config = {
 		},
 	},
 
+	exploration: {
+		enabled: true,
+		epsilon: { low: 0.3, medium: 0.1, high: 0.03 },
+		coldMaxVotes: 10,
+		minSubmitterReputation: 0.5,
+		maxChallengers: 10,
+	},
+
 	search: {
 		defaultLimit: 20,
 		maxLimit: 50,

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,7 @@ export const config = {
 	exploration: {
 		enabled: true,
 		epsilon: { low: 0.3, medium: 0.1, high: 0.03 },
-		coldMaxVotes: 10,
+		coldMaxVotes: 5,
 		minSubmitterReputation: 0.5,
 		maxChallengers: 10,
 	},

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1,10 +1,13 @@
 import { config } from "@/config"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
+import { compress } from "@/utils/compression"
 import { DETECTOR_VERSION } from "@/utils/detect-language"
+import { allowedSyncTiers, epsilonForTier, hashBucket } from "@/utils/exploration"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	findBySongArtist,
 	findByVideoId,
+	findEligibleChallengers,
 	findVariantsByVideoId,
 	getLyricsById,
 	invalidateCacheAfterDelete,
@@ -327,6 +330,217 @@ describe("findByVideoId", () => {
 		const rankingIdx = lookupCall!.sql.indexOf(RANKING_EXPR_JOINED)
 		expect(caseIdx).toBeGreaterThan(-1)
 		expect(rankingIdx).toBeGreaterThan(caseIdx)
+	})
+})
+
+describe("findEligibleChallengers", () => {
+	const primary: LyricsRow = { ...baseRow, id: 1, video_id: "vidC", sync_type: "plain" }
+
+	it("emits every eligibility predicate in the generated SQL", async () => {
+		const db = createMockDB([[]])
+		const env = createEnv(db, createMockCache())
+
+		await findEligibleChallengers(env, "vidC", primary)
+
+		const sql = db.calls[0].sql
+		expect(sql).toContain("l.id <> ?")
+		expect(sql).toContain("NOT (")
+		expect(sql).toMatch(/downvotes >= 0\.8 \* l\.vote_count/)
+		expect(sql).toContain("l.reputation_penalized = FALSE")
+		expect(sql).toContain("COALESCE(u.reputation, 0) >= ?")
+		expect(sql).toContain("l.sync_type IN (")
+		expect(sql).toContain("l.vote_count < ?")
+		expect(sql).toContain("FROM reports r WHERE r.lyrics_id = l.id")
+		expect(sql).toMatch(/ORDER BY l\.vote_count ASC, l\.created_at ASC, l\.id ASC/)
+	})
+
+	it("regression: admits default-reputation 1.0 submitters by comparing reputation with >= not > (deadlock fix)", async () => {
+		const db = createMockDB([[]])
+		const env = createEnv(db, createMockCache())
+
+		await findEligibleChallengers(env, "vidC", primary)
+
+		const sql = db.calls[0].sql
+		expect(sql).toContain("COALESCE(u.reputation, 0) >= ?")
+		expect(sql).not.toMatch(/COALESCE\(u\.reputation, 0\) > \?/)
+		expect(config.exploration.minSubmitterReputation).toBeLessThanOrEqual(1.0)
+		expect(db.calls[0].params).toContain(config.exploration.minSubmitterReputation)
+	})
+
+	it("binds all three sync tiers for a plain incumbent", async () => {
+		const db = createMockDB([[]])
+		const env = createEnv(db, createMockCache())
+
+		await findEligibleChallengers(env, "vidC", { ...primary, sync_type: "plain" })
+
+		const expected = [...allowedSyncTiers("plain")]
+		const params = db.calls[0].params
+		for (const tier of expected) {
+			expect(params).toContain(tier)
+		}
+		expect(expected).toHaveLength(3)
+	})
+
+	it("binds only richsync for a richsync incumbent (never downgrades)", async () => {
+		const db = createMockDB([[]])
+		const env = createEnv(db, createMockCache())
+
+		await findEligibleChallengers(env, "vidC", { ...primary, sync_type: "richsync" })
+
+		const expected = [...allowedSyncTiers("richsync")]
+		const params = db.calls[0].params
+		expect(expected).toEqual(["richsync"])
+		expect(params).toContain("richsync")
+		expect(params).not.toContain("linesync")
+		expect(params).not.toContain("plain")
+	})
+
+	it("binds floor, cold cap, reports threshold and overflow limit in order", async () => {
+		const db = createMockDB([[]])
+		const env = createEnv(db, createMockCache())
+
+		await findEligibleChallengers(env, "vidC", { ...primary, sync_type: "richsync" })
+
+		const params = db.calls[0].params
+		expect(params).toEqual([
+			"vidC",
+			primary.id,
+			config.exploration.minSubmitterReputation,
+			"richsync",
+			config.exploration.coldMaxVotes,
+			config.moderation.reportsThreshold,
+			config.exploration.maxChallengers + 1,
+		])
+	})
+
+	it("caps the pool to maxChallengers when the probe overflows", async () => {
+		const overflow = Array.from({ length: config.exploration.maxChallengers + 1 }, (_, i) => ({
+			...baseRow,
+			id: i + 10,
+		}))
+		const db = createMockDB([overflow])
+		const env = createEnv(db, createMockCache())
+
+		const results = await findEligibleChallengers(env, "vidC", primary)
+
+		expect(results).toHaveLength(config.exploration.maxChallengers)
+	})
+
+	it("decompresses challenger lyrics through the real codec", async () => {
+		const compressed = await compress("real lyric body")
+		const db = createMockDB([[{ ...baseRow, id: 2, lyrics: compressed }]])
+		const env = createEnv(db, createMockCache())
+
+		const results = await findEligibleChallengers(env, "vidC", primary)
+
+		expect(results).toHaveLength(1)
+		expect(results[0].lyrics).toBe("real lyric body")
+	})
+})
+
+describe("findByVideoId exploration", () => {
+	const explorePrimary: LyricsRow = {
+		...baseRow,
+		id: 1,
+		video_id: "vidExplore",
+		confidence: "low",
+		sync_type: "plain",
+	}
+	const challenger: LyricsRow = {
+		...baseRow,
+		id: 99,
+		video_id: "vidExplore",
+		sync_type: "plain",
+	}
+	const eps = epsilonForTier("low")
+
+	function cacheWithPrimary() {
+		return createMockCache({ "v:vidExplore": JSON.stringify(explorePrimary) })
+	}
+
+	it("anonymous lookup (no keyId) returns the primary and never queries challengers", async () => {
+		const db = createMockDB([])
+		const env = createEnv(db, cacheWithPrimary())
+
+		const result = await findByVideoId(env, "vidExplore")
+
+		expect(result?.id).toBe(explorePrimary.id)
+		const challengerCall = db.calls.find((c) => c.sql.includes("FROM reports r"))
+		expect(challengerCall).toBeUndefined()
+	})
+
+	it("returns the primary without exploring when the bucket lands above epsilon", async () => {
+		const keyId = "key-0"
+		expect(hashBucket(keyId, "vidExplore")).toBeGreaterThanOrEqual(eps)
+
+		const db = createMockDB([])
+		const env = createEnv(db, cacheWithPrimary())
+
+		const result = await findByVideoId(env, "vidExplore", keyId)
+
+		expect(result?.id).toBe(explorePrimary.id)
+		const challengerCall = db.calls.find((c) => c.sql.includes("FROM reports r"))
+		expect(challengerCall).toBeUndefined()
+	})
+
+	it("serves an eligible challenger when the bucket lands below epsilon", async () => {
+		const keyId = "key-18"
+		expect(hashBucket(keyId, "vidExplore")).toBeLessThan(eps)
+
+		const db = createMockDB([[challenger]])
+		const cache = cacheWithPrimary()
+		const env = createEnv(db, cache)
+
+		const result = await findByVideoId(env, "vidExplore", keyId)
+
+		expect(result?.id).toBe(challenger.id)
+		const cached = JSON.parse(cache.store.get("v:vidExplore") as string) as LyricsRow
+		expect(cached.id).toBe(explorePrimary.id)
+	})
+
+	it("falls back to the primary when no eligible challengers exist", async () => {
+		const keyId = "key-18"
+		expect(hashBucket(keyId, "vidExplore")).toBeLessThan(eps)
+
+		const db = createMockDB([[]])
+		const env = createEnv(db, cacheWithPrimary())
+
+		const result = await findByVideoId(env, "vidExplore", keyId)
+
+		expect(result?.id).toBe(explorePrimary.id)
+	})
+
+	it("kill-switch: returns the primary even for a would-explore bucket when disabled", async () => {
+		const keyId = "key-18"
+		expect(hashBucket(keyId, "vidExplore")).toBeLessThan(eps)
+
+		const db = createMockDB([[challenger]])
+		const env = createEnv(db, cacheWithPrimary())
+		;(config.exploration as { enabled: boolean }).enabled = false
+		try {
+			const result = await findByVideoId(env, "vidExplore", keyId)
+			expect(result?.id).toBe(explorePrimary.id)
+			const challengerCall = db.calls.find((c) => c.sql.includes("FROM reports r"))
+			expect(challengerCall).toBeUndefined()
+		} finally {
+			;(config.exploration as { enabled: boolean }).enabled = true
+		}
+	})
+
+	it("invariant: same (keyId, videoId) and pool selects the same arm on repeat", async () => {
+		const keyId = "key-18"
+		const pool = [
+			{ ...challenger, id: 99, upvotes: 1, downvotes: 0 },
+			{ ...challenger, id: 100, upvotes: 0, downvotes: 1 },
+		]
+
+		const dbA = createMockDB([pool])
+		const first = await findByVideoId(createEnv(dbA, cacheWithPrimary()), "vidExplore", keyId)
+
+		const dbB = createMockDB([pool])
+		const second = await findByVideoId(createEnv(dbB, cacheWithPrimary()), "vidExplore", keyId)
+
+		expect(first?.id).toBe(second?.id)
 	})
 })
 

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -11,11 +11,19 @@ import { Logger } from "@/infra/logger"
 import type { Env, LyricsRow, LyricsSearchResult, LyricsSubmission } from "@/types"
 import { compress, decompress, isCompressed } from "@/utils/compression"
 import { DETECTOR_VERSION, detectLanguage } from "@/utils/detect-language"
+import {
+	allowedSyncTiers,
+	epsilonForTier,
+	hashBucket,
+	hashSeed,
+	selectArm,
+} from "@/utils/exploration"
 import { extractPlainText } from "@/utils/extract-text"
 import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
 
 const log = new Logger("db")
 const cacheLog = new Logger("cache")
+const exploreLog = new Logger("explore")
 
 const LYRICS_WITH_SUBMITTER = `
 	SELECT l.*, u.key_id AS submitter_key_id, u.reputation AS submitter_reputation,
@@ -25,7 +33,7 @@ const LYRICS_WITH_SUBMITTER = `
 	LEFT JOIN users u ON l.submitter_id = u.id
 `
 
-export async function findByVideoId(env: Env, videoId: string): Promise<LyricsRow | null> {
+async function getPrimary(env: Env, videoId: string): Promise<LyricsRow | null> {
 	const cached = await env.CACHE.get(`v:${videoId}`)
 	if (cached) {
 		try {
@@ -59,6 +67,89 @@ export async function findByVideoId(env: Env, videoId: string): Promise<LyricsRo
 	}
 
 	return result
+}
+
+export async function findEligibleChallengers(
+	env: Env,
+	videoId: string,
+	primary: LyricsRow
+): Promise<LyricsRow[]> {
+	const tiers = [...allowedSyncTiers(primary.sync_type)]
+	const tierPlaceholders = tiers.map(() => "?").join(", ")
+
+	const results = await env.DB.prepare(
+		`
+		${LYRICS_WITH_SUBMITTER}
+		WHERE l.video_id = ?
+			AND l.deleted_at IS NULL
+			AND l.id <> ?
+			AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
+			AND l.reputation_penalized = FALSE
+			AND COALESCE(u.reputation, 0) >= ?
+			AND l.sync_type IN (${tierPlaceholders})
+			AND l.vote_count < ?
+			AND (SELECT COUNT(*) FROM reports r WHERE r.lyrics_id = l.id) < ?
+		ORDER BY l.vote_count ASC, l.created_at ASC, l.id ASC
+		LIMIT ?
+		`
+	)
+		.bind(
+			videoId,
+			primary.id,
+			config.exploration.minSubmitterReputation,
+			...tiers,
+			config.exploration.coldMaxVotes,
+			config.moderation.reportsThreshold,
+			config.exploration.maxChallengers + 1
+		)
+		.all<LyricsRow>()
+
+	let rows = results.results
+	if (rows.length > config.exploration.maxChallengers) {
+		exploreLog.info("explore.pool_capped", {
+			videoId,
+			cap: config.exploration.maxChallengers,
+		})
+		rows = rows.slice(0, config.exploration.maxChallengers)
+	}
+
+	for (const row of rows) {
+		if (isCompressed(row.lyrics)) {
+			row.lyrics = await decompress(row.lyrics)
+		}
+	}
+
+	return rows
+}
+
+export async function findByVideoId(
+	env: Env,
+	videoId: string,
+	keyId: string | null = null
+): Promise<LyricsRow | null> {
+	const primary = await getPrimary(env, videoId)
+	if (!primary) return null
+	if (!keyId || !config.exploration.enabled) return primary
+
+	const bucket = hashBucket(keyId, videoId)
+	const eps = epsilonForTier(primary.confidence)
+	if (bucket >= eps) return primary
+
+	const challengers = await findEligibleChallengers(env, videoId, primary)
+	if (challengers.length === 0) return primary
+
+	const arm = selectArm(challengers, hashSeed(keyId, videoId))
+	exploreLog.info("explore.serve", {
+		videoId,
+		incumbentId: primary.id,
+		incumbentConfidence: primary.confidence,
+		eps,
+		bucket,
+		armId: arm.id,
+		armVoteCount: arm.vote_count,
+		poolSize: challengers.length,
+	})
+	return arm
 }
 
 export async function findVariantsByVideoId(

--- a/src/routes/lyrics.explore.test.ts
+++ b/src/routes/lyrics.explore.test.ts
@@ -1,0 +1,210 @@
+import type { Env, LyricsRow } from "@/types"
+import { hashBucket } from "@/utils/exploration"
+import { describe, expect, it } from "vitest"
+import { lyricsRoutes } from "./lyrics"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							return (queue.shift() as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							return { results: (queue.shift() as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+	}
+	return db
+}
+
+function makeMockCache(seed: Record<string, string> = {}) {
+	const store = new Map<string, string>(Object.entries(seed))
+	return {
+		async get(key: string) {
+			return store.get(key) ?? null
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+		async delete(key: string) {
+			store.delete(key)
+		},
+		async keys() {
+			return []
+		},
+		async setNX() {
+			return true
+		},
+	}
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>, cache: ReturnType<typeof makeMockCache>): Env {
+	const limiter = {
+		async limit() {
+			return { success: true }
+		},
+	}
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		RATE_LIMITER: limiter as unknown as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: limiter as unknown as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+	}
+}
+
+const VIDEO_ID = "dQw4w9WgXcQ"
+const EXPLORE_KEY = "k1"
+const CONTROL_KEY = "abc"
+
+function makeLyricsRow(overrides: Partial<LyricsRow> = {}): LyricsRow {
+	return {
+		id: 1,
+		video_id: VIDEO_ID,
+		song: "Song",
+		artist: "Artist",
+		album: null,
+		isrc: null,
+		duration: 200,
+		song_norm: "song",
+		artist_norm: "artist",
+		album_norm: null,
+		lyrics: "plain body",
+		format: "plain",
+		language: null,
+		sync_type: "plain",
+		score: 0,
+		upvotes: 0,
+		downvotes: 0,
+		effective_score: 0,
+		vote_count: 0,
+		diversity_bonus: 1,
+		confidence: "low",
+		lyrics_text_search: null,
+		score_updated_at: null,
+		created_at: 1700000000,
+		updated_at: 1700000000,
+		submitter_id: null,
+		submitter_key_id: null,
+		submitter_reputation: null,
+		submitter_nickname: null,
+		deleted_at: null,
+		deleted_by_user_id: null,
+		deleted_by_role: null,
+		deletion_reason: null,
+		...overrides,
+	}
+}
+
+function seedPrimary(cache: ReturnType<typeof makeMockCache>, primary: LyricsRow) {
+	cache.put(`v:${primary.video_id}`, JSON.stringify(primary))
+}
+
+interface LyricsGetBody {
+	success: boolean
+	data: { id: number; videoId: string; userVote: 1 | -1 | null }
+}
+
+describe("GET /lyrics epsilon exploration threading", () => {
+	it("preconditions: explore key buckets below low-tier epsilon, control key does not", () => {
+		expect(hashBucket(EXPLORE_KEY, VIDEO_ID)).toBeLessThan(0.3)
+		expect(hashBucket(CONTROL_KEY, VIDEO_ID)).toBeGreaterThanOrEqual(0.3)
+	})
+
+	it("serves a challenger when the caller key buckets into the explore window", async () => {
+		const primary = makeLyricsRow({ id: 1, confidence: "low", sync_type: "plain" })
+		const challenger = makeLyricsRow({ id: 2, sync_type: "plain", vote_count: 0 })
+		const cache = makeMockCache()
+		seedPrimary(cache, primary)
+		const db = makeMockDB([null, [challenger], null])
+		const app = lyricsRoutes(makeEnv(db, cache))
+
+		const res = await app.handle(
+			new Request(`http://localhost/lyrics?v=${VIDEO_ID}`, {
+				headers: { "x-key-id": EXPLORE_KEY },
+			})
+		)
+		const body = (await res.json()) as LyricsGetBody
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.data.id).toBe(challenger.id)
+		expect(body.data.videoId).toBe(VIDEO_ID)
+	})
+
+	it("serves the primary unchanged when no x-key-id header is present", async () => {
+		const primary = makeLyricsRow({ id: 1, confidence: "low", sync_type: "plain" })
+		const challenger = makeLyricsRow({ id: 2, sync_type: "plain", vote_count: 0 })
+		const cache = makeMockCache()
+		seedPrimary(cache, primary)
+		const db = makeMockDB([[challenger], null])
+		const app = lyricsRoutes(makeEnv(db, cache))
+
+		const res = await app.handle(new Request(`http://localhost/lyrics?v=${VIDEO_ID}`))
+		const body = (await res.json()) as LyricsGetBody
+
+		expect(res.status).toBe(200)
+		expect(body.data.id).toBe(primary.id)
+	})
+
+	it("serves the primary when the caller key buckets outside the explore window", async () => {
+		const primary = makeLyricsRow({ id: 1, confidence: "low", sync_type: "plain" })
+		const challenger = makeLyricsRow({ id: 2, sync_type: "plain", vote_count: 0 })
+		const cache = makeMockCache()
+		seedPrimary(cache, primary)
+		const db = makeMockDB([null, [challenger], null])
+		const app = lyricsRoutes(makeEnv(db, cache))
+
+		const res = await app.handle(
+			new Request(`http://localhost/lyrics?v=${VIDEO_ID}`, {
+				headers: { "x-key-id": CONTROL_KEY },
+			})
+		)
+		const body = (await res.json()) as LyricsGetBody
+
+		expect(res.status).toBe(200)
+		expect(body.data.id).toBe(primary.id)
+	})
+
+	it("reflects the served arm in the response payload, not the incumbent", async () => {
+		const primary = makeLyricsRow({ id: 1, song: "Primary Song", confidence: "low" })
+		const challenger = makeLyricsRow({ id: 2, song: "Challenger Song", sync_type: "plain" })
+		const cache = makeMockCache()
+		seedPrimary(cache, primary)
+		const db = makeMockDB([null, [challenger], null])
+		const app = lyricsRoutes(makeEnv(db, cache))
+
+		const res = await app.handle(
+			new Request(`http://localhost/lyrics?v=${VIDEO_ID}`, {
+				headers: { "x-key-id": EXPLORE_KEY },
+			})
+		)
+		const body = (await res.json()) as { data: { id: number; song: string } }
+
+		expect(body.data.id).toBe(challenger.id)
+		expect(body.data.song).toBe(challenger.song)
+	})
+})

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -74,7 +74,11 @@ export const lyricsRoutes = (env: Env) =>
 				}
 			}
 			if (!keyId) {
-				return { lyricsUserId: null as number | null, lyricsBearerUserId: null as number | null }
+				return {
+					lyricsUserId: null as number | null,
+					lyricsBearerUserId: null as number | null,
+					lyricsKeyId: null as string | null,
+				}
 			}
 			const user = await env.DB.prepare("SELECT id FROM users WHERE key_id = ?")
 				.bind(keyId)
@@ -83,13 +87,14 @@ export const lyricsRoutes = (env: Env) =>
 			return {
 				lyricsUserId: userId,
 				lyricsBearerUserId: bearerVerified ? userId : null,
+				lyricsKeyId: keyId,
 			}
 		})
 		.get(
 			"/",
-			async ({ query, env, lyricsUserId, status }) => {
+			async ({ query, env, lyricsUserId, lyricsKeyId, status }) => {
 				if (query.v) {
-					const result = await findByVideoId(env, query.v)
+					const result = await findByVideoId(env, query.v, lyricsKeyId)
 					if (!result) {
 						return status(404, buildError(ErrorCode.NOT_FOUND))
 					}

--- a/src/utils/exploration.test.ts
+++ b/src/utils/exploration.test.ts
@@ -1,0 +1,207 @@
+import { config } from "@/config"
+import type { Confidence } from "@/types"
+import { describe, expect, it } from "vitest"
+import { allowedSyncTiers, epsilonForTier, hashBucket, hashSeed, selectArm } from "./exploration"
+
+describe("hashBucket", () => {
+	it("is always in [0, 1)", () => {
+		for (let i = 0; i < 1000; i++) {
+			const bucket = hashBucket(`key-${i}`, `video-${i % 37}`)
+			expect(bucket).toBeGreaterThanOrEqual(0)
+			expect(bucket).toBeLessThan(1)
+		}
+	})
+
+	it("is deterministic for identical inputs", () => {
+		expect(hashBucket("abc", "xyz")).toBe(hashBucket("abc", "xyz"))
+		expect(hashBucket("user-1", "dQw4w9WgXcQ")).toBe(hashBucket("user-1", "dQw4w9WgXcQ"))
+	})
+
+	it("changes when keyId changes", () => {
+		expect(hashBucket("key-a", "video-1")).not.toBe(hashBucket("key-b", "video-1"))
+	})
+
+	it("changes when videoId changes", () => {
+		expect(hashBucket("key-a", "video-1")).not.toBe(hashBucket("key-a", "video-2"))
+	})
+
+	it("spreads across multiple deciles", () => {
+		const deciles = new Set<number>()
+		for (let i = 0; i < 1000; i++) {
+			const bucket = hashBucket(`spread-${i}`, "dQw4w9WgXcQ")
+			deciles.add(Math.floor(bucket * 10))
+		}
+		expect(deciles.size).toBeGreaterThan(1)
+	})
+})
+
+describe("hashSeed", () => {
+	it("returns an unsigned 32-bit integer", () => {
+		for (let i = 0; i < 1000; i++) {
+			const seed = hashSeed(`key-${i}`, `video-${i}`)
+			expect(Number.isInteger(seed)).toBe(true)
+			expect(seed).toBeGreaterThanOrEqual(0)
+			expect(seed).toBeLessThanOrEqual(0xffffffff)
+		}
+	})
+
+	it("is deterministic for identical inputs", () => {
+		expect(hashSeed("abc", "xyz")).toBe(hashSeed("abc", "xyz"))
+	})
+
+	it("agrees with hashBucket on the same key", () => {
+		expect(hashSeed("user-1", "video-1") / 0x100000000).toBe(hashBucket("user-1", "video-1"))
+	})
+})
+
+describe("epsilonForTier", () => {
+	it("maps low to the configured low epsilon", () => {
+		expect(epsilonForTier("low")).toBe(config.exploration.epsilon.low)
+	})
+
+	it("maps medium to the configured medium epsilon", () => {
+		expect(epsilonForTier("medium")).toBe(config.exploration.epsilon.medium)
+	})
+
+	it("maps high to the configured high epsilon", () => {
+		expect(epsilonForTier("high")).toBe(config.exploration.epsilon.high)
+	})
+})
+
+describe("allowedSyncTiers", () => {
+	it("never downgrades a richsync incumbent", () => {
+		const tiers = allowedSyncTiers("richsync")
+		expect(tiers).toEqual(new Set(["richsync"]))
+	})
+
+	it("allows linesync to be replaced by linesync or richsync", () => {
+		const tiers = allowedSyncTiers("linesync")
+		expect(tiers).toEqual(new Set(["linesync", "richsync"]))
+	})
+
+	it("allows plain to be replaced by any sync type", () => {
+		const tiers = allowedSyncTiers("plain")
+		expect(tiers).toEqual(new Set(["plain", "linesync", "richsync"]))
+	})
+})
+
+describe("selectArm", () => {
+	it("returns a member of the pool", () => {
+		const arms = [
+			{ id: "a", upvotes: 2, downvotes: 1 },
+			{ id: "b", upvotes: 5, downvotes: 0 },
+			{ id: "c", upvotes: 0, downvotes: 3 },
+		]
+		const chosen = selectArm(arms, hashSeed("user-1", "video-1"))
+		expect(arms).toContain(chosen)
+	})
+
+	it("returns the single arm for a one-element pool", () => {
+		const arms = [{ id: "only", upvotes: 0, downvotes: 0 }]
+		expect(selectArm(arms, 12345)).toBe(arms[0])
+	})
+
+	it("exploits a strongly upvoted arm over a downvoted one", () => {
+		const arms = [
+			{ id: "good", upvotes: 9, downvotes: 0 },
+			{ id: "bad", upvotes: 0, downvotes: 9 },
+		]
+		let goodCount = 0
+		for (let seed = 0; seed < 500; seed++) {
+			if (selectArm(arms, seed).id === "good") goodCount++
+		}
+		expect(goodCount).toBeGreaterThan(450)
+	})
+})
+
+describe("edge cases", () => {
+	it("epsilonForTier returns 0 for an out-of-union value", () => {
+		expect(epsilonForTier("bogus" as Confidence)).toBe(0)
+	})
+
+	it("selectArm throws on an empty pool", () => {
+		expect(() => selectArm([], 1)).toThrow("selectArm: empty pool")
+	})
+
+	it("hashBucket handles empty strings", () => {
+		const bucket = hashBucket("", "")
+		expect(bucket).toBeGreaterThanOrEqual(0)
+		expect(bucket).toBeLessThan(1)
+	})
+
+	it("selectArm handles all-zero-vote arms without crashing", () => {
+		const arms = [
+			{ id: "a", upvotes: 0, downvotes: 0 },
+			{ id: "b", upvotes: 0, downvotes: 0 },
+		]
+		expect(arms).toContain(selectArm(arms, 7))
+	})
+})
+
+describe("invariants", () => {
+	it("allowedSyncTiers for richsync never contains plain or linesync", () => {
+		const tiers = allowedSyncTiers("richsync")
+		expect(tiers.has("plain")).toBe(false)
+		expect(tiers.has("linesync")).toBe(false)
+	})
+
+	it("selectArm is deterministic per (arms, seed)", () => {
+		const arms = [
+			{ id: "a", upvotes: 3, downvotes: 2 },
+			{ id: "b", upvotes: 1, downvotes: 4 },
+			{ id: "c", upvotes: 6, downvotes: 1 },
+		]
+		expect(selectArm(arms, 99)).toBe(selectArm(arms, 99))
+	})
+
+	it("selectArm does not mutate the input array", () => {
+		const arms = [
+			{ id: "a", upvotes: 1, downvotes: 0 },
+			{ id: "b", upvotes: 0, downvotes: 1 },
+			{ id: "c", upvotes: 2, downvotes: 2 },
+		]
+		const snapshot = [...arms]
+		selectArm(arms, 42)
+		expect(arms).toEqual(snapshot)
+		expect(arms[0].id).toBe("a")
+		expect(arms[1].id).toBe("b")
+		expect(arms[2].id).toBe("c")
+	})
+
+	it("selectArm explores more than one distinct arm when all votes are zero", () => {
+		const arms = [
+			{ id: "a", upvotes: 0, downvotes: 0 },
+			{ id: "b", upvotes: 0, downvotes: 0 },
+			{ id: "c", upvotes: 0, downvotes: 0 },
+		]
+		const picked = new Set<string>()
+		for (let seed = 0; seed < 200; seed++) {
+			picked.add(selectArm(arms, seed).id)
+		}
+		expect(picked.size).toBeGreaterThan(1)
+	})
+})
+
+describe("regressions", () => {
+	it("selectArm never produces NaN or Infinity theta across a wide seed sweep", () => {
+		const arms = [
+			{ id: "a", upvotes: 0, downvotes: 0 },
+			{ id: "b", upvotes: 100, downvotes: 0 },
+			{ id: "c", upvotes: 0, downvotes: 100 },
+		]
+		for (let seed = 0; seed < 2000; seed++) {
+			const chosen = selectArm(arms, seed)
+			expect(arms).toContain(chosen)
+		}
+	})
+
+	it("selectArm guards uniforms into (0, 1] so ln never sees zero", () => {
+		const arms = [
+			{ id: "a", upvotes: 0, downvotes: 0 },
+			{ id: "b", upvotes: 0, downvotes: 0 },
+		]
+		for (let seed = 0; seed < 100; seed++) {
+			expect(arms).toContain(selectArm(arms, seed))
+		}
+	})
+})

--- a/src/utils/exploration.ts
+++ b/src/utils/exploration.ts
@@ -1,0 +1,85 @@
+import { config } from "@/config"
+import type { Confidence } from "@/types"
+
+type SyncType = "richsync" | "linesync" | "plain"
+
+function hash32(str: string): number {
+	let h = 0
+	for (let i = 0; i < str.length; i++) {
+		h = (h << 5) - h + str.charCodeAt(i)
+		h |= 0
+	}
+	return h >>> 0
+}
+
+export function hashBucket(keyId: string, videoId: string): number {
+	return hash32(`${keyId}:${videoId}`) / 0x100000000
+}
+
+export function hashSeed(keyId: string, videoId: string): number {
+	return hash32(`${keyId}:${videoId}`)
+}
+
+export function epsilonForTier(confidence: Confidence): number {
+	return config.exploration.epsilon[confidence] ?? 0
+}
+
+export function allowedSyncTiers(incumbentSyncType: SyncType): Set<SyncType> {
+	switch (incumbentSyncType) {
+		case "richsync":
+			return new Set(["richsync"])
+		case "linesync":
+			return new Set(["linesync", "richsync"])
+		case "plain":
+			return new Set(["plain", "linesync", "richsync"])
+	}
+}
+
+function mulberry32(seed: number) {
+	let a = seed >>> 0
+	return () => {
+		a = (a + 0x6d2b79f5) | 0
+		let t = Math.imul(a ^ (a >>> 15), 1 | a)
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+function gammaInt(shape: number, rand: () => number): number {
+	let sum = 0
+	for (let i = 0; i < shape; i++) {
+		// map [0, 1) to (0, 1] so the log argument is never zero
+		const u = 1 - rand()
+		sum -= Math.log(u)
+	}
+	return sum
+}
+
+export function selectArm<T extends { upvotes: number; downvotes: number }>(
+	challengers: T[],
+	seed: number
+): T {
+	if (challengers.length === 0) {
+		throw new Error("selectArm: empty pool")
+	}
+	if (challengers.length === 1) {
+		return challengers[0]
+	}
+
+	const rand = mulberry32(seed)
+	let best = challengers[0]
+	let bestTheta = -1
+
+	for (const arm of challengers) {
+		const ga = gammaInt(arm.upvotes + 1, rand)
+		const gb = gammaInt(arm.downvotes + 1, rand)
+		const total = ga + gb
+		const theta = total === 0 ? 0.5 : ga / total
+		if (theta > bestTheta) {
+			bestTheta = theta
+			best = arm
+		}
+	}
+
+	return best
+}


### PR DESCRIPTION
New submissions for a song that already has a winner never get served, so they never earn the votes they need to win. This serves a challenger in the primary slot once in a while so it can collect real votes and get promoted by the existing ranking.

- `hash(x-key-id + videoId)` buckets each user. Under epsilon, serve an eligible challenger; otherwise the primary, exactly as before.
- Epsilon keys on the incumbent's confidence: low 0.30, medium 0.10, high 0.03.
- Among challengers, pick one by Thompson sampling over existing vote counts. No impression tracking.
- The exploit path (most traffic) is unchanged and still cache-hot. Challengers are never cached.

Backend only. The shipped extension already sends `x-key-id` and votes/reports against the served `id`, so no client change is needed. Legacy `/getLyrics` is left untouched...