### PR TITLE
feat(requests): bot-authenticated submission endpoint

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -28,6 +28,16 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS nickname_updated_at INTEGER;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_nickname_lower
     ON users(nickname_lower) WHERE nickname_lower IS NOT NULL;
 
+-- Discord account links (Discord user <-> Better Lyrics key)
+CREATE TABLE IF NOT EXISTS discord_links (
+    discord_id TEXT PRIMARY KEY,
+    key_id TEXT UNIQUE NOT NULL,
+    discord_username TEXT,
+    linked_at INTEGER NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW())::INTEGER)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discord_links_key_id ON discord_links(key_id);
+
 -- Main lyrics table
 CREATE TABLE IF NOT EXISTS lyrics (
     id SERIAL PRIMARY KEY,

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,8 +29,6 @@ export const config = {
 	linking: {
 		stateTtlSeconds: 600, // OAuth round-trip window for the Discord link flow
 		discordScope: "identify",
-		// ponytail: config Set of accounts that can never be linked. Seeded with the
-		// shared community account. Move to a table if this list needs live edits.
 		blacklistedKeyIds: new Set<string>([
 			"cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e",
 		]),

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,16 @@ export const config = {
 		},
 	},
 
+	linking: {
+		stateTtlSeconds: 600, // OAuth round-trip window for the Discord link flow
+		discordScope: "identify",
+		// ponytail: config Set of accounts that can never be linked. Seeded with the
+		// shared community account. Move to a table if this list needs live edits.
+		blacklistedKeyIds: new Set<string>([
+			"cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e",
+		]),
+	},
+
 	reputation: {
 		default: 1.0,
 		min: 0.0,

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export const config = {
 
 	requests: {
 		windowDays: 30,
-		discordNeutralWeight: 1.0, // reserved for deferred Discord-origin requests
+		discordNeutralWeight: 1.0,
 		needsFixingReportThreshold: 5,
 		leaderboard: {
 			cacheTtl: 300,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+export const COMMUNITY_KEY_ID = "cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e"
+
 export const config = {
 	submission: {
 		maxVariantsPerUserPerVideo: 3,
@@ -29,9 +31,7 @@ export const config = {
 	linking: {
 		stateTtlSeconds: 600, // OAuth round-trip window for the Discord link flow
 		discordScope: "identify",
-		blacklistedKeyIds: new Set<string>([
-			"cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e",
-		]),
+		blacklistedKeyIds: new Set<string>([COMMUNITY_KEY_ID]),
 	},
 
 	reputation: {

--- a/src/db/discordLinks.test.ts
+++ b/src/db/discordLinks.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+import type { Env } from "@/types"
+import { getByDiscordId, getByKeyId, linkDiscord, listLinks, unlinkByKeyId } from "./discordLinks"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							return (queue.shift() as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							return { results: (queue.shift() as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+	}
+	return db
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>): Env {
+	return { DB: db as unknown as Env["DB"] } as unknown as Env
+}
+
+const KEY = "a".repeat(64)
+
+describe("discordLinks", () => {
+	describe("linkDiscord", () => {
+		it("clears any prior link on either side, then inserts the new one", async () => {
+			const db = makeMockDB([null, null])
+			await linkDiscord(makeEnv(db), {
+				discordId: "discord-1",
+				keyId: KEY,
+				discordUsername: "alice",
+			})
+
+			const del = db.calls.find((c) => c.sql.includes("DELETE FROM discord_links"))
+			expect(del?.sql).toContain("key_id = ? OR discord_id = ?")
+			expect(del?.params).toEqual([KEY, "discord-1"])
+
+			const insert = db.calls.find((c) => c.sql.includes("INSERT INTO discord_links"))
+			expect(insert?.params).toEqual(["discord-1", KEY, "alice", expect.any(Number)])
+		})
+
+		it("stores a null username when none is provided", async () => {
+			const db = makeMockDB([null, null])
+			await linkDiscord(makeEnv(db), { discordId: "d2", keyId: KEY, discordUsername: null })
+			const insert = db.calls.find((c) => c.sql.includes("INSERT INTO discord_links"))
+			expect(insert?.params[2]).toBeNull()
+		})
+	})
+
+	describe("lookups", () => {
+		it("getByDiscordId returns the row when present", async () => {
+			const row = { discord_id: "d1", key_id: KEY, discord_username: "alice", linked_at: 1 }
+			const db = makeMockDB([row])
+			expect(await getByDiscordId(makeEnv(db), "d1")).toEqual(row)
+		})
+
+		it("getByDiscordId returns null when absent", async () => {
+			const db = makeMockDB([])
+			expect(await getByDiscordId(makeEnv(db), "missing")).toBeNull()
+		})
+
+		it("getByKeyId returns the row when present", async () => {
+			const row = { discord_id: "d1", key_id: KEY, discord_username: null, linked_at: 1 }
+			const db = makeMockDB([row])
+			expect(await getByKeyId(makeEnv(db), KEY)).toEqual(row)
+		})
+	})
+
+	describe("unlinkByKeyId", () => {
+		it("deletes the row for the key", async () => {
+			const db = makeMockDB([null])
+			await unlinkByKeyId(makeEnv(db), KEY)
+			const del = db.calls.find((c) => c.sql.includes("DELETE FROM discord_links"))
+			expect(del?.sql).toContain("WHERE key_id = ?")
+			expect(del?.params).toEqual([KEY])
+		})
+	})
+
+	describe("listLinks", () => {
+		it("returns all discord-to-key pairs", async () => {
+			const rows = [
+				{ discord_id: "d1", key_id: "k1" },
+				{ discord_id: "d2", key_id: "k2" },
+			]
+			const db = makeMockDB([rows])
+			expect(await listLinks(makeEnv(db))).toEqual(rows)
+		})
+
+		it("returns an empty array when there are no links", async () => {
+			const db = makeMockDB([])
+			expect(await listLinks(makeEnv(db))).toEqual([])
+		})
+	})
+})

--- a/src/db/discordLinks.test.ts
+++ b/src/db/discordLinks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import type { Env } from "@/types"
 import { getByDiscordId, getByKeyId, linkDiscord, listLinks, unlinkByKeyId } from "./discordLinks"
 
@@ -15,6 +15,8 @@ function makeMockDB(queue: unknown[] = []) {
 			return {
 				bind(...args: unknown[]) {
 					return {
+						getSql: () => sql,
+						getParams: () => args,
 						async first<T>(): Promise<T | null> {
 							calls.push({ sql, params: args })
 							return (queue.shift() as T) ?? null
@@ -29,6 +31,11 @@ function makeMockDB(queue: unknown[] = []) {
 						},
 					}
 				},
+			}
+		},
+		async batch(stmts: Array<{ getSql(): string; getParams(): unknown[] }>): Promise<void> {
+			for (const stmt of stmts) {
+				calls.push({ sql: stmt.getSql(), params: stmt.getParams() })
 			}
 		},
 	}
@@ -64,6 +71,33 @@ describe("discordLinks", () => {
 			await linkDiscord(makeEnv(db), { discordId: "d2", keyId: KEY, discordUsername: null })
 			const insert = db.calls.find((c) => c.sql.includes("INSERT INTO discord_links"))
 			expect(insert?.params[2]).toBeNull()
+		})
+
+		it("regression: runs the delete and insert in one atomic batch", async () => {
+			const db = makeMockDB()
+			const spy = vi.spyOn(db, "batch")
+			await linkDiscord(makeEnv(db), {
+				discordId: "discord-1",
+				keyId: KEY,
+				discordUsername: "alice",
+			})
+
+			expect(spy).toHaveBeenCalledOnce()
+			expect(db.calls).toHaveLength(2)
+			expect(db.calls[0].sql).toContain("DELETE FROM discord_links")
+			expect(db.calls[1].sql).toContain("INSERT INTO discord_links")
+		})
+
+		it("regression: keeps the prior link when the insert fails mid-transaction", async () => {
+			const db = makeMockDB()
+			db.batch = async () => {
+				throw new Error("constraint violation")
+			}
+
+			await expect(
+				linkDiscord(makeEnv(db), { discordId: "discord-1", keyId: KEY, discordUsername: "alice" })
+			).rejects.toThrow()
+			expect(db.calls).toEqual([])
 		})
 	})
 

--- a/src/db/discordLinks.ts
+++ b/src/db/discordLinks.ts
@@ -24,8 +24,6 @@ export async function linkDiscord(
 	params: { discordId: string; keyId: string; discordUsername: string | null }
 ): Promise<void> {
 	const now = Math.floor(Date.now() / 1000)
-	// ponytail: clear-then-insert without a txn; linking is per-user and rare, so the
-	// race window is acceptable. Wrap in a transaction if linking ever gets contended.
 	await env.DB.prepare("DELETE FROM discord_links WHERE key_id = ? OR discord_id = ?")
 		.bind(params.keyId, params.discordId)
 		.run()

--- a/src/db/discordLinks.ts
+++ b/src/db/discordLinks.ts
@@ -1,0 +1,48 @@
+import type { Env } from "@/types"
+
+export interface DiscordLink {
+	discord_id: string
+	key_id: string
+	discord_username: string | null
+	linked_at: number
+}
+
+export async function getByDiscordId(env: Env, discordId: string): Promise<DiscordLink | null> {
+	return env.DB.prepare("SELECT * FROM discord_links WHERE discord_id = ?")
+		.bind(discordId)
+		.first<DiscordLink>()
+}
+
+export async function getByKeyId(env: Env, keyId: string): Promise<DiscordLink | null> {
+	return env.DB.prepare("SELECT * FROM discord_links WHERE key_id = ?")
+		.bind(keyId)
+		.first<DiscordLink>()
+}
+
+export async function linkDiscord(
+	env: Env,
+	params: { discordId: string; keyId: string; discordUsername: string | null }
+): Promise<void> {
+	const now = Math.floor(Date.now() / 1000)
+	// ponytail: clear-then-insert without a txn; linking is per-user and rare, so the
+	// race window is acceptable. Wrap in a transaction if linking ever gets contended.
+	await env.DB.prepare("DELETE FROM discord_links WHERE key_id = ? OR discord_id = ?")
+		.bind(params.keyId, params.discordId)
+		.run()
+	await env.DB.prepare(
+		"INSERT INTO discord_links (discord_id, key_id, discord_username, linked_at) VALUES (?, ?, ?, ?)"
+	)
+		.bind(params.discordId, params.keyId, params.discordUsername, now)
+		.run()
+}
+
+export async function unlinkByKeyId(env: Env, keyId: string): Promise<void> {
+	await env.DB.prepare("DELETE FROM discord_links WHERE key_id = ?").bind(keyId).run()
+}
+
+export async function listLinks(env: Env): Promise<Pick<DiscordLink, "discord_id" | "key_id">[]> {
+	const { results } = await env.DB.prepare("SELECT discord_id, key_id FROM discord_links")
+		.bind()
+		.all<Pick<DiscordLink, "discord_id" | "key_id">>()
+	return results
+}

--- a/src/db/discordLinks.ts
+++ b/src/db/discordLinks.ts
@@ -24,14 +24,15 @@ export async function linkDiscord(
 	params: { discordId: string; keyId: string; discordUsername: string | null }
 ): Promise<void> {
 	const now = Math.floor(Date.now() / 1000)
-	await env.DB.prepare("DELETE FROM discord_links WHERE key_id = ? OR discord_id = ?")
-		.bind(params.keyId, params.discordId)
-		.run()
-	await env.DB.prepare(
-		"INSERT INTO discord_links (discord_id, key_id, discord_username, linked_at) VALUES (?, ?, ?, ?)"
-	)
-		.bind(params.discordId, params.keyId, params.discordUsername, now)
-		.run()
+	await env.DB.batch([
+		env.DB.prepare("DELETE FROM discord_links WHERE key_id = ? OR discord_id = ?").bind(
+			params.keyId,
+			params.discordId
+		),
+		env.DB.prepare(
+			"INSERT INTO discord_links (discord_id, key_id, discord_username, linked_at) VALUES (?, ?, ?, ?)"
+		).bind(params.discordId, params.keyId, params.discordUsername, now),
+	])
 }
 
 export async function unlinkByKeyId(env: Env, keyId: string): Promise<void> {

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -23,6 +23,10 @@ export async function getUserById(env: Env, userId: number): Promise<User | null
 	return env.DB.prepare("SELECT * FROM users WHERE id = ?").bind(userId).first<User>()
 }
 
+export async function getUserByKeyId(env: Env, keyId: string): Promise<User | null> {
+	return env.DB.prepare("SELECT * FROM users WHERE key_id = ?").bind(keyId).first<User>()
+}
+
 export async function updateUserReputation(env: Env, userId: number, delta: number): Promise<void> {
 	await env.DB.prepare(
 		"UPDATE users SET reputation = MAX(0.0, MIN(2.0, reputation + ?)) WHERE id = ?"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { authRoutes } from "@/routes/auth"
 import { compatRoutes } from "@/routes/compat"
 import { feedRoutes } from "@/routes/feed"
 import { leaderboardRoutes } from "@/routes/leaderboard"
+import { linkRoutes, linkStartRoutes } from "@/routes/links"
 import { lyricsRoutes } from "@/routes/lyrics"
 import { requestRoutes } from "@/routes/requests"
 import { userRoutes } from "@/routes/users"
@@ -194,6 +195,8 @@ const app = new Elysia({ adapter: node() })
 	.use(leaderboardRoutes(env))
 	.use(userRoutes(env))
 	.use(authRoutes(env))
+	.use(linkStartRoutes(env))
+	.use(linkRoutes(env))
 	.get("/*", ({ request }) => {
 		const { pathname } = new URL(request.url)
 

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -31,6 +31,16 @@ function readB2Config(): B2Config | null {
 	return { keyId, applicationKey, bucket, endpoint }
 }
 
+function readDiscordOAuthConfig(): Env["DISCORD_OAUTH"] {
+	const clientId = process.env.DISCORD_CLIENT_ID
+	const clientSecret = process.env.DISCORD_CLIENT_SECRET
+	const redirectUri = process.env.DISCORD_OAUTH_REDIRECT_URI
+
+	if (!clientId || !clientSecret || !redirectUri) return null
+
+	return { clientId, clientSecret, redirectUri }
+}
+
 export function createEnv(): Env {
 	const databaseUrl = process.env.DATABASE_URL
 	if (!databaseUrl) throw new Error("DATABASE_URL is required")
@@ -60,5 +70,6 @@ export function createEnv(): Env {
 		DUMP_DATABASE_URL: process.env.DUMP_DATABASE_URL || null,
 		B2: readB2Config(),
 		BUTLER_BOT_SECRET: process.env.BUTLER_BOT_SECRET || null,
+		DISCORD_OAUTH: readDiscordOAuthConfig(),
 	}
 }

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -59,5 +59,6 @@ export function createEnv(): Env {
 		DUMP_PUBLIC_BASE_URL: process.env.DUMP_PUBLIC_BASE_URL || "",
 		DUMP_DATABASE_URL: process.env.DUMP_DATABASE_URL || null,
 		B2: readB2Config(),
+		BUTLER_BOT_SECRET: process.env.BUTLER_BOT_SECRET || null,
 	}
 }

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, it } from "vitest"
+import { COMMUNITY_KEY_ID } from "@/utils/blacklist"
+import { canonicalJson, hashPublicKey } from "@/utils/crypto"
+import type { Env } from "@/types"
+import { linkRoutes, linkStartRoutes } from "./links"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							return (queue.shift() as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							return { results: (queue.shift() as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+	}
+	return db
+}
+
+function makeMockCache(seed: Record<string, string> = {}) {
+	const store = new Map(Object.entries(seed))
+	const puts: { key: string; value: string }[] = []
+	return {
+		store,
+		puts,
+		async get(k: string) {
+			return store.get(k) ?? null
+		},
+		async put(k: string, v: string) {
+			store.set(k, v)
+			puts.push({ key: k, value: v })
+		},
+		async delete(k: string) {
+			store.delete(k)
+		},
+		async getDel(k: string) {
+			const v = store.get(k) ?? null
+			store.delete(k)
+			return v
+		},
+		async setNX() {
+			return true
+		},
+		async keys() {
+			return []
+		},
+	}
+}
+
+const OAUTH = {
+	clientId: "client-1",
+	clientSecret: "secret-1",
+	redirectUri: "https://unison.boidu.dev/links/discord/callback",
+}
+
+function makeEnv(
+	db: ReturnType<typeof makeMockDB>,
+	cache: ReturnType<typeof makeMockCache>,
+	overrides: Partial<Env> = {}
+): Env {
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		RATE_LIMITER: {
+			async limit() {
+				return { success: true }
+			},
+		} as unknown as Env["RATE_LIMITER"],
+		READ_RATE_LIMITER: {} as unknown as Env["READ_RATE_LIMITER"],
+		CACHE_TTL_SECONDS: "300",
+		DUMPS_ENABLED: false,
+		DUMP_PUBLIC_BASE_URL: "",
+		DUMP_DATABASE_URL: null,
+		B2: null,
+		DISCORD_OAUTH: OAUTH,
+		...overrides,
+	}
+}
+
+async function generateKeyPair() {
+	return crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"])
+}
+
+type GeneratedKeyPair = Awaited<ReturnType<typeof generateKeyPair>>
+
+async function signedStartBody(keyId: string, kp: GeneratedKeyPair, publicJwk: JsonWebKey) {
+	const payload = { timestamp: Date.now(), nonce: "n".repeat(32), keyId }
+	const buf = new TextEncoder().encode(canonicalJson(payload))
+	const sig = await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, kp.privateKey, buf)
+	const bytes = new Uint8Array(sig)
+	let bin = ""
+	for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+	return { payload, signature: btoa(bin), publicKey: publicJwk }
+}
+
+function okJson(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	})
+}
+
+function discordFetch(user: {
+	id: string
+	username: string
+	global_name?: string | null
+}): typeof fetch {
+	return (async (input: string | URL | Request) => {
+		const url = String(input)
+		if (url.endsWith("/oauth2/token")) return okJson({ access_token: "tok" })
+		if (url.endsWith("/users/@me")) return okJson(user)
+		return new Response(null, { status: 404 })
+	}) as typeof fetch
+}
+
+describe("POST /links/discord/start", () => {
+	it("returns a Discord authorize URL and stores single-use state bound to the key", async () => {
+		const kp = await generateKeyPair()
+		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
+		const keyId = await hashPublicKey(publicJwk)
+
+		const db = makeMockDB([
+			{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 }, // getPublicKey
+			{ id: 7, key_id: keyId }, // getOrCreateUser
+		])
+		const cache = makeMockCache()
+		const app = linkStartRoutes(makeEnv(db, cache))
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/start", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(await signedStartBody(keyId, kp, publicJwk)),
+			})
+		)
+
+		expect(res.status).toBe(200)
+		const json = (await res.json()) as { data: { authorizeUrl: string } }
+		const url = new URL(json.data.authorizeUrl)
+		expect(url.origin + url.pathname).toBe("https://discord.com/oauth2/authorize")
+		const state = url.searchParams.get("state")
+		expect(state).toBeTruthy()
+		expect(cache.store.get(`link_state:${state}`)).toBe(keyId)
+	})
+
+	it("refuses to start a link for a blacklisted key", async () => {
+		const kp = await generateKeyPair()
+		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
+		// Force the signed identity to be the community key by registering it under that id.
+		const db = makeMockDB([
+			{ key_id: COMMUNITY_KEY_ID, public_key: JSON.stringify(publicJwk), created_at: 0 },
+			{ id: 1, key_id: COMMUNITY_KEY_ID },
+		])
+		const cache = makeMockCache()
+		const app = linkStartRoutes(makeEnv(db, cache))
+
+		const body = await signedStartBody(COMMUNITY_KEY_ID, kp, publicJwk)
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/start", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			})
+		)
+		expect(res.status).toBe(403)
+	})
+
+	it("reports 503 when Discord OAuth is not configured", async () => {
+		const kp = await generateKeyPair()
+		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
+		const keyId = await hashPublicKey(publicJwk)
+		const db = makeMockDB([
+			{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 },
+			{ id: 7, key_id: keyId },
+		])
+		const cache = makeMockCache()
+		const app = linkStartRoutes(makeEnv(db, cache, { DISCORD_OAUTH: null }))
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/start", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(await signedStartBody(keyId, kp, publicJwk)),
+			})
+		)
+		expect(res.status).toBe(503)
+	})
+})
+
+describe("GET /links/discord/callback", () => {
+	const KEY = "a".repeat(64)
+
+	it("links the account and redirects to the success page", async () => {
+		const cache = makeMockCache({ "link_state:st-1": KEY })
+		const db = makeMockDB([null, null]) // linkDiscord: delete, insert
+		const app = linkRoutes(
+			makeEnv(db, cache),
+			discordFetch({ id: "d-1", username: "alice", global_name: "Alice" })
+		)
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=c-1&state=st-1", {
+				redirect: "manual",
+			})
+		)
+
+		expect(res.status).toBe(302)
+		const loc = res.headers.get("location") ?? ""
+		expect(loc).toContain("/link?status=linked")
+		expect(loc).toContain("name=Alice")
+		const insert = db.calls.find((c) => c.sql.includes("INSERT INTO discord_links"))
+		expect(insert?.params).toEqual(["d-1", KEY, "Alice", expect.any(Number)])
+		// state is single-use
+		expect(cache.store.has("link_state:st-1")).toBe(false)
+	})
+
+	it("redirects to expired when the state is unknown", async () => {
+		const cache = makeMockCache()
+		const app = linkRoutes(makeEnv(makeMockDB(), cache), discordFetch({ id: "d", username: "x" }))
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=c&state=missing", {
+				redirect: "manual",
+			})
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("status=expired")
+	})
+
+	it("redirects to blocked when the key is blacklisted", async () => {
+		const cache = makeMockCache({ "link_state:st-2": COMMUNITY_KEY_ID })
+		const app = linkRoutes(makeEnv(makeMockDB(), cache), discordFetch({ id: "d", username: "x" }))
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=c&state=st-2", {
+				redirect: "manual",
+			})
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("status=blocked")
+	})
+
+	it("redirects to error when Discord exchange fails", async () => {
+		const cache = makeMockCache({ "link_state:st-3": KEY })
+		const failing = (async (input: string | URL | Request) => {
+			if (String(input).endsWith("/oauth2/token")) return new Response(null, { status: 400 })
+			return new Response(null, { status: 404 })
+		}) as typeof fetch
+		const app = linkRoutes(makeEnv(makeMockDB(), cache), failing)
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=bad&state=st-3", {
+				redirect: "manual",
+			})
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("status=error")
+	})
+
+	it("redirects to error when params are missing", async () => {
+		const app = linkRoutes(
+			makeEnv(makeMockDB(), makeMockCache()),
+			discordFetch({ id: "d", username: "x" })
+		)
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback", { redirect: "manual" })
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("status=error")
+	})
+})
+
+describe("bot read endpoints", () => {
+	it("returns all links to an authorized bot", async () => {
+		const rows = [{ discord_id: "d1", key_id: "k1" }]
+		const db = makeMockDB([rows])
+		const app = linkRoutes(makeEnv(db, makeMockCache(), { BUTLER_BOT_SECRET: "bot-secret" }))
+		const res = await app.handle(
+			new Request("http://localhost/links/bot/all", {
+				headers: { authorization: "Bearer bot-secret" },
+			})
+		)
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true, data: { links: rows } })
+	})
+
+	it("rejects an unauthorized bot request", async () => {
+		const app = linkRoutes(
+			makeEnv(makeMockDB(), makeMockCache(), { BUTLER_BOT_SECRET: "bot-secret" })
+		)
+		const res = await app.handle(
+			new Request("http://localhost/links/bot/all", {
+				headers: { authorization: "Bearer wrong" },
+			})
+		)
+		expect(res.status).toBe(401)
+	})
+
+	it("returns the blacklist to an authorized bot", async () => {
+		const app = linkRoutes(
+			makeEnv(makeMockDB(), makeMockCache(), { BUTLER_BOT_SECRET: "bot-secret" })
+		)
+		const res = await app.handle(
+			new Request("http://localhost/links/bot/blacklist", {
+				headers: { authorization: "Bearer bot-secret" },
+			})
+		)
+		expect(res.status).toBe(200)
+		const json = (await res.json()) as { data: { keyIds: string[] } }
+		expect(json.data.keyIds).toContain(COMMUNITY_KEY_ID)
+	})
+})
+
+describe("GET /links/me and DELETE /links/discord", () => {
+	const KEY = "a".repeat(64)
+	const TOKEN = "session-token"
+
+	function sessionEnv(db: ReturnType<typeof makeMockDB>) {
+		const cache = makeMockCache({
+			[`session:${TOKEN}`]: JSON.stringify({ keyId: KEY, issuedAt: 0, expiresAt: 9_999_999_999 }),
+		})
+		return makeEnv(db, cache)
+	}
+
+	it("reports linked status for the signed-in user", async () => {
+		const db = makeMockDB([
+			{ id: 7, key_id: KEY }, // getOrCreateUser (eitherAuth)
+			{ discord_id: "d-1", key_id: KEY, discord_username: "alice", linked_at: 1 }, // getByKeyId
+		])
+		const app = linkRoutes(sessionEnv(db))
+		const res = await app.handle(
+			new Request("http://localhost/links/me", { headers: { authorization: `Bearer ${TOKEN}` } })
+		)
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({
+			success: true,
+			data: { linked: true, discordId: "d-1", discordUsername: "alice" },
+		})
+	})
+
+	it("reports not-linked when there is no link", async () => {
+		const db = makeMockDB([
+			{ id: 7, key_id: KEY }, // getOrCreateUser
+			null, // getByKeyId -> none
+		])
+		const app = linkRoutes(sessionEnv(db))
+		const res = await app.handle(
+			new Request("http://localhost/links/me", { headers: { authorization: `Bearer ${TOKEN}` } })
+		)
+		expect(res.status).toBe(200)
+		expect(((await res.json()) as { data: { linked: boolean } }).data.linked).toBe(false)
+	})
+
+	it("unlinks the signed-in user", async () => {
+		const db = makeMockDB([
+			{ id: 7, key_id: KEY }, // getOrCreateUser
+			null, // unlinkByKeyId delete
+		])
+		const app = linkRoutes(sessionEnv(db))
+		const res = await app.handle(
+			new Request("http://localhost/links/discord", {
+				method: "DELETE",
+				headers: { authorization: `Bearer ${TOKEN}` },
+			})
+		)
+		expect(res.status).toBe(200)
+		const del = db.calls.find((c) => c.sql.includes("DELETE FROM discord_links"))
+		expect(del?.params).toEqual([KEY])
+	})
+})

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { COMMUNITY_KEY_ID } from "@/utils/blacklist"
+import { COMMUNITY_KEY_ID } from "@/config"
 import { canonicalJson, hashPublicKey } from "@/utils/crypto"
 import type { Env } from "@/types"
 import { linkRoutes, linkStartRoutes } from "./links"

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -17,6 +17,8 @@ function makeMockDB(queue: unknown[] = []) {
 			return {
 				bind(...args: unknown[]) {
 					return {
+						getSql: () => sql,
+						getParams: () => args,
 						async first<T>(): Promise<T | null> {
 							calls.push({ sql, params: args })
 							return (queue.shift() as T) ?? null
@@ -31,6 +33,11 @@ function makeMockDB(queue: unknown[] = []) {
 						},
 					}
 				},
+			}
+		},
+		async batch(stmts: Array<{ getSql(): string; getParams(): unknown[] }>): Promise<void> {
+			for (const stmt of stmts) {
+				calls.push({ sql: stmt.getSql(), params: stmt.getParams() })
 			}
 		},
 	}

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -1,0 +1,115 @@
+import { Elysia, t } from "elysia"
+import { config } from "@/config"
+import { getByKeyId, linkDiscord, listLinks, unlinkByKeyId } from "@/db/discordLinks"
+import { Logger } from "@/infra/logger"
+import type { Env } from "@/types"
+import { eitherAuth } from "@/utils/either-auth"
+import { signedRequest } from "@/utils/auth"
+import { isLinkBlacklisted, listBlacklistedKeyIds } from "@/utils/blacklist"
+import { isAuthorizedBot } from "@/utils/bot-auth"
+import { buildAuthorizeUrl, exchangeCodeForUser } from "@/utils/discord-oauth"
+import { ErrorCode, buildError } from "@/utils/errors"
+import { generateSessionToken } from "@/utils/session"
+
+const log = new Logger("links")
+
+const LINK_STATE_PREFIX = "link_state:"
+const LINK_PAGE = "/link"
+
+function redirectToLinkPage(status: string, name?: string): Response {
+	const params = new URLSearchParams({ status })
+	if (name) params.set("name", name)
+	return new Response(null, {
+		status: 302,
+		headers: { location: `${LINK_PAGE}?${params.toString()}` },
+	})
+}
+
+export const linkStartRoutes = (env: Env) =>
+	new Elysia({ prefix: "/links" })
+		.decorate("env", env)
+		.use(signedRequest)
+		.post("/discord/start", async ({ env, keyId, status }) => {
+			const oauth = env.DISCORD_OAUTH
+			if (!oauth) {
+				return status(503, buildError(ErrorCode.LINKING_DISABLED))
+			}
+			if (isLinkBlacklisted(keyId)) {
+				log.warn("blacklisted key attempted to start a link", { keyId })
+				return status(403, buildError(ErrorCode.LINK_BLACKLISTED))
+			}
+
+			const state = generateSessionToken()
+			await env.CACHE.put(`${LINK_STATE_PREFIX}${state}`, keyId, {
+				expirationTtl: config.linking.stateTtlSeconds,
+			})
+			const authorizeUrl = buildAuthorizeUrl(oauth, state, config.linking.discordScope)
+			return status(200, { success: true, data: { authorizeUrl } })
+		})
+
+export const linkRoutes = (env: Env, fetchImpl: typeof fetch = fetch) =>
+	new Elysia({ prefix: "/links" })
+		.decorate("env", env)
+		.get(
+			"/discord/callback",
+			async ({ env, query }) => {
+				const { code, state } = query
+				if (!code || !state) return redirectToLinkPage("error")
+
+				const keyId = await env.CACHE.getDel(`${LINK_STATE_PREFIX}${state}`)
+				if (!keyId) return redirectToLinkPage("expired")
+				if (isLinkBlacklisted(keyId)) {
+					log.warn("blacklisted key reached link callback", { keyId })
+					return redirectToLinkPage("blocked")
+				}
+
+				const oauth = env.DISCORD_OAUTH
+				if (!oauth) return redirectToLinkPage("error")
+
+				let identity: Awaited<ReturnType<typeof exchangeCodeForUser>>
+				try {
+					identity = await exchangeCodeForUser(oauth, code, fetchImpl)
+				} catch (err) {
+					log.warn("discord oauth exchange failed", { error: (err as Error).message })
+					return redirectToLinkPage("error")
+				}
+
+				await linkDiscord(env, {
+					discordId: identity.id,
+					keyId,
+					discordUsername: identity.displayName,
+				})
+				log.info("account linked", { keyId, discordId: identity.id })
+				return redirectToLinkPage("linked", identity.displayName)
+			},
+			{ query: t.Object({ code: t.Optional(t.String()), state: t.Optional(t.String()) }) }
+		)
+		.get("/bot/all", async ({ env, headers, status }) => {
+			if (!isAuthorizedBot(headers.authorization, env)) {
+				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+			}
+			const links = await listLinks(env)
+			return status(200, { success: true, data: { links } })
+		})
+		.get("/bot/blacklist", ({ env, headers, status }) => {
+			if (!isAuthorizedBot(headers.authorization, env)) {
+				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+			}
+			return status(200, { success: true, data: { keyIds: listBlacklistedKeyIds() } })
+		})
+		.use(eitherAuth)
+		.get("/me", async ({ env, keyId, status }) => {
+			const link = await getByKeyId(env, keyId)
+			return status(200, {
+				success: true,
+				data: {
+					linked: link !== null,
+					discordId: link?.discord_id ?? null,
+					discordUsername: link?.discord_username ?? null,
+				},
+			})
+		})
+		.delete("/discord", async ({ env, keyId, status }) => {
+			await unlinkByKeyId(env, keyId)
+			return status(200, { success: true, data: { unlinked: true } })
+		})

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -5,7 +5,7 @@ import { Logger } from "@/infra/logger"
 import type { Env } from "@/types"
 import { eitherAuth } from "@/utils/either-auth"
 import { signedRequest } from "@/utils/auth"
