### PR TITLE
Wait for YouTube player onReady before driving lyric sync

### DIFF
--- a/web/src/hooks/useYouTubePlayer.test.tsx
+++ b/web/src/hooks/useYouTubePlayer.test.tsx
@@ -1,29 +1,43 @@
 import { act, render, renderHook } from "@testing-library/react"
 import { createElement } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { __resetForTests, useYouTubePlayer } from "./useYouTubePlayer"
+import { type UseYouTubePlayerResult, __resetForTests, useYouTubePlayer } from "./useYouTubePlayer"
 
 interface FakePlayerOptions {
   videoId: string
+  events?: { onReady?: () => void }
 }
 
+// Models the real YT.Player: methods are NOT attached until the iframe posts
+// "initialDelivery" and onReady fires. Calling one before then throws, exactly
+// like `player.getCurrentTime is not a function` in production.
 class FakePlayer {
   destroyed = false
+  ready = false
   currentTime = 0
   state = 2
   seeks: Array<{ seconds: number; allowSeekAhead: boolean }> = []
+  onReady?: () => void
   static instances: FakePlayer[] = []
 
-  constructor(_elem: HTMLElement | string, _opts: FakePlayerOptions) {
+  constructor(_elem: HTMLElement | string, opts: FakePlayerOptions) {
+    this.onReady = opts.events?.onReady
     FakePlayer.instances.push(this)
   }
+  fireReady() {
+    this.ready = true
+    this.onReady?.()
+  }
   getCurrentTime() {
+    if (!this.ready) throw new TypeError("getCurrentTime is not a function")
     return this.currentTime
   }
   getPlayerState() {
+    if (!this.ready) throw new TypeError("getPlayerState is not a function")
     return this.state
   }
   seekTo(seconds: number, allowSeekAhead: boolean) {
+    if (!this.ready) throw new TypeError("seekTo is not a function")
     this.seeks.push({ seconds, allowSeekAhead })
     this.currentTime = seconds
   }
@@ -91,6 +105,9 @@ describe("useYouTubePlayer", () => {
     const player = FakePlayer.instances[0]
     expect(player).toBeDefined()
     act(() => {
+      player.fireReady()
+    })
+    act(() => {
       captured?.seekTo(7.25)
     })
     expect(player.seeks).toEqual([{ seconds: 7.25, allowSeekAhead: true }])
@@ -137,6 +154,10 @@ describe("useYouTubePlayer", () => {
     if (getCurrentTimeMs === null || getPlaying === null) throw new Error("getters never captured")
     const readTime: () => number = getCurrentTimeMs
     const readPlaying: () => boolean = getPlaying
+
+    act(() => {
+      player.fireReady()
+    })
 
     player.currentTime = 2.5
     expect(readTime()).toBe(2500)
@@ -211,5 +232,99 @@ describe("useYouTubePlayer", () => {
       await Promise.resolve()
     })
     expect(() => unmount()).not.toThrow()
+  })
+})
+
+describe("useYouTubePlayer readiness gating", () => {
+  let result: UseYouTubePlayerResult
+  let unmount: () => void
+
+  async function mountFor(videoId: string) {
+    installYT()
+    function CaptureHarness() {
+      result = useYouTubePlayer(videoId)
+      return createElement("div", { ref: result.ref })
+    }
+    const rendered = render(createElement(CaptureHarness))
+    unmount = rendered.unmount
+    await act(async () => {
+      await Promise.resolve()
+    })
+    return rendered
+  }
+
+  // The real YT.Player attaches getCurrentTime/getPlayerState/seekTo only after
+  // onReady fires; calling one before then throws. The rAF sync loop in
+  // LyricsRenderer calls these every frame, so an unguarded pre-ready call threw
+  // and killed the loop forever ("barely works most of the time"). These lock in
+  // that the hook never touches the player before onReady.
+  it("regression: getCurrentTimeMs returns 0 and does not throw before the player is ready", async () => {
+    await mountFor("abc")
+    expect(FakePlayer.instances[0].ready).toBe(false)
+    expect(() => result.getCurrentTimeMs()).not.toThrow()
+    expect(result.getCurrentTimeMs()).toBe(0)
+    unmount()
+  })
+
+  it("regression: getPlaying returns false and does not throw before the player is ready", async () => {
+    await mountFor("abc")
+    expect(() => result.getPlaying()).not.toThrow()
+    expect(result.getPlaying()).toBe(false)
+    unmount()
+  })
+
+  it("regression: seekTo is a no-op and does not throw before the player is ready", async () => {
+    await mountFor("abc")
+    expect(() => result.seekTo(9)).not.toThrow()
+    expect(FakePlayer.instances[0].seeks).toEqual([])
+    unmount()
+  })
+
+  it("starts reading real player values only once onReady fires", async () => {
+    await mountFor("abc")
+    const player = FakePlayer.instances[0]
+    player.currentTime = 3
+    player.state = 1
+    expect(result.getCurrentTimeMs()).toBe(0)
+    expect(result.getPlaying()).toBe(false)
+
+    act(() => {
+      player.fireReady()
+    })
+    expect(result.getCurrentTimeMs()).toBe(3000)
+    expect(result.getPlaying()).toBe(true)
+    unmount()
+  })
+
+  it("regression: changing videoId resets readiness so the new player is not queried before its onReady", async () => {
+    function Harness2({ videoId }: { videoId: string }) {
+      result = useYouTubePlayer(videoId)
+      return createElement("div", { ref: result.ref })
+    }
+    installYT()
+    const rendered = render(createElement(Harness2, { videoId: "abc" }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    act(() => {
+      FakePlayer.instances[0].fireReady()
+    })
+    expect(result.getCurrentTimeMs).toBeDefined()
+
+    rendered.rerender(createElement(Harness2, { videoId: "def" }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const next = FakePlayer.instances[1]
+    expect(next.ready).toBe(false)
+    expect(() => result.getCurrentTimeMs()).not.toThrow()
+    expect(result.getCurrentTimeMs()).toBe(0)
+
+    next.currentTime = 5
+    act(() => {
+      next.fireReady()
+    })
+    expect(result.getCurrentTimeMs()).toBe(5000)
+    rendered.unmount()
   })
 })

--- a/web/src/hooks/useYouTubePlayer.ts
+++ b/web/src/hooks/useYouTubePlayer.ts
@@ -14,6 +14,7 @@ interface YTPlayerCtorOptions {
   width?: string | number
   height?: string | number
   playerVars?: { origin?: string }
+  events?: { onReady?: () => void }
 }
 
 interface YTNamespace {
@@ -88,6 +89,10 @@ export interface UseYouTubePlayerResult {
 export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult {
   const [node, setNode] = useState<HTMLDivElement | null>(null)
   const playerRef = useRef<YTPlayer | null>(null)
+  // YT.Player methods aren't attached until onReady fires; calling one earlier
+  // throws. The rAF sync loop polls every frame, so the getters must stay inert
+  // until the player is ready or one throw kills the loop permanently.
+  const readyRef = useRef(false)
 
   useEffect(() => {
     if (!videoId || !node) return
@@ -95,6 +100,7 @@ export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult
     if (!win) return
 
     let cancelled = false
+    readyRef.current = false
 
     const run = async () => {
       const yt = await ensureScript(win).catch(() => null)
@@ -104,6 +110,11 @@ export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult
         width: "100%",
         height: "100%",
         playerVars: { origin: win.location.origin },
+        events: {
+          onReady: () => {
+            if (!cancelled) readyRef.current = true
+          },
+        },
       })
       playerRef.current = player
     }
@@ -111,6 +122,7 @@ export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult
 
     return () => {
       cancelled = true
+      readyRef.current = false
       const player = playerRef.current
       if (player) player.destroy()
       playerRef.current = null
@@ -119,19 +131,19 @@ export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult
 
   const seekTo = useCallback((seconds: number) => {
     const player = playerRef.current
-    if (!player) return
+    if (!player || !readyRef.current) return
     player.seekTo(seconds, true)
   }, [])
 
   const getCurrentTimeMs = useCallback(() => {
     const player = playerRef.current
-    if (!player) return 0
+    if (!player || !readyRef.current) return 0
     return player.getCurrentTime() * 1000
   }, [])
 
   const getPlaying = useCallback(() => {
     const player = playerRef.current
-    if (!player) return false
+    if (!player || !readyRef.current) return false
     return player.getPlayerState() === YT_STATE_PLAYING
   }, [])
 


### PR DESCRIPTION
Synced lyrics rarely tracked the video. The page called `getCurrentTime()` on the YouTube player before the iframe finished loading, but that method is not attached until the player fires `onReady`, so the call threw and the requestAnimationFrame sync loop died on its very first frame. Whether sync worked at all came down to a race nobody could win reliably.

The hook now holds off until `onReady` fires. The time and play-state getters stay inert until then instead of throwing, so the loop keeps running and sync kicks in the moment the player is live.