### PR TITLE
Retune low-volume thresholds to the real vote distribution

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -27,8 +27,8 @@ describe("config.thresholdAudit", () => {
 		const t = config.thresholdAudit.targets
 		expect(t.minVotesForConfidence).toEqual({ targetFraction: 0.25, floor: 2, ceil: 10 })
 		expect(t.primarySlotMinVotes).toEqual({ targetFraction: 0.2, floor: 2, ceil: 10 })
-		expect(t.autoHideMinVotes).toEqual({ targetFraction: 0.5, floor: 2, ceil: 10 })
+		expect(t.autoHideMinVotes).toEqual({ targetFraction: 0.15, floor: 2, ceil: 10 })
 		expect(t.autoHideDecisiveMinVotes).toEqual({ targetFraction: 0.5, floor: 2, ceil: 10 })
-		expect(t.reportsThreshold).toEqual({ targetFraction: 0.1, floor: 2, ceil: 10 })
+		expect(t.reportsThreshold).toEqual({ targetFraction: 0.15, floor: 2, ceil: 10 })
 	})
 })

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -15,3 +15,20 @@ describe("config additions for abuse mitigation", () => {
 		expect(config.ranking.primarySlot.minVotes).toBe(3)
 	})
 })
+
+describe("config.thresholdAudit", () => {
+	it("is disabled-safe and carries a daily schedule and tolerance", () => {
+		expect(typeof config.thresholdAudit.enabled).toBe("boolean")
+		expect(config.thresholdAudit.schedule).toBe("0 9 * * *")
+		expect(config.thresholdAudit.driftTolerance).toBe(0.1)
+	})
+
+	it("defines target/floor/ceil for every audited threshold", () => {
+		const t = config.thresholdAudit.targets
+		expect(t.minVotesForConfidence).toEqual({ targetFraction: 0.25, floor: 2, ceil: 10 })
+		expect(t.primarySlotMinVotes).toEqual({ targetFraction: 0.2, floor: 2, ceil: 10 })
+		expect(t.autoHideMinVotes).toEqual({ targetFraction: 0.5, floor: 2, ceil: 10 })
+		expect(t.autoHideDecisiveMinVotes).toEqual({ targetFraction: 0.5, floor: 2, ceil: 10 })
+		expect(t.reportsThreshold).toEqual({ targetFraction: 0.1, floor: 2, ceil: 10 })
+	})
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,19 @@ export const config = {
 		maxChallengers: 10,
 	},
 
+	thresholdAudit: {
+		enabled: true,
+		schedule: "0 9 * * *",
+		driftTolerance: 0.1,
+		targets: {
+			minVotesForConfidence: { targetFraction: 0.25, floor: 2, ceil: 10 },
+			primarySlotMinVotes: { targetFraction: 0.2, floor: 2, ceil: 10 },
+			autoHideMinVotes: { targetFraction: 0.5, floor: 2, ceil: 10 },
+			autoHideDecisiveMinVotes: { targetFraction: 0.5, floor: 2, ceil: 10 },
+			reportsThreshold: { targetFraction: 0.1, floor: 2, ceil: 10 },
+		},
+	},
+
 	search: {
 		defaultLimit: 20,
 		maxLimit: 50,

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,12 +4,12 @@ export const config = {
 	},
 
 	moderation: {
-		reportsThreshold: 5,
+		reportsThreshold: 2,
 		autoHide: {
-			minVotes: 5,
+			minVotes: 3,
 			downvoteRatio: 0.8,
 			maxEffectiveScore: -0.5,
-			decisiveMinVotes: 3,
+			decisiveMinVotes: 2,
 			decisiveMinAgeDays: 3,
 			reputationPenalty: 0.2,
 		},
@@ -32,7 +32,7 @@ export const config = {
 		max: 2.0,
 		consensusDelta: 0.1,
 		selfVoteWeight: 0.5,
-		minVotesForConfidence: 5,
+		minVotesForConfidence: 3,
 		voteWeightFloor: 0.5,
 	},
 
@@ -65,9 +65,9 @@ export const config = {
 		targets: {
 			minVotesForConfidence: { targetFraction: 0.25, floor: 2, ceil: 10 },
 			primarySlotMinVotes: { targetFraction: 0.2, floor: 2, ceil: 10 },
-			autoHideMinVotes: { targetFraction: 0.5, floor: 2, ceil: 10 },
+			autoHideMinVotes: { targetFraction: 0.15, floor: 2, ceil: 10 },
 			autoHideDecisiveMinVotes: { targetFraction: 0.5, floor: 2, ceil: 10 },
-			reportsThreshold: { targetFraction: 0.1, floor: 2, ceil: 10 },
+			reportsThreshold: { targetFraction: 0.15, floor: 2, ceil: 10 },
 		},
 	},
 

--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -1394,14 +1394,14 @@ describe("read paths filter deleted rows", () => {
 })
 
 describe("AUTO_HIDE_PREDICATE", () => {
-	it("encodes the standard path: 5 votes, 80% downvotes, effective_score < -0.5", () => {
-		expect(AUTO_HIDE_PREDICATE).toContain("vote_count >= 5")
+	it("encodes the standard path: 3 votes, 80% downvotes, effective_score < -0.5", () => {
+		expect(AUTO_HIDE_PREDICATE).toContain("vote_count >= 3")
 		expect(AUTO_HIDE_PREDICATE).toContain("downvotes >= 0.8 * vote_count")
 		expect(AUTO_HIDE_PREDICATE).toContain("effective_score < -0.5")
 	})
 
-	it("encodes the decisive path: 3 unanimous downvotes aged 3 days", () => {
-		expect(AUTO_HIDE_PREDICATE).toContain("vote_count >= 3")
+	it("encodes the decisive path: 2 unanimous downvotes aged 3 days", () => {
+		expect(AUTO_HIDE_PREDICATE).toContain("vote_count >= 2")
 		expect(AUTO_HIDE_PREDICATE).toContain("downvotes = vote_count")
 		expect(AUTO_HIDE_PREDICATE).toContain("- created_at >= 259200")
 	})

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { closeRedis } from "@/infra/cache"
 import { closePool } from "@/infra/database"
 import { createEnv } from "@/infra/env"
 import { Logger, flushLogs } from "@/infra/logger"
+import { backfillConfidence } from "@/jobs/backfill-confidence"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
 import { backfillLanguage } from "@/jobs/backfill-language"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
@@ -254,13 +255,17 @@ backfillLanguage(env)
 	})
 	.catch((err) => log.error("language backfill failed", { error: (err as Error).message }))
 
+backfillConfidence(env)
+	.then(({ updated }) => {
+		if (updated > 0) log.info("confidence backfill complete", { updated })
+	})
+	.catch((err) => log.error("confidence backfill failed", { error: (err as Error).message }))
+
 cleanupFulfilledRequests(env)
 	.then(({ deleted }) => {
 		if (deleted > 0) log.info("cleanup fulfilled requests complete", { deleted })
 	})
-	.catch((err) =>
-		log.error("cleanup fulfilled requests failed", { error: (err as Error).message }),
-	)
+	.catch((err) => log.error("cleanup fulfilled requests failed", { error: (err as Error).message }))
 
 process.on("unhandledRejection", (reason) => {
 	const err = reason instanceof Error ? reason : new Error(String(reason))

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { backfillTextSearch } from "@/jobs/backfill-text-search"
 import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
 import { runDumpJob } from "@/jobs/dump"
 import { updateScores } from "@/jobs/score-updater"
+import { auditThresholds } from "@/jobs/threshold-audit"
 import { authRoutes } from "@/routes/auth"
 import { compatRoutes } from "@/routes/compat"
 import { feedRoutes } from "@/routes/feed"
@@ -115,6 +116,19 @@ const app = new Elysia({ adapter: node() })
 				} else {
 					cronLog.info("daily dump complete", result)
 				}
+			},
+		})
+	)
+	.use(
+		cron({
+			name: "threshold-audit",
+			pattern: config.thresholdAudit.schedule,
+			timezone: "UTC",
+			async run() {
+				if (!config.thresholdAudit.enabled) return
+				cronLog.info("starting threshold check")
+				const result = await auditThresholds(env)
+				cronLog.info("threshold check complete", result)
 			},
 		})
 	)

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,13 @@ const app = new Elysia({ adapter: node() })
 			timezone: "UTC",
 			async run() {
 				if (!config.thresholdAudit.enabled) return
-				cronLog.info("starting threshold check")
-				const result = await auditThresholds(env)
-				cronLog.info("threshold check complete", result)
+				try {
+					cronLog.info("starting threshold check")
+					const result = await auditThresholds(env)
+					cronLog.info("threshold check complete", result)
+				} catch (err) {
+					cronLog.error("threshold check failed", { error: (err as Error).message })
+				}
 			},
 		})
 	)

--- a/src/jobs/backfill-confidence.test.ts
+++ b/src/jobs/backfill-confidence.test.ts
@@ -1,0 +1,124 @@
+import { config } from "@/config"
+import type { Env } from "@/types"
+import { describe, expect, it } from "vitest"
+import { backfillConfidence } from "./backfill-confidence"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(scripted: Array<unknown[] | unknown>) {
+	const calls: DBCall[] = []
+	const queue = [...scripted]
+	const db = {
+		calls,
+		prepare(sql: string) {
+			const stmt = {
+				bind(..._args: unknown[]) {
+					return stmt
+				},
+				async first<T>(): Promise<T | null> {
+					calls.push({ sql, params: [] })
+					const next = queue.shift()
+					return (next as T) ?? null
+				},
+				async all<T>(): Promise<{ results: T[] }> {
+					calls.push({ sql, params: [] })
+					const next = queue.shift()
+					return { results: (next as T[]) ?? [] }
+				},
+				async run(): Promise<void> {
+					calls.push({ sql, params: [] })
+					queue.shift()
+				},
+			}
+			return stmt
+		},
+	}
+	return db
+}
+
+function makeMockCache(initial: Record<string, string> = {}) {
+	const store = new Map(Object.entries(initial))
+	const deleteCalls: string[] = []
+	const keysCalls: string[] = []
+	return {
+		store,
+		deleteCalls,
+		keysCalls,
+		async get(key: string) {
+			return store.get(key) ?? null
+		},
+		async put() {},
+		async delete(key: string) {
+			deleteCalls.push(key)
+			store.delete(key)
+		},
+		async keys(pattern: string) {
+			keysCalls.push(pattern)
+			const re = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`)
+			return [...store.keys()].filter((k) => re.test(k))
+		},
+		async setNX() {
+			return true
+		},
+	}
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>, cache: ReturnType<typeof makeMockCache>): Env {
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		RATE_LIMITER: {} as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+	}
+}
+
+describe("backfillConfidence", () => {
+	it("recomputes tiers and invalidates cache for each changed video", async () => {
+		const db = makeMockDB([
+			[
+				{ id: 1, video_id: "vidA" },
+				{ id: 2, video_id: "vidA" },
+				{ id: 3, video_id: "vidB" },
+			],
+			undefined,
+		])
+		const cache = makeMockCache()
+		const env = makeEnv(db, cache)
+
+		const result = await backfillConfidence(env)
+
+		expect(result.updated).toBe(3)
+		expect(cache.deleteCalls.sort()).toEqual(["v:vidA", "v:vidB"])
+		expect(db.calls.some((c) => /UPDATE\s+lyrics/i.test(c.sql))).toBe(true)
+	})
+
+	it("is idempotent: no changed rows means no UPDATE and no cache invalidation", async () => {
+		const db = makeMockDB([[]])
+		const cache = makeMockCache()
+		const env = makeEnv(db, cache)
+
+		const result = await backfillConfidence(env)
+
+		expect(result.updated).toBe(0)
+		expect(cache.deleteCalls).toEqual([])
+		expect(db.calls.some((c) => /UPDATE\s+lyrics/i.test(c.sql))).toBe(false)
+	})
+
+	it("uses the configured confidence threshold and excludes deleted rows", async () => {
+		const db = makeMockDB([[]])
+		const env = makeEnv(db, makeMockCache())
+		await backfillConfidence(env)
+		const selectSql = db.calls[0].sql
+		expect(selectSql).toContain(`vote_count >= ${config.reputation.minVotesForConfidence}`)
+		expect(selectSql).toContain("diversity_bonus = 1")
+		expect(selectSql).toContain("deleted_at IS NULL")
+	})
+})

--- a/src/jobs/backfill-confidence.ts
+++ b/src/jobs/backfill-confidence.ts
@@ -1,0 +1,36 @@
+import { config } from "@/config"
+import { invalidateCache } from "@/db/lyrics"
+import { Logger } from "@/infra/logger"
+import type { Env } from "@/types"
+
+const log = new Logger("backfill")
+
+export async function backfillConfidence(env: Env): Promise<{ updated: number }> {
+	const threshold = config.reputation.minVotesForConfidence
+	// Reproduces the confidence rule in calculateScore (score-updater.ts) in SQL.
+	// If that rule changes, update this expression to match.
+	const tierExpr = `CASE
+			WHEN vote_count >= ${threshold} AND diversity_bonus = 1 THEN 'high'
+			WHEN vote_count >= ${threshold} THEN 'medium'
+			ELSE 'low'
+		END`
+
+	const changed = await env.DB.prepare(
+		`SELECT id, video_id FROM lyrics WHERE deleted_at IS NULL AND confidence <> ${tierExpr}`
+	).all<{ id: number; video_id: string }>()
+
+	const rows = changed.results || []
+	if (rows.length === 0) return { updated: 0 }
+
+	await env.DB.prepare(
+		`UPDATE lyrics SET confidence = ${tierExpr} WHERE deleted_at IS NULL AND confidence <> ${tierExpr}`
+	).run()
+
+	const videoIds = [...new Set(rows.map((r) => r.video_id))]
+	for (const videoId of videoIds) {
+		await invalidateCache(env, videoId)
+	}
+
+	log.info("confidence backfill complete", { updated: rows.length, videos: videoIds.length })
+	return { updated: rows.length }
+}

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -117,7 +117,7 @@ describe("calculateScore", () => {
 		expect(result.diversity_bonus).toBe(0)
 	})
 
-	it("returns low confidence for fewer than 5 votes", () => {
+	it("returns low confidence for fewer than 3 votes", () => {
 		const votes = [
 			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
 			{ vote: 1, reputation: 1.0, avg_vote: -0.5, is_self_vote: 0 },
@@ -128,8 +128,8 @@ describe("calculateScore", () => {
 		expect(result.confidence).toBe("low")
 	})
 
-	it("returns medium confidence for 5+ votes without diversity", () => {
-		const votes = Array.from({ length: 5 }, () => ({
+	it("returns medium confidence for 3+ votes without diversity", () => {
+		const votes = Array.from({ length: 3 }, () => ({
 			vote: 1,
 			reputation: 1.0,
 			avg_vote: 0.5,
@@ -141,13 +141,11 @@ describe("calculateScore", () => {
 		expect(result.confidence).toBe("medium")
 	})
 
-	it("returns high confidence for 5+ votes with diversity", () => {
+	it("returns high confidence for 3+ votes with diversity", () => {
 		const votes = [
 			{ vote: 1, reputation: 1.0, avg_vote: -0.5, is_self_vote: 0 },
 			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
 			{ vote: 1, reputation: 1.0, avg_vote: 0.3, is_self_vote: 0 },
-			{ vote: 1, reputation: 1.0, avg_vote: 0.2, is_self_vote: 0 },
-			{ vote: 1, reputation: 1.0, avg_vote: -0.1, is_self_vote: 0 },
 		]
 
 		const result = calculateScore(1, votes)
@@ -517,7 +515,7 @@ describe("reputation bounds", () => {
 	})
 
 	it("config has correct minimum votes for confidence", () => {
-		expect(config.reputation.minVotesForConfidence).toBe(5)
+		expect(config.reputation.minVotesForConfidence).toBe(3)
 	})
 
 	it("config has correct consensus delta", () => {

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -165,7 +165,8 @@ export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsS
 	const effectiveScore = totalWeight > 0 ? weightedSum / totalWeight : 0
 	const diversityBonus = harshUpvotes > 0 && generousUpvotes > 0
 
-	// Determine confidence level
+	// Determine confidence level. This rule is also reproduced in SQL by
+	// backfill-confidence.ts; keep the two in sync.
 	let confidence: Confidence = "low"
 	if (votes.length >= config.reputation.minVotesForConfidence) {
 		confidence = diversityBonus ? "high" : "medium"

--- a/src/jobs/threshold-audit.test.ts
+++ b/src/jobs/threshold-audit.test.ts
@@ -1,3 +1,4 @@
+import { config } from "@/config"
 import { auditThresholds } from "@/jobs/threshold-audit"
 import type { Env } from "@/types"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -8,10 +9,11 @@ function histRow(total: number, counts: Partial<Record<number, number>>) {
 	return row
 }
 
-function makeEnv(scriptedRows: unknown[], cache: Map<string, string>): Env {
+function makeEnv(scriptedRows: unknown[], cache: Map<string, string>, sqls: string[] = []): Env {
 	const queue = [...scriptedRows]
 	const db = {
-		prepare() {
+		prepare(sql: string) {
+			sqls.push(sql)
 			return {
 				bind() {
 					return this
@@ -103,5 +105,25 @@ describe("auditThresholds", () => {
 		const result = await auditThresholds(env)
 		expect(result.drifted).toEqual([])
 		expect(result.notified).toBe(false)
+	})
+
+	it("mirrors the live moderation filters in its population queries", async () => {
+		const sqls: string[] = []
+		const env = makeEnv(
+			[histRow(0, {}), histRow(0, {}), histRow(0, {}), histRow(0, {}), histRow(0, {})],
+			new Map(),
+			sqls
+		)
+
+		await auditThresholds(env)
+
+		const decisive = sqls.find((s) => s.includes("downvotes = vote_count"))
+		expect(decisive).toBeDefined()
+		expect(decisive).toContain(String(config.moderation.autoHide.decisiveMinAgeDays * 86400))
+
+		const ratio = sqls.find((s) => s.includes("downvotes >="))
+		expect(ratio).toBeDefined()
+		expect(ratio).toContain(String(config.moderation.autoHide.downvoteRatio))
+		expect(ratio).toContain(String(config.moderation.autoHide.maxEffectiveScore))
 	})
 })

--- a/src/jobs/threshold-audit.test.ts
+++ b/src/jobs/threshold-audit.test.ts
@@ -1,0 +1,107 @@
+import { auditThresholds } from "@/jobs/threshold-audit"
+import type { Env } from "@/types"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+function histRow(total: number, counts: Partial<Record<number, number>>) {
+	const row: Record<string, string> = { total: String(total) }
+	for (let k = 2; k <= 10; k++) row[`at_least_${k}`] = String(counts[k] ?? 0)
+	return row
+}
+
+function makeEnv(scriptedRows: unknown[], cache: Map<string, string>): Env {
+	const queue = [...scriptedRows]
+	const db = {
+		prepare() {
+			return {
+				bind() {
+					return this
+				},
+				async first<T>(): Promise<T | null> {
+					return (queue.shift() as T) ?? null
+				},
+			}
+		},
+	}
+	const cacheAdapter = {
+		async get(key: string) {
+			return cache.get(key) ?? null
+		},
+		async put(key: string, value: string) {
+			cache.set(key, value)
+		},
+		async delete(key: string) {
+			cache.delete(key)
+		},
+	}
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cacheAdapter as unknown as Env["CACHE"],
+		RATE_LIMITER: {} as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+	}
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	process.env.NTFY_TOPIC_URL = ""
+})
+
+// Five populations in registry order: confidence, proven, autoHideMinVotes,
+// autoHideDecisive, reports. Confidence has the issue-#41 drifting shape
+// (current 5 -> recommended 3); the rest are empty (no drift).
+function scriptDriftingConfidenceOnly(): unknown[] {
+	return [
+		histRow(571, { 2: 200, 3: 57, 4: 40, 5: 34, 6: 29, 7: 22, 8: 20, 9: 18, 10: 17 }),
+		histRow(0, {}),
+		histRow(0, {}),
+		histRow(0, {}),
+		histRow(0, {}),
+	]
+}
+
+describe("auditThresholds", () => {
+	it("detects drift on confidence and notifies once", async () => {
+		process.env.NTFY_TOPIC_URL = "https://ntfy.sh/x"
+		const fetchSpy = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }))
+		vi.stubGlobal("fetch", fetchSpy)
+		const cache = new Map<string, string>()
+		const env = makeEnv(scriptDriftingConfidenceOnly(), cache)
+
+		const result = await auditThresholds(env)
+
+		expect(result.checked).toBe(5)
+		expect(result.drifted).toContain("minVotesForConfidence")
+		expect(result.notified).toBe(true)
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		expect(cache.get("audit:lastNotified:minVotesForConfidence")).toBe("3")
+	})
+
+	it("dedups: a second identical run does not notify again", async () => {
+		process.env.NTFY_TOPIC_URL = "https://ntfy.sh/x"
+		const fetchSpy = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }))
+		vi.stubGlobal("fetch", fetchSpy)
+		const cache = new Map<string, string>([["audit:lastNotified:minVotesForConfidence", "3"]])
+		const env = makeEnv(scriptDriftingConfidenceOnly(), cache)
+
+		const result = await auditThresholds(env)
+
+		expect(result.drifted).toContain("minVotesForConfidence")
+		expect(result.notified).toBe(false)
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("reports no drift when every population is empty", async () => {
+		const env = makeEnv(
+			[histRow(0, {}), histRow(0, {}), histRow(0, {}), histRow(0, {}), histRow(0, {})],
+			new Map()
+		)
+		const result = await auditThresholds(env)
+		expect(result.drifted).toEqual([])
+		expect(result.notified).toBe(false)
+	})
+})

--- a/src/jobs/threshold-audit.test.ts
+++ b/src/jobs/threshold-audit.test.ts
@@ -54,11 +54,12 @@ afterEach(() => {
 })
 
 // Five populations in registry order: confidence, proven, autoHideMinVotes,
-// autoHideDecisive, reports. Confidence has the issue-#41 drifting shape
-// (current 5 -> recommended 3); the rest are empty (no drift).
+// autoHideDecisive, reports. Confidence has a drifting shape
+// (current 3 -> recommended 4); the rest are empty (no drift).
+// cov@3 = 240/600 = 0.40 > target 0.25, and 0.40 - 0.25 = 0.15 > 0.10 tolerance.
 function scriptDriftingConfidenceOnly(): unknown[] {
 	return [
-		histRow(571, { 2: 200, 3: 57, 4: 40, 5: 34, 6: 29, 7: 22, 8: 20, 9: 18, 10: 17 }),
+		histRow(600, { 2: 300, 3: 240, 4: 120, 5: 90, 6: 70, 7: 55, 8: 44, 9: 35, 10: 28 }),
 		histRow(0, {}),
 		histRow(0, {}),
 		histRow(0, {}),
@@ -80,14 +81,14 @@ describe("auditThresholds", () => {
 		expect(result.drifted).toContain("minVotesForConfidence")
 		expect(result.notified).toBe(true)
 		expect(fetchSpy).toHaveBeenCalledTimes(1)
-		expect(cache.get("audit:lastNotified:minVotesForConfidence")).toBe("3")
+		expect(cache.get("audit:lastNotified:minVotesForConfidence")).toBe("4")
 	})
 
 	it("dedups: a second identical run does not notify again", async () => {
 		process.env.NTFY_TOPIC_URL = "https://ntfy.sh/x"
 		const fetchSpy = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }))
 		vi.stubGlobal("fetch", fetchSpy)
-		const cache = new Map<string, string>([["audit:lastNotified:minVotesForConfidence", "3"]])
+		const cache = new Map<string, string>([["audit:lastNotified:minVotesForConfidence", "4"]])
 		const env = makeEnv(scriptDriftingConfidenceOnly(), cache)
 
 		const result = await auditThresholds(env)

--- a/src/jobs/threshold-audit.ts
+++ b/src/jobs/threshold-audit.ts
@@ -1,0 +1,141 @@
+import { config } from "@/config"
+import type { Env } from "@/types"
+import { notify } from "@/utils/ntfy"
+import { type DriftResult, type Histogram, checkDrift } from "@/utils/threshold-derive"
+
+const HIST_KEYS = [2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+function atLeastSelect(valueExpr: string): string {
+	return HIST_KEYS.map((k) => `COUNT(*) FILTER (WHERE ${valueExpr} >= ${k}) AS at_least_${k}`).join(
+		",\n\t\t\t"
+	)
+}
+
+type HistRow = { total: number } & Record<string, number>
+
+function toHistogram(row: HistRow | null): Histogram {
+	if (!row) return { total: 0, atLeast: {} }
+	const atLeast: Record<number, number> = {}
+	// node-pg returns bigint COUNT(*) columns as strings, so coerce to number
+	for (const k of HIST_KEYS) atLeast[k] = Number(row[`at_least_${k}`] ?? 0)
+	return { total: Number(row.total ?? 0), atLeast }
+}
+
+async function lyricsHistogram(env: Env, where: string): Promise<Histogram> {
+	const row = await env.DB.prepare(`
+		SELECT COUNT(*) AS total,
+			${atLeastSelect("vote_count")}
+		FROM lyrics
+		WHERE ${where}
+	`).first<HistRow>()
+	return toHistogram(row)
+}
+
+async function reportsHistogram(env: Env): Promise<Histogram> {
+	const row = await env.DB.prepare(`
+		SELECT COUNT(*) AS total,
+			${atLeastSelect("c")}
+		FROM (SELECT COUNT(*) AS c FROM reports GROUP BY lyrics_id) g
+	`).first<HistRow>()
+	return toHistogram(row)
+}
+
+interface Audited {
+	name: string
+	current: number
+	target: { targetFraction: number; floor: number; ceil: number }
+	histogram: (env: Env) => Promise<Histogram>
+}
+
+function registry(): Audited[] {
+	const t = config.thresholdAudit.targets
+	return [
+		{
+			name: "minVotesForConfidence",
+			current: config.reputation.minVotesForConfidence,
+			target: t.minVotesForConfidence,
+			histogram: (env) => lyricsHistogram(env, "effective_score > 0 AND deleted_at IS NULL"),
+		},
+		{
+			name: "primarySlotMinVotes",
+			current: config.ranking.primarySlot.minVotes,
+			target: t.primarySlotMinVotes,
+			histogram: (env) => lyricsHistogram(env, "effective_score > 0 AND deleted_at IS NULL"),
+		},
+		{
+			name: "autoHideMinVotes",
+			current: config.moderation.autoHide.minVotes,
+			target: t.autoHideMinVotes,
+			histogram: (env) =>
+				lyricsHistogram(
+					env,
+					"vote_count > 0 AND downvotes >= 0.8 * vote_count AND effective_score < -0.5 AND deleted_at IS NULL"
+				),
+		},
+		{
+			name: "autoHideDecisiveMinVotes",
+			current: config.moderation.autoHide.decisiveMinVotes,
+			target: t.autoHideDecisiveMinVotes,
+			histogram: (env) =>
+				lyricsHistogram(env, "vote_count > 0 AND downvotes = vote_count AND deleted_at IS NULL"),
+		},
+		{
+			name: "reportsThreshold",
+			current: config.moderation.reportsThreshold,
+			target: t.reportsThreshold,
+			histogram: reportsHistogram,
+		},
+	]
+}
+
+function formatMessage(drifts: DriftResult[]): string {
+	return drifts
+		.map(
+			(d) =>
+				`${d.name}: ${d.current} -> ${d.recommended} (coverage ${(d.currentCoverage * 100).toFixed(1)}% vs target ${(d.targetFraction * 100).toFixed(0)}%)`
+		)
+		.join("\n")
+}
+
+export async function auditThresholds(
+	env: Env
+): Promise<{ checked: number; drifted: string[]; notified: boolean }> {
+	const items = registry()
+	const results: DriftResult[] = []
+
+	for (const item of items) {
+		const hist = await item.histogram(env)
+		const result = checkDrift({
+			name: item.name,
+			hist,
+			current: item.current,
+			targetFraction: item.target.targetFraction,
+			floor: item.target.floor,
+			ceil: item.target.ceil,
+			tolerance: config.thresholdAudit.driftTolerance,
+		})
+		results.push(result)
+	}
+
+	const drifted = results.filter((r) => r.drifted)
+
+	const fresh: DriftResult[] = []
+	for (const d of drifted) {
+		const key = `audit:lastNotified:${d.name}`
+		const last = await env.CACHE.get(key)
+		if (last === String(d.recommended)) continue
+		fresh.push(d)
+	}
+
+	let notified = false
+	if (fresh.length > 0) {
+		notified = await notify(formatMessage(fresh), { title: "Threshold drift detected" })
+		if (notified) {
+			for (const d of fresh) {
+				await env.CACHE.put(`audit:lastNotified:${d.name}`, String(d.recommended))
+			}
+		}
+	}
+
+	return { checked: results.length, drifted: drifted.map((d) => d.name), notified }
+}

--- a/src/jobs/threshold-audit.ts
+++ b/src/jobs/threshold-audit.ts
@@ -32,6 +32,7 @@ async function lyricsHistogram(env: Env, where: string): Promise<Histogram> {
 }
 
 async function reportsHistogram(env: Env): Promise<Histogram> {
+	// denominator is lyrics with at least one report, so coverage is over reported rows
 	const row = await env.DB.prepare(`
 		SELECT COUNT(*) AS total,
 			${atLeastSelect("c")}
@@ -49,7 +50,9 @@ interface Audited {
 
 function registry(): Audited[] {
 	const t = config.thresholdAudit.targets
+	const ah = config.moderation.autoHide
 	return [
+		// positive incumbents are the promotion candidates these bars gate, so derive over them
 		{
 			name: "minVotesForConfidence",
 			current: config.reputation.minVotesForConfidence,
@@ -69,7 +72,7 @@ function registry(): Audited[] {
 			histogram: (env) =>
 				lyricsHistogram(
 					env,
-					"vote_count > 0 AND downvotes >= 0.8 * vote_count AND effective_score < -0.5 AND deleted_at IS NULL"
+					`vote_count > 0 AND downvotes >= ${ah.downvoteRatio} * vote_count AND effective_score < ${ah.maxEffectiveScore} AND deleted_at IS NULL`
 				),
 		},
 		{
@@ -77,7 +80,10 @@ function registry(): Audited[] {
 			current: config.moderation.autoHide.decisiveMinVotes,
 			target: t.autoHideDecisiveMinVotes,
 			histogram: (env) =>
-				lyricsHistogram(env, "vote_count > 0 AND downvotes = vote_count AND deleted_at IS NULL"),
+				lyricsHistogram(
+					env,
+					`vote_count > 0 AND downvotes = vote_count AND EXTRACT(EPOCH FROM NOW())::INTEGER - created_at >= ${ah.decisiveMinAgeDays * 86400} AND deleted_at IS NULL`
+				),
 		},
 		{
 			name: "reportsThreshold",

--- a/src/utils/ntfy.test.ts
+++ b/src/utils/ntfy.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { notify } from "@/utils/ntfy"
+
+const ORIGINAL = process.env.NTFY_TOPIC_URL
+
+afterEach(() => {
+	process.env.NTFY_TOPIC_URL = ORIGINAL
+	vi.unstubAllGlobals()
+})
+
+describe("notify", () => {
+	it("returns false and does not fetch when the topic url is unset", async () => {
+		process.env.NTFY_TOPIC_URL = ""
+		const fetchSpy = vi.fn()
+		vi.stubGlobal("fetch", fetchSpy)
+		const ok = await notify("hello", { title: "t" })
+		expect(ok).toBe(false)
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("posts the message body to the topic url and returns true on 2xx", async () => {
+		process.env.NTFY_TOPIC_URL = "https://ntfy.sh/unison-thresholds"
+		const fetchSpy = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }))
+		vi.stubGlobal("fetch", fetchSpy)
+		const ok = await notify("body text", { title: "Threshold drift" })
+		expect(ok).toBe(true)
+		const [url, init] = fetchSpy.mock.calls[0]
+		expect(url).toBe("https://ntfy.sh/unison-thresholds")
+		expect(init.method).toBe("POST")
+		expect(init.body).toBe("body text")
+		expect(init.headers.Title).toBe("Threshold drift")
+	})
+
+	it("returns false on a non-2xx response without throwing", async () => {
+		process.env.NTFY_TOPIC_URL = "https://ntfy.sh/unison-thresholds"
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 500 })))
+		await expect(notify("x")).resolves.toBe(false)
+	})
+
+	it("swallows fetch rejections and returns false", async () => {
+		process.env.NTFY_TOPIC_URL = "https://ntfy.sh/unison-thresholds"
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")))
+		await expect(notify("x")).resolves.toBe(false)
+	})
+})

--- a/src/utils/ntfy.ts
+++ b/src/utils/ntfy.ts
@@ -1,0 +1,30 @@
+import { Logger } from "@/infra/logger"
+
+const log = new Logger("ntfy")
+
+const TIMEOUT_MS = 5_000
+
+export async function notify(message: string, opts?: { title?: string }): Promise<boolean> {
+	const url = process.env.NTFY_TOPIC_URL
+	if (!url) return false
+
+	const headers: Record<string, string> = { Priority: "default", Tags: "warning" }
+	if (opts?.title) headers.Title = opts.title
+
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers,
+			body: message,
+			signal: AbortSignal.timeout(TIMEOUT_MS),
+		})
+		if (!res.ok) {
+			log.warn("ntfy non-2xx", { status: res.status })
+			return false
+		}
+		return true
+	} catch (err) {
+		log.warn("ntfy failed", { error: (err as Error).message })
+		return false
+	}
+}

--- a/src/utils/threshold-derive.test.ts
+++ b/src/utils/threshold-derive.test.ts
@@ -1,0 +1,98 @@
+import {
+	type Histogram,
+	checkDrift,
+	coverageAtLeast,
+	deriveThreshold,
+} from "@/utils/threshold-derive"
+import { describe, expect, it } from "vitest"
+
+// Real shape from issue #41: 571 positive incumbents, median vote_count 1,
+// p90 3, p95 6, ~3% reach 10. Encoded as an at-least histogram.
+const INCUMBENTS: Histogram = {
+	total: 571,
+	atLeast: { 1: 571, 2: 200, 3: 57, 4: 40, 5: 34, 6: 29, 7: 22, 8: 20, 9: 18, 10: 17 },
+}
+
+describe("coverageAtLeast", () => {
+	it("returns the fraction of the population at or above the threshold", () => {
+		expect(coverageAtLeast(INCUMBENTS, 3)).toBeCloseTo(57 / 571, 5)
+	})
+
+	it("returns 0 for an empty population", () => {
+		expect(coverageAtLeast({ total: 0, atLeast: {} }, 2)).toBe(0)
+	})
+
+	it("treats an unknown threshold key as zero coverage", () => {
+		expect(coverageAtLeast(INCUMBENTS, 99)).toBe(0)
+	})
+})
+
+describe("deriveThreshold", () => {
+	it("picks the smallest integer whose coverage is at or below the target", () => {
+		// ~25% target: coverage at 2 is 200/571 (0.35) > 0.25, at 3 is 0.10 <= 0.25 -> 3
+		expect(deriveThreshold(INCUMBENTS, 0.25, { floor: 2, ceil: 10 })).toBe(3)
+	})
+
+	it("never returns below the floor even when the floor already satisfies the target", () => {
+		expect(deriveThreshold(INCUMBENTS, 0.9, { floor: 2, ceil: 10 })).toBe(2)
+	})
+
+	it("clamps to the ceil when no threshold in range meets the target", () => {
+		expect(deriveThreshold(INCUMBENTS, 0.001, { floor: 2, ceil: 10 })).toBe(10)
+	})
+
+	it("returns the floor for an empty population", () => {
+		expect(deriveThreshold({ total: 0, atLeast: {} }, 0.25, { floor: 2, ceil: 10 })).toBe(2)
+	})
+})
+
+describe("invariants", () => {
+	it("is monotonic: a smaller target fraction yields a non-decreasing threshold", () => {
+		const loose = deriveThreshold(INCUMBENTS, 0.4, { floor: 2, ceil: 10 })
+		const strict = deriveThreshold(INCUMBENTS, 0.05, { floor: 2, ceil: 10 })
+		expect(strict).toBeGreaterThanOrEqual(loose)
+	})
+})
+
+describe("checkDrift", () => {
+	it("flags drift when the recommendation differs and coverage is outside the tolerance band", () => {
+		const r = checkDrift({
+			name: "minVotesForConfidence",
+			hist: INCUMBENTS,
+			current: 5,
+			targetFraction: 0.25,
+			floor: 2,
+			ceil: 10,
+			tolerance: 0.1,
+		})
+		expect(r.recommended).toBe(3)
+		expect(r.drifted).toBe(true)
+	})
+
+	it("stays quiet when the recommendation differs but coverage is within tolerance", () => {
+		const r = checkDrift({
+			name: "x",
+			hist: INCUMBENTS,
+			current: 3,
+			targetFraction: 0.12,
+			floor: 2,
+			ceil: 10,
+			tolerance: 0.1,
+		})
+		expect(r.drifted).toBe(false)
+	})
+
+	it("stays quiet when the recommendation equals the current value", () => {
+		const r = checkDrift({
+			name: "x",
+			hist: INCUMBENTS,
+			current: 3,
+			targetFraction: 0.25,
+			floor: 2,
+			ceil: 10,
+			tolerance: 0.1,
+		})
+		expect(r.recommended).toBe(3)
+		expect(r.drifted).toBe(false)
+	})
+})

--- a/src/utils/threshold-derive.test.ts
+++ b/src/utils/threshold-derive.test.ts
@@ -95,4 +95,17 @@ describe("checkDrift", () => {
 		expect(r.recommended).toBe(3)
 		expect(r.drifted).toBe(false)
 	})
+
+	it("never flags drift on an empty population", () => {
+		const r = checkDrift({
+			name: "x",
+			hist: { total: 0, atLeast: {} },
+			current: 5,
+			targetFraction: 0.25,
+			floor: 2,
+			ceil: 10,
+			tolerance: 0.1,
+		})
+		expect(r.drifted).toBe(false)
+	})
 })

--- a/src/utils/threshold-derive.ts
+++ b/src/utils/threshold-derive.ts
@@ -42,6 +42,9 @@ export function checkDrift(params: {
 	const { name, hist, current, targetFraction, floor, ceil, tolerance } = params
 	const recommended = deriveThreshold(hist, targetFraction, { floor, ceil })
 	const currentCoverage = coverageAtLeast(hist, current)
-	const drifted = recommended !== current && Math.abs(currentCoverage - targetFraction) > tolerance
+	const drifted =
+		hist.total > 0 &&
+		recommended !== current &&
+		Math.abs(currentCoverage - targetFraction) > tolerance
 	return { name, current, recommended, currentCoverage, targetFraction, drifted }
 }

--- a/src/utils/threshold-derive.ts
+++ b/src/utils/threshold-derive.ts
@@ -1,0 +1,47 @@
+export interface Histogram {
+	total: number
+	atLeast: Record<number, number>
+}
+
+export function coverageAtLeast(hist: Histogram, threshold: number): number {
+	if (hist.total <= 0) return 0
+	return (hist.atLeast[threshold] ?? 0) / hist.total
+}
+
+export function deriveThreshold(
+	hist: Histogram,
+	targetFraction: number,
+	opts: { floor: number; ceil: number }
+): number {
+	const { floor, ceil } = opts
+	if (hist.total <= 0) return floor
+	for (let t = floor; t <= ceil; t++) {
+		if (coverageAtLeast(hist, t) <= targetFraction) return t
+	}
+	return ceil
+}
+
+export interface DriftResult {
+	name: string
+	current: number
+	recommended: number
+	currentCoverage: number
+	targetFraction: number
+	drifted: boolean
+}
+
+export function checkDrift(params: {
+	name: string
+	hist: Histogram
+	current: number
+	targetFraction: number
+	floor: number
+	ceil: number
+	tolerance: number
+}): DriftResult {
+	const { name, hist, current, targetFraction, floor, ceil, tolerance } = params
+	const recommended = deriveThreshold(hist, targetFraction, { floor, ceil })
+	const currentCoverage = coverageAtLeast(hist, current)
+	const drifted = recommended !== current && Math.abs(currentCoverage - targetFraction) > tolerance
+	return { name, current, recommended, currentCoverage, targetFraction, drifted }
+}


### PR DESCRIPTION
Closes #41.

Retunes five low-volume thresholds to the real vote distribution (median 1, p90 3, p95 6), derived from live data rather than picked by hand:

- `minVotesForConfidence` 5 to 3
- `autoHide.minVotes` 5 to 3
- `autoHide.decisiveMinVotes` 3 to 2
- `reportsThreshold` 5 to 2 (the old 5 never fired, since nothing has 5 reports)
- `primarySlot.minVotes` unchanged at 3

The auto-hide and report changes are live read-time predicates, so they take effect on existing rows right away. Confidence is a stored column, so a startup backfill recomputes it for existing rows under the new threshold and busts their cache. Without it, quiet established entries would keep a stale `low` tier (and 3x the exploration churn) until someone voted on them again.

Also adds a daily job that re-derives all five from live data and pushes an ntfy.sh alert when one drifts past the tolerance band. It only alerts, never edits config, stays silent when `NTFY_TOPIC_URL` is unset, and dedups via Redis so an unchanged recommendation does not re-notify.

Deploy: set `NTFY_TOPIC_URL` on Railway to a private ntfy topic URL to get the drift alerts. Leaving it unset is safe, the job just logs instead of pushing.