-import { isLinkBlacklisted, listBlacklistedKeyIds } from "@/utils/blacklist"
+import { isLinkBlacklisted } from "@/utils/blacklist"
 import { isAuthorizedBot } from "@/utils/bot-auth"
 import { buildAuthorizeUrl, exchangeCodeForUser } from "@/utils/discord-oauth"
 import { ErrorCode, buildError } from "@/utils/errors"
@@ -95,7 +95,7 @@ export const linkRoutes = (env: Env, fetchImpl: typeof fetch = fetch) =>
 			if (!isAuthorizedBot(headers.authorization, env)) {
 				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
 			}
-			return status(200, { success: true, data: { keyIds: listBlacklistedKeyIds() } })
+			return status(200, { success: true, data: { keyIds: [...config.linking.blacklistedKeyIds] } })
 		})
 		.use(eitherAuth)
 		.get("/me", async ({ env, keyId, status }) => {

--- a/src/routes/requests.test.ts
+++ b/src/routes/requests.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { config } from "@/config"
 import type { Env } from "@/types"
 import { canonicalJson, hashPublicKey } from "@/utils/crypto"
 import { requestRoutes } from "./requests"
@@ -203,5 +204,201 @@ describe("POST /requests", () => {
 		)
 
 		expect(res.status).toBe(400)
+	})
+})
+
+const BOT_SECRET = "butler-bot-secret-value"
+
+function envWithBotSecret(db: ReturnType<typeof makeMockDB>): Env {
+	const env = makeEnv(db)
+	env.BUTLER_BOT_SECRET = BOT_SECRET
+	return env
+}
+
+function botRequest(body: unknown, secret: string | null = BOT_SECRET): Request {
+	const headers: Record<string, string> = { "content-type": "application/json" }
+	if (secret !== null) headers.authorization = `Bearer ${secret}`
+	return new Request("http://localhost/requests/bot", {
+		method: "POST",
+		headers,
+		body: JSON.stringify(body),
+	})
+}
+
+function lyricsRequestInsert(db: ReturnType<typeof makeMockDB>): DBCall | undefined {
+	return db.calls.find((c) => c.sql.includes("INSERT INTO lyrics_requests"))
+}
+
+describe("POST /requests/bot", () => {
+	it("attributes a linked request to the keyId at the user's reputation weight", async () => {
+		const keyId = "a".repeat(64)
+		const db = makeMockDB([
+			{ id: 7, key_id: keyId, reputation: 1.4 }, // getUserByKeyId
+			null, // hasServableSyncedVariant -> none
+			null, // requested_songs upsert
+			{ id: 100 }, // lyrics_requests insert RETURNING
+			{ demand: 1.4, request_count: 1 }, // videoDemand
+		])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({
+				videoId: "vid1",
+				song: "Song",
+				artist: "Artist",
+				thumbnailUrl: "https://x/t.jpg",
+				keyId,
+			})
+		)
+
+		expect(res.status).toBe(201)
+		expect(await res.json()).toEqual({
+			success: true,
+			data: { status: "created", demand: 1.4, requestCount: 1 },
+		})
+
+		const insert = lyricsRequestInsert(db)
+		expect(insert?.params).toEqual(["vid1", keyId, "discord", 1.4, expect.any(Number)])
+	})
+
+	it("submits an unlinked request at the neutral weight keyed by requesterId", async () => {
+		const db = makeMockDB([
+			null, // hasServableSyncedVariant -> none
+			null, // requested_songs upsert
+			{ id: 101 }, // lyrics_requests insert RETURNING
+			{ demand: 1, request_count: 1 }, // videoDemand
+		])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({
+				videoId: "vid2",
+				song: "Song",
+				artist: "Artist",
+				requesterId: "discord-user-123",
+			})
+		)
+
+		expect(res.status).toBe(201)
+		const insert = lyricsRequestInsert(db)
+		expect(insert?.params).toEqual([
+			"vid2",
+			"discord-user-123",
+			"discord",
+			config.requests.discordNeutralWeight,
+			expect.any(Number),
+		])
+	})
+
+	it("falls back to the neutral weight when the linked user has no row yet", async () => {
+		const keyId = "b".repeat(64)
+		const db = makeMockDB([
+			null, // getUserByKeyId -> not found
+			null, // hasServableSyncedVariant
+			null, // requested_songs upsert
+			{ id: 102 }, // insert
+			{ demand: 1, request_count: 1 }, // demand
+		])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({ videoId: "vid3", song: "Song", artist: "Artist", keyId })
+		)
+
+		expect(res.status).toBe(201)
+		expect(lyricsRequestInsert(db)?.params[3]).toBe(config.requests.discordNeutralWeight)
+	})
+
+	it("passes through already_available without creating a request", async () => {
+		const db = makeMockDB([
+			null, // getUserByKeyId
+			{ ok: 1 }, // hasServableSyncedVariant -> synced exists
+		])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({ videoId: "vid4", song: "Song", artist: "Artist", keyId: "c".repeat(64) })
+		)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true, data: { status: "already_available" } })
+		expect(lyricsRequestInsert(db)).toBeUndefined()
+	})
+
+	describe("auth", () => {
+		it("rejects a missing bot secret with 401", async () => {
+			const db = makeMockDB([])
+			const env = envWithBotSecret(db)
+			const app = requestRoutes(env)
+
+			const res = await app.handle(
+				botRequest({ videoId: "v", song: "S", artist: "A", requesterId: "d" }, null)
+			)
+			expect(res.status).toBe(401)
+		})
+
+		it("rejects a wrong bot secret with 401", async () => {
+			const db = makeMockDB([])
+			const env = envWithBotSecret(db)
+			const app = requestRoutes(env)
+
+			const res = await app.handle(
+				botRequest({ videoId: "v", song: "S", artist: "A", requesterId: "d" }, "wrong-secret")
+			)
+			expect(res.status).toBe(401)
+		})
+
+		it("rejects when no bot secret is configured on the server with 401", async () => {
+			const db = makeMockDB([])
+			const env = makeEnv(db) // no BUTLER_BOT_SECRET
+			const app = requestRoutes(env)
+
+			const res = await app.handle(
+				botRequest({ videoId: "v", song: "S", artist: "A", requesterId: "d" }, "anything")
+			)
+			expect(res.status).toBe(401)
+		})
+	})
+
+	describe("validation", () => {
+		it("rejects a request missing the videoId with 400", async () => {
+			const db = makeMockDB([])
+			const env = envWithBotSecret(db)
+			const app = requestRoutes(env)
+
+			const res = await app.handle(
+				botRequest({ videoId: "", song: "S", artist: "A", requesterId: "d" })
+			)
+			expect(res.status).toBe(400)
+		})
+
+		it("rejects a request with neither keyId nor requesterId with 400", async () => {
+			const db = makeMockDB([])
+			const env = envWithBotSecret(db)
+			const app = requestRoutes(env)
+
+			const res = await app.handle(botRequest({ videoId: "v", song: "S", artist: "A" }))
+			expect(res.status).toBe(400)
+		})
+
+		it("rejects an over-long song name with 400", async () => {
+			const db = makeMockDB([])
+			const env = envWithBotSecret(db)
+			const app = requestRoutes(env)
+
+			const res = await app.handle(
+				botRequest({
+					videoId: "v",
+					song: "x".repeat(config.validation.song.maxLength + 1),
+					artist: "A",
+					requesterId: "d",
+				})
+			)
+			expect(res.status).toBe(400)
+		})
 	})
 })

