### PR TITLE
fix(feed): honor explicit sort instead of pinning preferred artists

### DIFF
--- a/src/db/feed-filters.test.ts
+++ b/src/db/feed-filters.test.ts
@@ -312,16 +312,25 @@ describe("buildOrderByClause", () => {
 		)
 	})
 
-	it("maps top-rated desc to effective_score DESC, id DESC", () => {
+	it("maps top-rated desc to effective_score DESC, vote_count DESC, id DESC", () => {
 		expect(buildOrderByClause({ sort: "top-rated", sortDir: "desc" }, DEFAULT)).toBe(
-			"effective_score DESC, id DESC"
+			"effective_score DESC, vote_count DESC, id DESC"
 		)
 	})
 
-	it("maps top-rated asc to effective_score ASC, id ASC", () => {
+	it("maps top-rated asc to effective_score ASC, vote_count ASC, id ASC", () => {
 		expect(buildOrderByClause({ sort: "top-rated", sortDir: "asc" }, DEFAULT)).toBe(
-			"effective_score ASC, id ASC"
+			"effective_score ASC, vote_count ASC, id ASC"
 		)
+	})
+
+	it("regression: top-rated breaks effective_score ties by vote_count so saturated 1.0 scores rank by popularity", () => {
+		// effective_score is a reputation-weighted vote average bounded at 1.0, so a
+		// 1-vote and a 29-vote all-upvoted entry both score 1.0. Without the
+		// vote_count tiebreak, id DESC surfaced the newest single-vote uploads above
+		// genuinely well-voted lyrics under "Top Rated".
+		const clause = buildOrderByClause({ sort: "top-rated", sortDir: "desc" }, DEFAULT)
+		expect(clause).toBe("effective_score DESC, vote_count DESC, id DESC")
 	})
 
 	it("maps most-voted desc to vote_count DESC, id DESC", () => {
@@ -346,9 +355,9 @@ describe("buildOrderByClause", () => {
 		expect(parts[1]).toBe("id ASC")
 	})
 
-	it("uses id DESC as the tiebreaker for desc sorts", () => {
+	it("uses id DESC as the final tiebreaker for desc sorts", () => {
 		const clause = buildOrderByClause({ sort: "top-rated", sortDir: "desc" }, DEFAULT)
 		const parts = clause.split(",").map((s) => s.trim())
-		expect(parts[1]).toBe("id DESC")
+		expect(parts.at(-1)).toBe("id DESC")
 	})
 })

--- a/src/db/feed-filters.ts
+++ b/src/db/feed-filters.ts
@@ -101,5 +101,9 @@ export function buildOrderByClause(filters: FeedFilters, defaultExpr: string): s
 	if (!filters.sort || filters.sort === "default") return defaultExpr
 	const column = SORT_COLUMN[filters.sort]
 	const dir = filters.sortDir === "asc" ? "ASC" : "DESC"
-	return `${column} ${dir}, id ${dir}`
+	// effective_score is a reputation-weighted vote average that saturates at 1.0,
+	// so many entries tie at the top. Break those ties by vote_count so well-voted
+	// lyrics outrank brand-new single-vote uploads under "Top Rated".
+	const tiebreak = filters.sort === "top-rated" ? `vote_count ${dir}, ` : ""
+	return `${column} ${dir}, ${tiebreak}id ${dir}`
 }

--- a/src/db/feed.test.ts
+++ b/src/db/feed.test.ts
@@ -460,7 +460,7 @@ describe("getMySubmissions", () => {
 		})
 
 		const sql = db.calls[0].sql
-		expect(sql).toMatch(/ORDER BY\s+effective_score ASC,\s+id ASC/)
+		expect(sql).toMatch(/ORDER BY\s+effective_score ASC,\s+vote_count ASC,\s+id ASC/)
 	})
 
 	it("applies filters without adding a quality gate", async () => {

--- a/src/db/feed.test.ts
+++ b/src/db/feed.test.ts
@@ -324,7 +324,8 @@ describe("getPersonalizedFeed", () => {
 
 		const feedSql = db.calls[1].sql
 		expect(feedSql).toContain("effective_score > 0")
-		expect(feedSql).toMatch(/ORDER BY\s+is_personalized DESC,\s+created_at DESC,\s+id DESC/)
+		expect(feedSql).toMatch(/\)\s*AS\s+unique_videos\s+ORDER BY\s+created_at DESC,\s+id DESC/)
+		expect(feedSql).not.toMatch(/ORDER BY\s+is_personalized DESC/)
 		expect(feedSql).toMatch(/ORDER BY video_id,.*LN\(/s)
 	})
 
@@ -358,7 +359,7 @@ describe("getPersonalizedFeed", () => {
 		expect(feedSql).not.toContain("is_personalized")
 	})
 
-	it("keeps is_personalized DESC as the primary outer sort key with sort=most-voted", async () => {
+	it("drops the is_personalized boost when an explicit sort is chosen (most-voted)", async () => {
 		const db = createMockDB([[{ artist_norm: "limbo" }], []])
 		await getPersonalizedFeed(createEnv(db), 42, 20, 0, {
 			sort: "most-voted",
@@ -366,7 +367,28 @@ describe("getPersonalizedFeed", () => {
 		})
 
 		const feedSql = db.calls[1].sql
-		expect(feedSql).toMatch(/ORDER BY\s+is_personalized DESC,\s+vote_count DESC,\s+id DESC/)
+		expect(feedSql).toMatch(/\)\s*AS\s+unique_videos\s+ORDER BY\s+vote_count DESC,\s+id DESC/)
+		expect(feedSql).not.toMatch(/ORDER BY\s+is_personalized DESC/)
+	})
+
+	it("regression: explicit sorts honor the label instead of pinning preferred artists on top", async () => {
+		// Bug: is_personalized DESC was always the primary outer sort key, so a
+		// logged-in user's preferred-artist items pinned above everything and the
+		// chosen sort only ordered within that tier. The true most-voted / newest
+		// item landed on page 2. Explicit sorts must match the global ordering.
+		for (const sort of ["newest", "top-rated", "most-voted"] as const) {
+			const db = createMockDB([[{ artist_norm: "limbo" }], []])
+			await getPersonalizedFeed(createEnv(db), 42, 20, 0, { sort, sortDir: "desc" })
+			expect(db.calls[1].sql).not.toMatch(/ORDER BY\s+is_personalized DESC/)
+		}
+	})
+
+	it("keeps the is_personalized boost on the default feed (no explicit sort)", async () => {
+		const db = createMockDB([[{ artist_norm: "limbo" }], []])
+		await getPersonalizedFeed(createEnv(db), 42, 20, 0, { sort: "default" })
+
+		const feedSql = db.calls[1].sql
+		expect(feedSql).toMatch(/\)\s*AS\s+unique_videos\s+ORDER BY\s+is_personalized DESC/)
 	})
 
 	it("keeps SQL shape unchanged when filters are absent (regression)", async () => {

--- a/src/db/feed.ts
+++ b/src/db/feed.ts
@@ -164,6 +164,12 @@ export async function getPersonalizedFeed(
 
 	const outerOrderBy = buildOrderByClause(filters, `${RANKING_EXPR} DESC`)
 
+	// The preferred-artist boost is a feature of the default discovery feed only.
+	// When the user picks an explicit sort, that label is the contract: honor it
+	// globally instead of pinning preferred items above the true top result.
+	const isDefaultSort = !filters.sort || filters.sort === "default"
+	const personalizedBoost = isDefaultSort ? "is_personalized DESC, " : ""
+
 	// Single-stream query so OFFSET applies to one stable order; preferred-artist
 	// items boost to the top via is_personalized DESC without a second SELECT,
 	// which would otherwise let the same item reappear across page boundaries.
@@ -179,7 +185,7 @@ export async function getPersonalizedFeed(
 			WHERE ${innerWhere.join(" AND ")}
 			ORDER BY video_id, ${RANKING_EXPR} DESC
 		) AS unique_videos
-		ORDER BY is_personalized DESC, ${outerOrderBy}
+		ORDER BY ${personalizedBoost}${outerOrderBy}
 		LIMIT ?${hasOffset ? " OFFSET ?" : ""}
 	`
 

--- a/src/routes/feed.test.ts
+++ b/src/routes/feed.test.ts
@@ -210,7 +210,8 @@ describe("GET /feed", () => {
 		const feedSql = db.calls[2].sql
 		expect(feedSql).toContain("is_personalized")
 		expect(feedSql).toContain("sync_type = ?")
-		expect(feedSql).toMatch(/ORDER BY\s+is_personalized DESC,\s+created_at DESC,\s+id DESC/)
+		expect(feedSql).toMatch(/\)\s*AS\s+unique_videos\s+ORDER BY\s+created_at DESC,\s+id DESC/)
+		expect(feedSql).not.toMatch(/ORDER BY\s+is_personalized DESC/)
 		expect(db.calls[2].params).toContain("richsync")
 	})
 


### PR DESCRIPTION
Two feed sort fixes.

Signed-in users picking a sort still got their preferred artists pinned on top, so the real newest/most-voted entry landed on page 2. The boost now stays on the default feed only.

Top Rated also surfaced brand-new single-vote uploads, because effective_score maxes out at 1.0 and ties fell back to newest. It now breaks those ties by vote_count.