### PR TITLE
gate confidence tiers behind a minimum score floor

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export const config = {
 		consensusDelta: 0.1,
 		selfVoteWeight: 0.5,
 		minVotesForConfidence: 3,
+		minScoreForConfidence: 0.5,
 		voteWeightFloor: 0.5,
 	},
 

--- a/src/jobs/backfill-confidence.test.ts
+++ b/src/jobs/backfill-confidence.test.ts
@@ -121,4 +121,12 @@ describe("backfillConfidence", () => {
 		expect(selectSql).toContain("diversity_bonus = 1")
 		expect(selectSql).toContain("deleted_at IS NULL")
 	})
+
+	it("gates medium/high tiers behind the configured score floor", async () => {
+		const db = makeMockDB([[]])
+		const env = makeEnv(db, makeMockCache())
+		await backfillConfidence(env)
+		const selectSql = db.calls[0].sql
+		expect(selectSql).toContain(`effective_score >= ${config.reputation.minScoreForConfidence}`)
+	})
 })

--- a/src/jobs/backfill-confidence.ts
+++ b/src/jobs/backfill-confidence.ts
@@ -7,11 +7,12 @@ const log = new Logger("backfill")
 
 export async function backfillConfidence(env: Env): Promise<{ updated: number }> {
 	const threshold = config.reputation.minVotesForConfidence
+	const scoreFloor = config.reputation.minScoreForConfidence
 	// Reproduces the confidence rule in calculateScore (score-updater.ts) in SQL.
 	// If that rule changes, update this expression to match.
 	const tierExpr = `CASE
-			WHEN vote_count >= ${threshold} AND diversity_bonus = 1 THEN 'high'
-			WHEN vote_count >= ${threshold} THEN 'medium'
+			WHEN vote_count >= ${threshold} AND effective_score >= ${scoreFloor} AND diversity_bonus = 1 THEN 'high'
+			WHEN vote_count >= ${threshold} AND effective_score >= ${scoreFloor} THEN 'medium'
 			ELSE 'low'
 		END`
 

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -229,6 +229,62 @@ describe("calculateScore", () => {
 	})
 })
 
+describe("confidence score floor", () => {
+	it("returns low confidence when score is below the floor despite enough votes", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.3, is_self_vote: 0 },
+			{ vote: -1, reputation: 1.0, avg_vote: -0.2, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBeCloseTo(0.333, 2)
+		expect(result.effective_score).toBeLessThan(config.reputation.minScoreForConfidence)
+		expect(result.confidence).toBe("low")
+	})
+
+	it("does not award high confidence when diverse raters agree but score is below the floor", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: -0.5, is_self_vote: 0 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: -1, reputation: 2.0, avg_vote: 0.0, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.diversity_bonus).toBe(1)
+		expect(result.effective_score).toBeLessThan(config.reputation.minScoreForConfidence)
+		expect(result.confidence).toBe("low")
+	})
+
+	it("awards medium confidence at exactly the score floor", () => {
+		const votes = [
+			{ vote: 1, reputation: 2.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.3, is_self_vote: 0 },
+			{ vote: -1, reputation: 1.0, avg_vote: -0.2, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBeCloseTo(config.reputation.minScoreForConfidence, 5)
+		expect(result.confidence).toBe("medium")
+	})
+
+	it("still awards high confidence for a strong, diverse, well-voted row", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: -0.5, is_self_vote: 0 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.3, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBeGreaterThanOrEqual(config.reputation.minScoreForConfidence)
+		expect(result.confidence).toBe("high")
+	})
+})
+
 describe("updateReputations", () => {
 	interface DBCall {
 		sql: string

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -165,10 +165,14 @@ export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsS
 	const effectiveScore = totalWeight > 0 ? weightedSum / totalWeight : 0
 	const diversityBonus = harshUpvotes > 0 && generousUpvotes > 0
 
-	// Determine confidence level. This rule is also reproduced in SQL by
-	// backfill-confidence.ts; keep the two in sync.
+	// Determine confidence level. A tier above "low" requires both enough votes
+	// and a score clearing the floor, so "trusted" never lands on a marginal row.
+	// This rule is also reproduced in SQL by backfill-confidence.ts; keep them in sync.
 	let confidence: Confidence = "low"
-	if (votes.length >= config.reputation.minVotesForConfidence) {
+	if (
+		votes.length >= config.reputation.minVotesForConfidence &&
+		effectiveScore >= config.reputation.minScoreForConfidence
+	) {
 		confidence = diversityBonus ? "high" : "medium"
 	}
 


### PR DESCRIPTION
`confidence` (the trusted badge) was gated only on vote count, so a +0.2 song with 3 votes read as trusted. Worse, the column ignores score entirely, so on the player/variants/profile (no `effective_score > 0` feed gate) a net-negative row could wear it too.

Now a tier above `low` also needs `effective_score >= 0.5`, in both `calculateScore` and the backfill SQL.

Floor came from the live distribution, not a guess: of 102 trusted rows, 95 sit at or above 0.75 (p10 through p90 all 1.0) and the 7 junk rows are at or below 0.5, with nothing in between. 0.5 cuts the junk and leaves room for genuinely-good-but-contested rows.

Startup `backfillConfidence` demotes the 7 existing rows and clears their caches on deploy.