--- a/src/routes/requests.test.ts
+++ b/src/routes/requests.test.ts
@@ -312,6 +312,54 @@ describe("POST /requests/bot", () => {
 		expect(lyricsRequestInsert(db)?.params[3]).toBe(config.requests.discordNeutralWeight)
 	})
 
+	it("resolves a discordId to its linked key and attributes at that reputation", async () => {
+		const keyId = "d".repeat(64)
+		const db = makeMockDB([
+			{ discord_id: "disc-1", key_id: keyId }, // getByDiscordId
+			{ id: 9, key_id: keyId, reputation: 1.7 }, // getUserByKeyId
+			null, // hasServableSyncedVariant
+			null, // requested_songs upsert
+			{ id: 200 }, // lyrics_requests insert
+			{ demand: 1.7, request_count: 1 }, // videoDemand
+		])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({ videoId: "vid5", song: "Song", artist: "Artist", discordId: "disc-1" })
+		)
+
+		expect(res.status).toBe(201)
+		const insert = lyricsRequestInsert(db)
+		expect(insert?.params).toEqual(["vid5", keyId, "discord", 1.7, expect.any(Number)])
+	})
+
+	it("submits at neutral weight keyed by discordId when that Discord user is unlinked", async () => {
+		const db = makeMockDB([
+			null, // getByDiscordId -> not linked
+			null, // hasServableSyncedVariant
+			null, // requested_songs upsert
+			{ id: 201 }, // lyrics_requests insert
+			{ demand: 1, request_count: 1 }, // videoDemand
+		])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({ videoId: "vid6", song: "Song", artist: "Artist", discordId: "disc-2" })
+		)
+
+		expect(res.status).toBe(201)
+		const insert = lyricsRequestInsert(db)
+		expect(insert?.params).toEqual([
+			"vid6",
+			"disc-2",
+			"discord",
+			config.requests.discordNeutralWeight,
+			expect.any(Number),
+		])
+	})
+
 	it("passes through already_available without creating a request", async () => {
 		const db = makeMockDB([
 			null, // getUserByKeyId

--- a/src/routes/requests.test.ts
+++ b/src/routes/requests.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { config } from "@/config"
+import { COMMUNITY_KEY_ID, config } from "@/config"
 import type { Env } from "@/types"
 import { canonicalJson, hashPublicKey } from "@/utils/crypto"
 import { requestRoutes } from "./requests"
@@ -259,7 +259,20 @@ describe("POST /requests/bot", () => {
 		})
 
 		const insert = lyricsRequestInsert(db)
-		expect(insert?.params).toEqual(["vid1", keyId, "discord", 1.4, expect.any(Number)])
+		expect(insert?.params).toEqual(["vid1", keyId, "extension", 1.4, expect.any(Number)])
+	})
+
+	it("rejects a request attributed to a blacklisted key", async () => {
+		const db = makeMockDB([])
+		const env = envWithBotSecret(db)
+		const app = requestRoutes(env)
+
+		const res = await app.handle(
+			botRequest({ videoId: "vid1", song: "Song", artist: "Artist", keyId: COMMUNITY_KEY_ID })
+		)
+
+		expect(res.status).toBe(403)
+		expect(lyricsRequestInsert(db)).toBeUndefined()
 	})
 
 	it("submits an unlinked request at the neutral weight keyed by requesterId", async () => {
@@ -331,7 +344,7 @@ describe("POST /requests/bot", () => {
 
 		expect(res.status).toBe(201)
 		const insert = lyricsRequestInsert(db)
-		expect(insert?.params).toEqual(["vid5", keyId, "discord", 1.7, expect.any(Number)])
+		expect(insert?.params).toEqual(["vid5", keyId, "extension", 1.7, expect.any(Number)])
 	})
 
 	it("submits at neutral weight keyed by discordId when that Discord user is unlinked", async () => {

--- a/src/routes/requests.ts
+++ b/src/routes/requests.ts
@@ -5,6 +5,7 @@ import { createRequest } from "@/db/requests"
 import { getUserById, getUserByKeyId } from "@/db/users"
 import type { Env } from "@/types"
 import { signedRequest } from "@/utils/auth"
+import { isLinkBlacklisted } from "@/utils/blacklist"
 import { isAuthorizedBot } from "@/utils/bot-auth"
 import { ErrorCode, buildError } from "@/utils/errors"
 
@@ -77,6 +78,10 @@ export const requestRoutes = (env: Env) =>
 				attributedKeyId = link?.key_id ?? null
 			}
 
+			if (attributedKeyId && isLinkBlacklisted(attributedKeyId)) {
+				return status(403, buildError(ErrorCode.LINK_BLACKLISTED))
+			}
+
 			const requesterId = attributedKeyId ?? discordId ?? requesterIdInput
 			if (!requesterId) {
 				return status(
@@ -104,7 +109,7 @@ export const requestRoutes = (env: Env) =>
 				artist,
 				thumbnailUrl: readThumbnailUrl(b),
 				requesterId,
-				requesterType: "discord",
+				requesterType: attributedKeyId ? "extension" : "discord",
 				weight,
 			})
 

--- a/src/routes/requests.ts
+++ b/src/routes/requests.ts
@@ -1,14 +1,120 @@
+import { timingSafeEqual } from "node:crypto"
 import { Elysia } from "elysia"
 import { config } from "@/config"
 import { createRequest } from "@/db/requests"
-import { getUserById } from "@/db/users"
+import { getUserById, getUserByKeyId } from "@/db/users"
 import type { Env } from "@/types"
 import { signedRequest } from "@/utils/auth"
 import { ErrorCode, buildError } from "@/utils/errors"
 
+type FieldErrorCode =
+	| typeof ErrorCode.INVALID_PAYLOAD
+	| typeof ErrorCode.SONG_TOO_LONG
+	| typeof ErrorCode.ARTIST_TOO_LONG
+
+type RequestFields = { videoId: string; song: string; artist: string }
+
+type FieldValidation = { ok: true; fields: RequestFields } | { ok: false; code: FieldErrorCode }
+
+function validateRequestFields(p: Record<string, unknown>): FieldValidation {
+	if (
+		typeof p.videoId !== "string" ||
+		!p.videoId ||
+		typeof p.song !== "string" ||
+		!p.song ||
+		typeof p.artist !== "string" ||
+		!p.artist
+	) {
+		return { ok: false, code: ErrorCode.INVALID_PAYLOAD }
+	}
+	if (p.song.length > config.validation.song.maxLength) {
+		return { ok: false, code: ErrorCode.SONG_TOO_LONG }
+	}
+	if (p.artist.length > config.validation.artist.maxLength) {
+		return { ok: false, code: ErrorCode.ARTIST_TOO_LONG }
+	}
+	return { ok: true, fields: { videoId: p.videoId, song: p.song, artist: p.artist } }
+}
+
+function fieldErrorBody(code: FieldErrorCode) {
+	const overrides =
+		code === ErrorCode.INVALID_PAYLOAD ? { error: "Invalid request payload" } : undefined
+	return buildError(code, overrides)
+}
+
+function readThumbnailUrl(p: Record<string, unknown>): string | null {
+	return typeof p.thumbnailUrl === "string" && p.thumbnailUrl ? p.thumbnailUrl : null
+}
+
+function extractBearer(header: unknown): string | null {
+	if (typeof header !== "string") return null
+	const match = /^Bearer (.+)$/.exec(header)
+	return match ? match[1] : null
+}
+
+function secretsMatch(provided: string, expected: string): boolean {
+	const a = Buffer.from(provided)
+	const b = Buffer.from(expected)
+	if (a.length !== b.length) return false
+	return timingSafeEqual(a, b)
+}
+
 export const requestRoutes = (env: Env) =>
 	new Elysia({ prefix: "/requests" })
 		.decorate("env", env)
+		.post("/bot", async ({ env, headers, body, status }) => {
+			const secret = env.BUTLER_BOT_SECRET
+			const provided = extractBearer(headers.authorization)
+			if (!secret || !provided || !secretsMatch(provided, secret)) {
+				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+			}
+
+			const b = (body ?? {}) as Record<string, unknown>
+			const validation = validateRequestFields(b)
+			if (!validation.ok) {
+				return status(400, fieldErrorBody(validation.code))
+			}
+			const { videoId, song, artist } = validation.fields
+
+			const keyId = typeof b.keyId === "string" && b.keyId ? b.keyId : null
+			const requesterIdInput =
+				typeof b.requesterId === "string" && b.requesterId ? b.requesterId : null
+			if (!keyId && !requesterIdInput) {
+				return status(
+					400,
+					buildError(ErrorCode.INVALID_PAYLOAD, { error: "keyId or requesterId required" })
+				)
+			}
+
+			const requesterId = keyId ?? (requesterIdInput as string)
+			const { success } = await env.RATE_LIMITER.limit({ key: requesterId })
+			if (!success) {
+				return status(429, buildError(ErrorCode.RATE_LIMITED))
+			}
+
+			let weight: number = config.requests.discordNeutralWeight
+			if (keyId) {
+				const user = await getUserByKeyId(env, keyId)
+				weight = user?.reputation ?? config.requests.discordNeutralWeight
+			}
+
+			const result = await createRequest(env, {
+				videoId,
+				song,
+				artist,
+				thumbnailUrl: readThumbnailUrl(b),
+				requesterId,
+				requesterType: "discord",
+				weight,
+			})
+
+			if (result.status === "already_available") {
+				return status(200, { success: true, data: { status: result.status } })
+			}
+
+			const code = result.status === "created" ? 201 : 200
+			return status(code, { success: true, data: result })
+		})
 		.use(signedRequest)
 		.post("/", async ({ env, keyId, userId, signedPayload, status }) => {
 			const { success } = await env.RATE_LIMITER.limit({ key: keyId })
@@ -16,39 +122,20 @@ export const requestRoutes = (env: Env) =>
 				return status(429, buildError(ErrorCode.RATE_LIMITED))
 			}
 
-			const p = signedPayload
-			if (
-				typeof p.videoId !== "string" ||
-				!p.videoId ||
-				typeof p.song !== "string" ||
-				!p.song ||
-				typeof p.artist !== "string" ||
-				!p.artist
-			) {
-				return status(
-					400,
-					buildError(ErrorCode.INVALID_PAYLOAD, { error: "Invalid request payload" })
-				)
+			const validation = validateRequestFields(signedPayload)
+			if (!validation.ok) {
+				return status(400, fieldErrorBody(validation.code))
 			}
-
-			if (p.song.length > config.validation.song.maxLength) {
-				return status(400, buildError(ErrorCode.SONG_TOO_LONG))
-			}
-			if (p.artist.length > config.validation.artist.maxLength) {
-				return status(400, buildError(ErrorCode.ARTIST_TOO_LONG))
-			}
-
-			const thumbnailUrl =
-				typeof p.thumbnailUrl === "string" && p.thumbnailUrl ? p.thumbnailUrl : null
+			const { videoId, song, artist } = validation.fields
 
 			const user = await getUserById(env, userId)
 			const weight = user?.reputation ?? 1.0
 
 			const result = await createRequest(env, {
-				videoId: p.videoId,
-				song: p.song,
-				artist: p.artist,
-				thumbnailUrl,
+				videoId,
+				song,
+				artist,
+				thumbnailUrl: readThumbnailUrl(signedPayload),
 				requesterId: keyId,
 				requesterType: "extension",
 				weight,

--- a/src/routes/requests.ts
+++ b/src/routes/requests.ts
@@ -1,10 +1,11 @@
-import { timingSafeEqual } from "node:crypto"
 import { Elysia } from "elysia"
 import { config } from "@/config"
+import { getByDiscordId } from "@/db/discordLinks"
 import { createRequest } from "@/db/requests"
 import { getUserById, getUserByKeyId } from "@/db/users"
 import type { Env } from "@/types"
 import { signedRequest } from "@/utils/auth"
+import { isAuthorizedBot } from "@/utils/bot-auth"
 import { ErrorCode, buildError } from "@/utils/errors"
 
 type FieldErrorCode =
@@ -46,26 +47,16 @@ function readThumbnailUrl(p: Record<string, unknown>): string | null {
 	return typeof p.thumbnailUrl === "string" && p.thumbnailUrl ? p.thumbnailUrl : null
 }
 
-function extractBearer(header: unknown): string | null {
-	if (typeof header !== "string") return null
-	const match = /^Bearer (.+)$/.exec(header)
-	return match ? match[1] : null
-}
-
-function secretsMatch(provided: string, expected: string): boolean {
-	const a = Buffer.from(provided)
-	const b = Buffer.from(expected)
-	if (a.length !== b.length) return false
-	return timingSafeEqual(a, b)
+function readString(p: Record<string, unknown>, key: string): string | null {
+	const value = p[key]
+	return typeof value === "string" && value ? value : null
 }
 
 export const requestRoutes = (env: Env) =>
 	new Elysia({ prefix: "/requests" })
 		.decorate("env", env)
 		.post("/bot", async ({ env, headers, body, status }) => {
-			const secret = env.BUTLER_BOT_SECRET
-			const provided = extractBearer(headers.authorization)
-			if (!secret || !provided || !secretsMatch(provided, secret)) {
+			if (!isAuthorizedBot(headers.authorization, env)) {
 				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
 			}
 
@@ -76,25 +67,34 @@ export const requestRoutes = (env: Env) =>
 			}
 			const { videoId, song, artist } = validation.fields
 
-			const keyId = typeof b.keyId === "string" && b.keyId ? b.keyId : null
-			const requesterIdInput =
-				typeof b.requesterId === "string" && b.requesterId ? b.requesterId : null
-			if (!keyId && !requesterIdInput) {
+			const explicitKeyId = readString(b, "keyId")
+			const discordId = readString(b, "discordId")
+			const requesterIdInput = readString(b, "requesterId")
+
+			let attributedKeyId = explicitKeyId
+			if (!attributedKeyId && discordId) {
+				const link = await getByDiscordId(env, discordId)
+				attributedKeyId = link?.key_id ?? null
+			}
+
+			const requesterId = attributedKeyId ?? discordId ?? requesterIdInput
+			if (!requesterId) {
 				return status(
 					400,
-					buildError(ErrorCode.INVALID_PAYLOAD, { error: "keyId or requesterId required" })
+					buildError(ErrorCode.INVALID_PAYLOAD, {
+						error: "keyId, discordId, or requesterId required",
+					})
 				)
 			}
 
-			const requesterId = keyId ?? (requesterIdInput as string)
 			const { success } = await env.RATE_LIMITER.limit({ key: requesterId })
 			if (!success) {
 				return status(429, buildError(ErrorCode.RATE_LIMITED))
 			}
 
 			let weight: number = config.requests.discordNeutralWeight
-			if (keyId) {
-				const user = await getUserByKeyId(env, keyId)
+			if (attributedKeyId) {
+				const user = await getUserByKeyId(env, attributedKeyId)
 				weight = user?.reputation ?? config.requests.discordNeutralWeight
 			}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface Env {
 	DUMP_DATABASE_URL: string | null
 	B2: B2Config | null
 	BUTLER_BOT_SECRET?: string | null
+	DISCORD_OAUTH?: { clientId: string; clientSecret: string; redirectUri: string } | null
 }
 
 export interface RateLimiter {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface Env {
 	DUMP_PUBLIC_BASE_URL: string
 	DUMP_DATABASE_URL: string | null
 	B2: B2Config | null
+	BUTLER_BOT_SECRET?: string | null
 }
 
 export interface RateLimiter {

--- a/src/utils/blacklist.test.ts
+++ b/src/utils/blacklist.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { COMMUNITY_KEY_ID, isLinkBlacklisted, listBlacklistedKeyIds } from "./blacklist"
+
+describe("link blacklist", () => {
+	it("flags the community account", () => {
+		expect(isLinkBlacklisted(COMMUNITY_KEY_ID)).toBe(true)
+	})
+
+	it("ignores a normal key", () => {
+		expect(isLinkBlacklisted("b".repeat(64))).toBe(false)
+	})
+
+	describe("edge cases", () => {
+		it("matches case-insensitively", () => {
+			expect(isLinkBlacklisted(COMMUNITY_KEY_ID.toUpperCase())).toBe(true)
+		})
+
+		it("returns false for empty input", () => {
+			expect(isLinkBlacklisted("")).toBe(false)
+		})
+
+		it("exposes the community key in the listed set", () => {
+			expect(listBlacklistedKeyIds()).toContain(COMMUNITY_KEY_ID)
+		})
+	})
+})

--- a/src/utils/blacklist.test.ts
+++ b/src/utils/blacklist.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { COMMUNITY_KEY_ID } from "@/config"
-import { isLinkBlacklisted, listBlacklistedKeyIds } from "./blacklist"
+import { isLinkBlacklisted } from "./blacklist"
 
 describe("link blacklist", () => {
 	it("flags the community account", () => {
@@ -18,10 +18,6 @@ describe("link blacklist", () => {
 
 		it("returns false for empty input", () => {
 			expect(isLinkBlacklisted("")).toBe(false)
-		})
-
-		it("exposes the community key in the listed set", () => {
-			expect(listBlacklistedKeyIds()).toContain(COMMUNITY_KEY_ID)
 		})
 	})
 })

--- a/src/utils/blacklist.test.ts
+++ b/src/utils/blacklist.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { COMMUNITY_KEY_ID, isLinkBlacklisted, listBlacklistedKeyIds } from "./blacklist"
+import { COMMUNITY_KEY_ID } from "@/config"
+import { isLinkBlacklisted, listBlacklistedKeyIds } from "./blacklist"
 
 describe("link blacklist", () => {
 	it("flags the community account", () => {

--- a/src/utils/blacklist.ts
+++ b/src/utils/blacklist.ts
@@ -1,7 +1,5 @@
 import { config } from "@/config"
 
-export const COMMUNITY_KEY_ID = "cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e"
-
 export function isLinkBlacklisted(keyId: string): boolean {
 	if (!keyId) return false
 	return config.linking.blacklistedKeyIds.has(keyId.toLowerCase())

--- a/src/utils/blacklist.ts
+++ b/src/utils/blacklist.ts
@@ -1,0 +1,12 @@
+import { config } from "@/config"
+
+export const COMMUNITY_KEY_ID = "cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e"
+
+export function isLinkBlacklisted(keyId: string): boolean {
+	if (!keyId) return false
+	return config.linking.blacklistedKeyIds.has(keyId.toLowerCase())
+}
+
+export function listBlacklistedKeyIds(): string[] {
+	return [...config.linking.blacklistedKeyIds]
+}

--- a/src/utils/blacklist.ts
+++ b/src/utils/blacklist.ts
@@ -4,7 +4,3 @@ export function isLinkBlacklisted(keyId: string): boolean {
 	if (!keyId) return false
 	return config.linking.blacklistedKeyIds.has(keyId.toLowerCase())
 }
-
-export function listBlacklistedKeyIds(): string[] {
-	return [...config.linking.blacklistedKeyIds]
-}

--- a/src/utils/bot-auth.test.ts
+++ b/src/utils/bot-auth.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import type { Env } from "@/types"
+import { isAuthorizedBot } from "./bot-auth"
+
+function envWith(secret: string | null): Env {
+	return { BUTLER_BOT_SECRET: secret } as unknown as Env
+}
+
+describe("isAuthorizedBot", () => {
+	it("accepts the correct bearer secret", () => {
+		expect(isAuthorizedBot("Bearer s3cret", envWith("s3cret"))).toBe(true)
+	})
+
+	describe("rejections", () => {
+		it("rejects a wrong secret", () => {
+			expect(isAuthorizedBot("Bearer nope", envWith("s3cret"))).toBe(false)
+		})
+
+		it("rejects a missing header", () => {
+			expect(isAuthorizedBot(undefined, envWith("s3cret"))).toBe(false)
+		})
+
+		it("rejects a non-bearer header", () => {
+			expect(isAuthorizedBot("s3cret", envWith("s3cret"))).toBe(false)
+		})
+
+		it("rejects when no secret is configured", () => {
+			expect(isAuthorizedBot("Bearer anything", envWith(null))).toBe(false)
+		})
+
+		it("rejects a secret of a different length without throwing", () => {
+			expect(isAuthorizedBot("Bearer short", envWith("a-much-longer-secret"))).toBe(false)
+		})
+	})
+})

--- a/src/utils/bot-auth.ts
+++ b/src/utils/bot-auth.ts
@@ -1,0 +1,23 @@
+import { timingSafeEqual } from "node:crypto"
+import type { Env } from "@/types"
+
+function extractBearer(header: unknown): string | null {
+	if (typeof header !== "string") return null
+	const match = /^Bearer (.+)$/.exec(header)
+	return match ? match[1] : null
+}
+
+function secretsMatch(provided: string, expected: string): boolean {
+	const a = Buffer.from(provided)
+	const b = Buffer.from(expected)
+	if (a.length !== b.length) return false
+	return timingSafeEqual(a, b)
+}
+
+export function isAuthorizedBot(authorizationHeader: unknown, env: Env): boolean {
+	const secret = env.BUTLER_BOT_SECRET
+	if (!secret) return false
+	const provided = extractBearer(authorizationHeader)
+	if (!provided) return false
+	return secretsMatch(provided, secret)
+}

--- a/src/utils/discord-oauth.test.ts
+++ b/src/utils/discord-oauth.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { DiscordOAuthError, buildAuthorizeUrl, exchangeCodeForUser } from "./discord-oauth"
+
+const CFG = {
+	clientId: "client-123",
+	clientSecret: "secret-xyz",
+	redirectUri: "https://unison.boidu.dev/links/discord/callback",
+}
+
+describe("buildAuthorizeUrl", () => {
+	it("builds the authorize URL with the required params", () => {
+		const url = new URL(buildAuthorizeUrl(CFG, "state-abc", "identify"))
+		expect(url.origin + url.pathname).toBe("https://discord.com/oauth2/authorize")
+		expect(url.searchParams.get("client_id")).toBe("client-123")
+		expect(url.searchParams.get("redirect_uri")).toBe(CFG.redirectUri)
+		expect(url.searchParams.get("response_type")).toBe("code")
+		expect(url.searchParams.get("scope")).toBe("identify")
+		expect(url.searchParams.get("state")).toBe("state-abc")
+	})
+})
+
+function fakeFetch(handlers: {
+	token?: (body: string) => Response
+	user?: (auth: string | null) => Response
+}): typeof fetch {
+	return (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input)
+		if (url.endsWith("/oauth2/token")) {
+			return handlers.token?.(String(init?.body ?? "")) ?? new Response(null, { status: 500 })
+		}
+		if (url.endsWith("/users/@me")) {
+			const auth = new Headers(init?.headers).get("authorization")
+			return handlers.user?.(auth) ?? new Response(null, { status: 500 })
+		}
+		return new Response(null, { status: 404 })
+	}) as typeof fetch
+}
+
+function ok(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	})
+}
+
+describe("exchangeCodeForUser", () => {
+	it("exchanges the code and returns the Discord identity", async () => {
+		let tokenBody = ""
+		let sentAuth: string | null = null
+		const fetchImpl = fakeFetch({
+			token: (body) => {
+				tokenBody = body
+				return ok({ access_token: "tok-1", token_type: "Bearer" })
+			},
+			user: (auth) => {
+				sentAuth = auth
+				return ok({ id: "discord-999", username: "alice", global_name: "Alice In Wonderland" })
+			},
+		})
+
+		const user = await exchangeCodeForUser(CFG, "code-1", fetchImpl)
+
+		expect(user).toEqual({
+			id: "discord-999",
+			username: "alice",
+			displayName: "Alice In Wonderland",
+		})
+		expect(tokenBody).toContain("grant_type=authorization_code")
+		expect(tokenBody).toContain("code=code-1")
+		expect(sentAuth).toBe("Bearer tok-1")
+	})
+
+	it("falls back to username when global_name is null", async () => {
+		const fetchImpl = fakeFetch({
+			token: () => ok({ access_token: "tok-2" }),
+			user: () => ok({ id: "d2", username: "bob", global_name: null }),
+		})
+		const user = await exchangeCodeForUser(CFG, "code-2", fetchImpl)
+		expect(user.displayName).toBe("bob")
+	})
+
+	describe("error paths", () => {
+		it("throws when the token exchange fails", async () => {
+			const fetchImpl = fakeFetch({ token: () => new Response(null, { status: 400 }) })
+			await expect(exchangeCodeForUser(CFG, "bad", fetchImpl)).rejects.toBeInstanceOf(
+				DiscordOAuthError
+			)
+		})
+
+		it("throws when the user fetch fails", async () => {
+			const fetchImpl = fakeFetch({
+				token: () => ok({ access_token: "tok" }),
+				user: () => new Response(null, { status: 401 }),
+			})
+			await expect(exchangeCodeForUser(CFG, "code", fetchImpl)).rejects.toBeInstanceOf(
+				DiscordOAuthError
+			)
+		})
+
+		it("throws when the user payload is missing an id", async () => {
+			const fetchImpl = fakeFetch({
+				token: () => ok({ access_token: "tok" }),
+				user: () => ok({ username: "noid" }),
+			})
+			await expect(exchangeCodeForUser(CFG, "code", fetchImpl)).rejects.toBeInstanceOf(
+				DiscordOAuthError
+			)
+		})
+	})
+})

--- a/src/utils/discord-oauth.ts
+++ b/src/utils/discord-oauth.ts
@@ -1,0 +1,73 @@
+const DISCORD_API = "https://discord.com/api/v10"
+const DISCORD_AUTHORIZE = "https://discord.com/oauth2/authorize"
+
+export interface DiscordOAuthConfig {
+	clientId: string
+	clientSecret: string
+	redirectUri: string
+}
+
+export interface DiscordIdentity {
+	id: string
+	username: string
+	displayName: string
+}
+
+export class DiscordOAuthError extends Error {
+	constructor(public reason: string) {
+		super(`discord oauth failed: ${reason}`)
+		this.name = "DiscordOAuthError"
+	}
+}
+
+export function buildAuthorizeUrl(
+	cfg: Pick<DiscordOAuthConfig, "clientId" | "redirectUri">,
+	state: string,
+	scope: string
+): string {
+	const params = new URLSearchParams({
+		client_id: cfg.clientId,
+		redirect_uri: cfg.redirectUri,
+		response_type: "code",
+		scope,
+		state,
+		prompt: "consent",
+	})
+	return `${DISCORD_AUTHORIZE}?${params.toString()}`
+}
+
+export async function exchangeCodeForUser(
+	cfg: DiscordOAuthConfig,
+	code: string,
+	fetchImpl: typeof fetch = fetch
+): Promise<DiscordIdentity> {
+	const tokenRes = await fetchImpl(`${DISCORD_API}/oauth2/token`, {
+		method: "POST",
+		headers: { "content-type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "authorization_code",
+			code,
+			redirect_uri: cfg.redirectUri,
+			client_id: cfg.clientId,
+			client_secret: cfg.clientSecret,
+		}).toString(),
+	})
+	if (!tokenRes.ok) throw new DiscordOAuthError("token_exchange_failed")
+
+	const token = (await tokenRes.json().catch(() => null)) as { access_token?: string } | null
+	if (!token?.access_token) throw new DiscordOAuthError("no_access_token")
+
+	const userRes = await fetchImpl(`${DISCORD_API}/users/@me`, {
+		headers: { authorization: `Bearer ${token.access_token}` },
+	})
+	if (!userRes.ok) throw new DiscordOAuthError("user_fetch_failed")
+
+	const user = (await userRes.json().catch(() => null)) as {
+		id?: string
+		username?: string
+		global_name?: string | null
+	} | null
+	if (!user?.id || !user.username) throw new DiscordOAuthError("invalid_user")
+
+	return { id: user.id, username: user.username, displayName: user.global_name || user.username }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -27,6 +27,8 @@ export const ErrorCode = {
 	INVALID_REPORT_REASON: "INVALID_REPORT_REASON",
 	REPORT_DETAILS_TOO_LONG: "REPORT_DETAILS_TOO_LONG",
 	INVALID_CURSOR: "INVALID_CURSOR",
+	LINK_BLACKLISTED: "LINK_BLACKLISTED",
+	LINKING_DISABLED: "LINKING_DISABLED",
 } as const
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
@@ -129,6 +131,14 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	INVALID_CURSOR: {
 		error: "Invalid cursor",
 		hint: "The page cursor looks malformed. Reload the list and try again.",
+	},
+	LINK_BLACKLISTED: {
+		error: "Account cannot be linked",
+		hint: "This is a shared community account, so it can't be linked to a personal Discord.",
+	},
+	LINKING_DISABLED: {
+		error: "Linking unavailable",
+		hint: "Account linking is temporarily unavailable. Please try again later.",
 	},
 }
 

--- a/web/src/lib/links.ts
+++ b/web/src/lib/links.ts
@@ -1,0 +1,54 @@
+import type { SignedBody } from "./auth"
+
+interface ApiOk<T> {
+  success: true
+  data: T
+}
+interface ApiErr {
+  success: false
+  error: string
+}
+
+async function unwrap<T>(res: Response): Promise<T> {
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch {
+    throw new Error(`HTTP ${res.status}`)
+  }
+  if (!res.ok) {
+    const err = (body as { error?: unknown }).error
+    throw new Error(typeof err === "string" && err.length > 0 ? err : `HTTP ${res.status}`)
+  }
+  const envelope = body as ApiOk<T> | ApiErr
+  if (!envelope.success) throw new Error(envelope.error)
+  return envelope.data
+}
+
+export interface LinkStatus {
+  linked: boolean
+  discordId: string | null
+  discordUsername: string | null
+}
+
+export async function startDiscordLink(signedBody: SignedBody): Promise<{ authorizeUrl: string }> {
+  const res = await fetch("/links/discord/start", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(signedBody),
+  })
+  return unwrap<{ authorizeUrl: string }>(res)
+}
+
+export async function fetchLinkStatus(token: string): Promise<LinkStatus> {
+  const res = await fetch("/links/me", { headers: { authorization: `Bearer ${token}` } })
+  return unwrap<LinkStatus>(res)
+}
+
+export async function unlinkDiscord(token: string): Promise<void> {
+  const res = await fetch("/links/discord", {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${token}` },
+  })
+  await unwrap<{ unlinked: boolean }>(res)
+}

--- a/web/src/pages/LinkPage.test.tsx
+++ b/web/src/pages/LinkPage.test.tsx
@@ -1,0 +1,131 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AuthProvider } from "@/auth/AuthProvider"
+import { LinkPage } from "./LinkPage"
+
+function renderAt(entry: string) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <AuthProvider>
+        <LinkPage />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+function stubExtension(available: boolean, onAuth?: (req: { type: string }) => unknown) {
+  if (!available) {
+    vi.stubGlobal("chrome", undefined)
+    return
+  }
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => {
+        let onMessageListener: ((m: unknown) => void) | null = null
+        return {
+          name: info.name,
+          onMessage: {
+            addListener: (l: (m: unknown) => void) => {
+              onMessageListener = l
+            },
+          },
+          onDisconnect: {
+            addListener: (l: () => void) => {
+              if (info.name === "bl-probe") queueMicrotask(l)
+            },
+          },
+          postMessage: (req: { type: string }) => {
+            queueMicrotask(() => onMessageListener?.(onAuth?.(req)))
+          },
+          disconnect: () => {},
+        }
+      },
+    },
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+describe("LinkPage outcome screens", () => {
+  it("shows the success screen with the Discord name", async () => {
+    stubExtension(false)
+    renderAt("/link?status=linked&name=Alice")
+    expect(await screen.findByText(/you are all set/i)).toBeTruthy()
+    expect(screen.getByText(/as Alice/)).toBeTruthy()
+  })
+
+  it("shows the blocked screen for a community account", async () => {
+    stubExtension(false)
+    renderAt("/link?status=blocked")
+    expect(await screen.findByText(/cannot be linked/i)).toBeTruthy()
+  })
+
+  it("shows an error screen with a try again action", async () => {
+    stubExtension(false)
+    renderAt("/link?status=error")
+    expect(await screen.findByText(/something went wrong/i)).toBeTruthy()
+    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy()
+  })
+})
+
+describe("LinkPage main flow", () => {
+  it("prompts to install when the extension is missing", async () => {
+    stubExtension(false)
+    renderAt("/link")
+    expect(await screen.findByText(/install better lyrics first/i)).toBeTruthy()
+    expect(screen.getByRole("link", { name: /get better lyrics/i })).toBeTruthy()
+  })
+
+  it("shows the connect button when the extension is available", async () => {
+    stubExtension(true, () => ({ ok: true }))
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{}", { status: 200 })))
+    renderAt("/link")
+    expect(await screen.findByRole("button", { name: /connect with discord/i })).toBeTruthy()
+  })
+
+  it("runs the sign-and-start flow when Connect is clicked", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/auth/challenge")) {
+        return new Response(JSON.stringify({ success: true, data: { nonce: "n".repeat(16), expiresAt: 1 } }), {
+          status: 200,
+        })
+      }
+      if (url.endsWith("/links/discord/start")) {
+        return new Response(
+          JSON.stringify({ success: true, data: { authorizeUrl: "https://discord.com/oauth2/authorize?x=1" } }),
+          { status: 200 },
+        )
+      }
+      return new Response("{}", { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    vi.spyOn(window.location, "assign").mockImplementation(() => {})
+    stubExtension(true, (req) =>
+      req.type === "bl-auth-request"
+        ? { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
+        : { ok: true },
+    )
+
+    renderAt("/link")
+    const button = await screen.findByRole("button", { name: /connect with discord/i })
+    await act(async () => {
+      button.click()
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/auth/challenge"))
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith("/links/discord/start"))).toBe(true),
+    )
+  })
+})

--- a/web/src/pages/LinkPage.tsx
+++ b/web/src/pages/LinkPage.tsx
@@ -1,0 +1,195 @@
+import { IconAlertTriangle, IconBrandDiscord, IconCircleCheck, IconLoader2, IconPuzzle } from "@tabler/icons-react"
+import { useCallback, useEffect, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { useSession } from "@/auth/useSession"
+import { BetterLyricsLogo } from "@/components/BetterLyricsLogo"
+import { fetchChallenge, loadStoredSession } from "@/lib/auth"
+import { signInWithBetterLyrics } from "@/lib/extension"
+import { fetchLinkStatus, startDiscordLink, unlinkDiscord } from "@/lib/links"
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 py-10 text-center">
+      <BetterLyricsLogo size={44} />
+      {children}
+    </div>
+  )
+}
+
+function Title({ children }: { children: React.ReactNode }) {
+  return <h1 className="text-xl font-semibold text-unison-text">{children}</h1>
+}
+
+function Body({ children }: { children: React.ReactNode }) {
+  return <p className="max-w-sm text-sm leading-relaxed text-unison-text-secondary">{children}</p>
+}
+
+const discordButtonClass =
+  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-[#5865f2] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#4752c4] disabled:cursor-not-allowed disabled:opacity-60"
+
+const secondaryButtonClass =
+  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-unison-bg-elevated px-4 py-2.5 text-sm font-medium text-unison-text transition-colors hover:bg-unison-bg-hover disabled:cursor-not-allowed disabled:opacity-60"
+
+function OutcomeScreen({ status, name, onReset }: { status: string; name: string | null; onReset: () => void }) {
+  if (status === "linked") {
+    return (
+      <Shell>
+        <IconCircleCheck className="size-12 text-emerald-400" stroke={1.5} />
+        <Title>You are all set</Title>
+        <Body>
+          Your Discord is linked to Better Lyrics{name ? ` as ${name}` : ""}. Your roles update on their own, so you can
+          head back to Discord now.
+        </Body>
+      </Shell>
+    )
+  }
+  if (status === "blocked") {
+    return (
+      <Shell>
+        <IconAlertTriangle className="size-12 text-amber-400" stroke={1.5} />
+        <Title>This account cannot be linked</Title>
+        <Body>
+          This looks like a shared community account, so it cannot be connected to a personal Discord. If that is a
+          surprise, reach out to a moderator.
+        </Body>
+      </Shell>
+    )
+  }
+  const isExpired = status === "expired"
+  return (
+    <Shell>
+      <IconAlertTriangle className="size-12 text-amber-400" stroke={1.5} />
+      <Title>{isExpired ? "That timed out" : "Something went wrong"}</Title>
+      <Body>
+        {isExpired
+          ? "The link request expired before it finished. Start over and it will only take a moment."
+          : "We could not finish linking your account. Give it another try."}
+      </Body>
+      <button type="button" onClick={onReset} className={secondaryButtonClass}>
+        {isExpired ? "Start over" : "Try again"}
+      </button>
+    </Shell>
+  )
+}
+
+export function LinkPage() {
+  const session = useSession()
+  const [params, setParams] = useSearchParams()
+  const outcome = params.get("status")
+
+  const [connecting, setConnecting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [existing, setExisting] = useState<{ username: string | null } | null>(null)
+  const [working, setWorking] = useState(false)
+
+  useEffect(() => {
+    if (outcome) return
+    const stored = loadStoredSession()
+    if (!stored) return
+    let cancelled = false
+    fetchLinkStatus(stored.sessionToken)
+      .then((s) => {
+        if (cancelled) return
+        setExisting(s.linked ? { username: s.discordUsername } : null)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [outcome])
+
+  const connect = useCallback(async () => {
+    setConnecting(true)
+    setError(null)
+    try {
+      const { nonce } = await fetchChallenge()
+      const signedBody = await signInWithBetterLyrics(nonce)
+      const { authorizeUrl } = await startDiscordLink(signedBody)
+      window.location.assign(authorizeUrl)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : ""
+      setError(
+        message.includes("cannot be linked")
+          ? "This account cannot be linked. It looks like a shared community account."
+          : "We could not start the link. Make sure Better Lyrics is installed, then try again.",
+      )
+      setConnecting(false)
+    }
+  }, [])
+
+  const disconnect = useCallback(async () => {
+    const stored = loadStoredSession()
+    if (!stored) return
+    setWorking(true)
+    try {
+      await unlinkDiscord(stored.sessionToken)
+      setExisting(null)
+    } catch {
+      setError("We could not disconnect just now. Please try again.")
+    } finally {
+      setWorking(false)
+    }
+  }, [])
+
+  if (outcome) {
+    return <OutcomeScreen status={outcome} name={params.get("name")} onReset={() => setParams({})} />
+  }
+
+  if (session.status === "loading") {
+    return (
+      <Shell>
+        <IconLoader2 className="size-8 animate-spin text-unison-text-muted" stroke={1.5} />
+      </Shell>
+    )
+  }
+
+  if (!session.extensionAvailable) {
+    return (
+      <Shell>
+        <IconPuzzle className="size-12 text-unison-text-muted" stroke={1.5} />
+        <Title>Install Better Lyrics first</Title>
+        <Body>
+          Linking happens through the Better Lyrics extension. Install it, then come back to this page to connect your
+          Discord.
+        </Body>
+        <a href="https://betterlyrics.org" target="_blank" rel="noopener noreferrer" className={secondaryButtonClass}>
+          Get Better Lyrics
+        </a>
+      </Shell>
+    )
+  }
+
+  if (existing) {
+    return (
+      <Shell>
+        <IconCircleCheck className="size-12 text-emerald-400" stroke={1.5} />
+        <Title>Connected to Discord</Title>
+        <Body>
+          Your account is linked{existing.username ? ` as ${existing.username}` : ""}. Roles update on their own.
+        </Body>
+        <button type="button" onClick={disconnect} disabled={working} className={secondaryButtonClass}>
+          {working ? "Disconnecting..." : "Disconnect"}
+        </button>
+      </Shell>
+    )
+  }
+
+  return (
+    <Shell>
+      <Title>Connect Better Lyrics to Discord</Title>
+      <Body>
+        Link once to earn your leaderboard roles and get credit for the songs you add. It takes two quick taps: confirm
+        it is you in Better Lyrics, then approve Discord.
+      </Body>
+      <button type="button" onClick={connect} disabled={connecting} className={discordButtonClass}>
+        {connecting ? (
+          <IconLoader2 className="size-5 animate-spin" stroke={1.5} />
+        ) : (
+          <IconBrandDiscord className="size-5" stroke={1.5} />
+        )}
+        {connecting ? "Connecting..." : "Connect with Discord"}
+      </button>
+      {error ? <p className="max-w-sm text-sm text-red-400">{error}</p> : null}
+    </Shell>
+  )
+}

--- a/web/src/pages/LinkPage.tsx
+++ b/web/src/pages/LinkPage.tsx
@@ -1,4 +1,4 @@
-import { IconAlertTriangle, IconBrandDiscord, IconCircleCheck, IconLoader2, IconPuzzle } from "@tabler/icons-react"
+import { IconAlertTriangle, IconBrandDiscord, IconCircleCheck, IconLoader2 } from "@tabler/icons-react"
 import { useCallback, useEffect, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useSession } from "@/auth/useSession"
@@ -146,7 +146,6 @@ export function LinkPage() {
   if (!session.extensionAvailable) {
     return (
       <Shell>
-        <IconPuzzle className="size-12 text-unison-text-muted" stroke={1.5} />
         <Title>Install Better Lyrics first</Title>
         <Body>
           Linking happens through the Better Lyrics extension. Install it, then come back to this page to connect your

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from "./components/AppLayout"
 import { AboutPage } from "./pages/AboutPage"
 import { CuratorsPage } from "./pages/CuratorsPage"
 import { DownloadsPage } from "./pages/DownloadsPage"
+import { LinkPage } from "./pages/LinkPage"
 import { LyricsPage } from "./pages/LyricsPage"
 import { MePage } from "./pages/MePage"
 import { QueuePage } from "./pages/QueuePage"
@@ -24,6 +25,7 @@ const router = createBrowserRouter([
       { path: "curator/:keyId", element: <UserPage /> },
       { path: "about", element: <AboutPage /> },
       { path: "downloads", element: <DownloadsPage /> },
+      { path: "link", element: <LinkPage /> },
     ],
   },
 ])


### PR DESCRIPTION
## Overview

The Discord bot needs to add request-board entries for users, but it can't sign requests the way the extension does since the user's key stays in their browser. So I added a bot-authenticated path at `POST /requests/bot` behind a shared secret: if the user has linked their account the request is credited to their key at their reputation, otherwise it uses the neutral Discord weight keyed by their Discord id. I pulled the field validation into a shared helper so the existing signed route behaves exactly as before.
