### PR TITLE
feat: refresh discord linking UI and show connection status on profiles

### DIFF
--- a/src/routes/leaderboard.test.ts
+++ b/src/routes/leaderboard.test.ts
@@ -301,6 +301,7 @@ describe("GET /leaderboard/users/:keyId", () => {
 		const db = makeMockDB([
 			[{ key_id: keyId, reputation: 1.2, score: 5, submission_count: 2, total_upvotes: 8 }],
 			{ last_vote_at: 1700000123 },
+			null, // getByKeyId -> not linked
 			{ nickname: null },
 		])
 		const env = makeEnv(db)
@@ -314,6 +315,7 @@ describe("GET /leaderboard/users/:keyId", () => {
 				rank?: number
 				displayName?: string
 				lastVoteAt?: number | null
+				discordLinked?: boolean
 			}
 		}
 		expect(json.data.ranked).toBe(true)
@@ -321,11 +323,28 @@ describe("GET /leaderboard/users/:keyId", () => {
 		expect(json.data.rank).toBe(1)
 		expect(json.data.displayName?.length).toBeGreaterThan(0)
 		expect(json.data.lastVoteAt).toBe(1700000123)
+		expect(json.data.discordLinked).toBe(false)
+	})
+
+	it("reports discordLinked: true when the curator has a linked Discord account", async () => {
+		const keyId = "c".repeat(64)
+		const db = makeMockDB([
+			[{ key_id: keyId, reputation: 1.2, score: 5, submission_count: 2, total_upvotes: 8 }],
+			{ last_vote_at: 1700000123 },
+			{ discord_id: "d1", key_id: keyId, discord_username: "alice", linked_at: 1 },
+			{ nickname: null },
+		])
+		const env = makeEnv(db)
+		const app = leaderboardRoutes(env)
+		const res = await app.handle(new Request(`http://localhost/leaderboard/users/${keyId}`))
+		expect(res.status).toBe(200)
+		const json = (await res.json()) as { data: { discordLinked?: boolean } }
+		expect(json.data.discordLinked).toBe(true)
 	})
 
 	it("returns ranked: false with displayName and null lastVoteAt for an unknown user", async () => {
 		const keyId = "b".repeat(64)
-		const db = makeMockDB([[], { last_vote_at: null }, { nickname: null }])
+		const db = makeMockDB([[], { last_vote_at: null }, null, { nickname: null }])
 		const env = makeEnv(db)
 		const app = leaderboardRoutes(env)
 		const res = await app.handle(new Request(`http://localhost/leaderboard/users/${keyId}`))
@@ -336,12 +355,14 @@ describe("GET /leaderboard/users/:keyId", () => {
 				keyId?: string
 				displayName?: string
 				lastVoteAt?: number | null
+				discordLinked?: boolean
 			}
 		}
 		expect(json.data.ranked).toBe(false)
 		expect(json.data.keyId).toBe(keyId)
 		expect(json.data.displayName?.length).toBeGreaterThan(0)
 		expect(json.data.lastVoteAt).toBeNull()
+		expect(json.data.discordLinked).toBe(false)
 	})
 
 	it("rejects a keyId that is not 64 hex characters", async () => {
@@ -357,6 +378,7 @@ describe("GET /leaderboard/users/:keyId", () => {
 		const db = makeMockDB([
 			[{ key_id: keyId, reputation: 1.0, score: 3, submission_count: 1, total_upvotes: 4 }],
 			{ last_vote_at: 1700000456 },
+			null, // getByKeyId -> not linked
 			{ nickname: "Brook" },
 		])
 		const env = makeEnv(db)

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -9,6 +9,7 @@ import {
 	getSongRank,
 	type MostWantedCursor,
 } from "@/db/leaderboard"
+import { getByKeyId } from "@/db/discordLinks"
 import { getLastVoteAt } from "@/db/profile"
 import { resolveDisplayName } from "@/db/users"
 import type { Env } from "@/types"
@@ -143,11 +144,13 @@ export const leaderboardRoutes = (env: Env) =>
 		.get(
 			"/users/:keyId",
 			async ({ params, env }) => {
-				const [row, lastVoteAt] = await Promise.all([
+				const [row, lastVoteAt, link] = await Promise.all([
 					getCuratorRank(env, params.keyId),
 					getLastVoteAt(env, params.keyId),
+					getByKeyId(env, params.keyId),
 				])
 				const displayName = await resolveDisplayName(env, params.keyId)
+				const discordLinked = link !== null
 				if (row) {
 					const { nickname: _nickname, ...rest } = row
 					return {
@@ -157,6 +160,7 @@ export const leaderboardRoutes = (env: Env) =>
 							...rest,
 							displayName,
 							lastVoteAt,
+							discordLinked,
 						},
 					}
 				}
@@ -167,6 +171,7 @@ export const leaderboardRoutes = (env: Env) =>
 						keyId: params.keyId,
 						displayName,
 						lastVoteAt,
+						discordLinked,
 					},
 				}
 			},

--- a/web/src/components/DiscordBadge.tsx
+++ b/web/src/components/DiscordBadge.tsx
@@ -1,0 +1,10 @@
+import { IconBrandDiscordFilled } from "@tabler/icons-react"
+
+export function DiscordBadge() {
+  return (
+    <span className="discord-badge inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium">
+      <IconBrandDiscordFilled className="size-3.5" />
+      Connected
+    </span>
+  )
+}

--- a/web/src/components/DiscordSection.test.tsx
+++ b/web/src/components/DiscordSection.test.tsx
@@ -1,0 +1,45 @@
+import { act, cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { type DiscordSectionModel, DiscordSectionView } from "./DiscordSection"
+
+afterEach(cleanup)
+
+const base: DiscordSectionModel = {
+  status: "unlinked",
+  username: null,
+  connecting: false,
+  working: false,
+  error: null,
+  onConnect: () => {},
+  onDisconnect: () => {},
+}
+
+describe("DiscordSectionView", () => {
+  it("offers a connect button when unlinked", () => {
+    const onConnect = vi.fn()
+    render(<DiscordSectionView model={{ ...base, status: "unlinked", onConnect }} />)
+    const button = screen.getByRole("button", { name: /connect with discord/i })
+    act(() => button.click())
+    expect(onConnect).toHaveBeenCalledOnce()
+  })
+
+  it("shows the username and a disconnect button when linked", () => {
+    const onDisconnect = vi.fn()
+    render(<DiscordSectionView model={{ ...base, status: "linked", username: "user#1234", onDisconnect }} />)
+    expect(screen.getByText(/as user#1234/)).toBeTruthy()
+    const button = screen.getByRole("button", { name: /^disconnect$/i })
+    act(() => button.click())
+    expect(onDisconnect).toHaveBeenCalledOnce()
+  })
+
+  it("disables the disconnect button while working", () => {
+    render(<DiscordSectionView model={{ ...base, status: "linked", username: "x", working: true }} />)
+    const button = screen.getByRole("button", { name: /disconnecting/i })
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("surfaces an error message", () => {
+    render(<DiscordSectionView model={{ ...base, status: "unlinked", error: "nope" }} />)
+    expect(screen.getByText("nope")).toBeTruthy()
+  })
+})

--- a/web/src/components/DiscordSection.tsx
+++ b/web/src/components/DiscordSection.tsx
@@ -1,0 +1,73 @@
+import { IconBrandDiscordFilled, IconLoader2 } from "@tabler/icons-react"
+import { discordButtonClass, secondaryButtonClass } from "@/components/discord-ui"
+import { useDiscordLink } from "@/hooks/useDiscordLink"
+
+export interface DiscordSectionModel {
+  status: "loading" | "linked" | "unlinked"
+  username: string | null
+  connecting: boolean
+  working: boolean
+  error: string | null
+  onConnect: () => void
+  onDisconnect: () => void
+}
+
+const cardClass = "space-y-3 rounded-lg border border-unison-border bg-unison-bg-elevated p-4"
+
+export function DiscordSectionView({ model }: { model: DiscordSectionModel }) {
+  if (model.status === "loading") {
+    return (
+      <div className={cardClass}>
+        <IconLoader2 className="size-5 animate-spin text-unison-text-muted" stroke={1.5} />
+      </div>
+    )
+  }
+
+  if (model.status === "linked") {
+    return (
+      <div className={cardClass}>
+        <p className="text-sm text-unison-text">
+          Connected{model.username ? ` as ${model.username}` : ""}. Your roles update on their own.
+        </p>
+        <button type="button" onClick={model.onDisconnect} disabled={model.working} className={secondaryButtonClass}>
+          {model.working ? "Disconnecting..." : "Disconnect"}
+        </button>
+        {model.error ? <p className="text-xs text-red-400">{model.error}</p> : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cardClass}>
+      <p className="text-sm text-unison-text-secondary">
+        Link your Discord to earn leaderboard roles and get credit for the songs you add.
+      </p>
+      <button type="button" onClick={model.onConnect} disabled={model.connecting} className={discordButtonClass}>
+        {model.connecting ? (
+          <IconLoader2 className="size-5 animate-spin" stroke={1.5} />
+        ) : (
+          <IconBrandDiscordFilled className="size-5" />
+        )}
+        {model.connecting ? "Connecting..." : "Connect with Discord"}
+      </button>
+      {model.error ? <p className="text-xs text-red-400">{model.error}</p> : null}
+    </div>
+  )
+}
+
+export function DiscordSection() {
+  const link = useDiscordLink()
+  return (
+    <DiscordSectionView
+      model={{
+        status: link.status,
+        username: link.username,
+        connecting: link.connecting,
+        working: link.working,
+        error: link.error,
+        onConnect: link.connect,
+        onDisconnect: link.disconnect,
+      }}
+    />
+  )
+}

--- a/web/src/components/LinkView.test.tsx
+++ b/web/src/components/LinkView.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { LinkView, type LinkViewModel } from "./LinkView"
+
+afterEach(cleanup)
+
+function dotsAreStatic(container: HTMLElement): boolean {
+  const dots = container.querySelector(".link-pulse")
+  if (!dots) throw new Error("no .link-pulse element rendered")
+  return dots.classList.contains("link-pulse--static")
+}
+
+describe("LinkView", () => {
+  it("renders the install copy", () => {
+    render(<LinkView model={{ kind: "install" }} />)
+    expect(screen.getByText(/install better lyrics first/i)).toBeTruthy()
+    expect(screen.getByRole("link", { name: /get better lyrics/i })).toBeTruthy()
+  })
+
+  it("renders each outcome screen", () => {
+    const noop = () => {}
+    const cases: { model: LinkViewModel; text: RegExp }[] = [
+      { model: { kind: "linked", name: "Alice" }, text: /you are all set/i },
+      { model: { kind: "blocked" }, text: /cannot be linked/i },
+      { model: { kind: "expired", onReset: noop }, text: /timed out/i },
+      { model: { kind: "error", onReset: noop }, text: /something went wrong/i },
+    ]
+    for (const c of cases) {
+      const { unmount } = render(<LinkView model={c.model} />)
+      expect(screen.getByText(c.text)).toBeTruthy()
+      unmount()
+    }
+  })
+
+  describe("shimmer dots", () => {
+    it("animates while loading", () => {
+      const { container } = render(<LinkView model={{ kind: "loading" }} />)
+      expect(dotsAreStatic(container)).toBe(false)
+    })
+
+    it("animates while connecting", () => {
+      const { container } = render(
+        <LinkView model={{ kind: "connect", connecting: true, error: null, onConnect: () => {} }} />,
+      )
+      expect(dotsAreStatic(container)).toBe(false)
+    })
+
+    it("is static on the idle connect prompt", () => {
+      const { container } = render(
+        <LinkView model={{ kind: "connect", connecting: false, error: null, onConnect: () => {} }} />,
+      )
+      expect(dotsAreStatic(container)).toBe(true)
+    })
+
+    it("is static on resolved states", () => {
+      const { container } = render(<LinkView model={{ kind: "linked", name: null }} />)
+      expect(dotsAreStatic(container)).toBe(true)
+    })
+  })
+})

--- a/web/src/components/LinkView.tsx
+++ b/web/src/components/LinkView.tsx
@@ -1,0 +1,152 @@
+import { IconAlertTriangle, IconBrandDiscordFilled, IconLoader2, IconProgressDown } from "@tabler/icons-react"
+import type { ReactNode } from "react"
+import { discordButtonClass, secondaryButtonClass } from "@/components/discord-ui"
+import { LogoPair } from "@/components/LogoPair"
+
+const installIcon = <IconProgressDown className="size-7 text-unison-text-secondary" stroke={1.5} />
+const discordIcon = <IconBrandDiscordFilled className="size-7 text-white" />
+const warnIcon = <IconAlertTriangle className="size-7 text-amber-400" stroke={1.5} />
+
+function Layout({ partner, pulsing = false, children }: { partner: ReactNode; pulsing?: boolean; children: ReactNode }) {
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 py-10 text-center">
+      <LogoPair partner={partner} pulsing={pulsing} />
+      {children}
+    </div>
+  )
+}
+
+function Title({ children }: { children: ReactNode }) {
+  return <h1 className="text-xl font-semibold text-unison-text">{children}</h1>
+}
+
+function Body({ children }: { children: ReactNode }) {
+  return <p className="max-w-sm text-sm leading-relaxed text-unison-text-secondary">{children}</p>
+}
+
+function ErrorText({ children }: { children: ReactNode }) {
+  return <p className="max-w-sm text-sm text-red-400">{children}</p>
+}
+
+export type LinkViewModel =
+  | { kind: "loading" }
+  | { kind: "install" }
+  | { kind: "connect"; connecting: boolean; error: string | null; onConnect: () => void }
+  | { kind: "existing"; name: string | null; working: boolean; error: string | null; onDisconnect: () => void }
+  | { kind: "linked"; name: string | null }
+  | { kind: "blocked" }
+  | { kind: "expired"; onReset: () => void }
+  | { kind: "error"; onReset: () => void }
+
+export function LinkView({ model }: { model: LinkViewModel }) {
+  switch (model.kind) {
+    case "loading":
+      return (
+        <Layout partner={discordIcon} pulsing>
+          <IconLoader2 className="size-6 animate-spin text-unison-text-muted" stroke={1.5} />
+        </Layout>
+      )
+
+    case "install":
+      return (
+        <Layout partner={installIcon}>
+          <Title>Install Better Lyrics first</Title>
+          <Body>
+            Linking happens through the Better Lyrics extension. Install it, then come back to this page to connect your
+            Discord.
+          </Body>
+          <a
+            href="https://betterlyrics.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={secondaryButtonClass}
+          >
+            Get Better Lyrics
+          </a>
+        </Layout>
+      )
+
+    case "connect":
+      return (
+        <Layout partner={discordIcon} pulsing={model.connecting}>
+          <Title>Connect Better Lyrics to Discord</Title>
+          <Body>
+            Link once to earn your leaderboard roles and get credit for the songs you add. It takes two quick taps:
+            confirm it is you in Better Lyrics, then approve Discord.
+          </Body>
+          <button type="button" onClick={model.onConnect} disabled={model.connecting} className={discordButtonClass}>
+            {model.connecting ? (
+              <IconLoader2 className="size-5 animate-spin" stroke={1.5} />
+            ) : (
+              <IconBrandDiscordFilled className="size-5" />
+            )}
+            {model.connecting ? "Connecting..." : "Connect with Discord"}
+          </button>
+          {model.error ? <ErrorText>{model.error}</ErrorText> : null}
+        </Layout>
+      )
+
+    case "existing":
+      return (
+        <Layout partner={discordIcon}>
+          <Title>Connected to Discord</Title>
+          <Body>
+            Your account is linked{model.name ? ` as ${model.name}` : ""}. Roles update on their own.
+          </Body>
+          <button
+            type="button"
+            onClick={model.onDisconnect}
+            disabled={model.working}
+            className={secondaryButtonClass}
+          >
+            {model.working ? "Disconnecting..." : "Disconnect"}
+          </button>
+          {model.error ? <ErrorText>{model.error}</ErrorText> : null}
+        </Layout>
+      )
+
+    case "linked":
+      return (
+        <Layout partner={discordIcon}>
+          <Title>You are all set</Title>
+          <Body>
+            Your Discord is linked to Better Lyrics{model.name ? ` as ${model.name}` : ""}. Your roles update on their
+            own, so you can head back to Discord now.
+          </Body>
+        </Layout>
+      )
+
+    case "blocked":
+      return (
+        <Layout partner={warnIcon}>
+          <Title>This account cannot be linked</Title>
+          <Body>
+            This looks like a shared community account, so it cannot be connected to a personal Discord. If that is a
+            surprise, reach out to a moderator.
+          </Body>
+        </Layout>
+      )
+
+    case "expired":
+      return (
+        <Layout partner={warnIcon}>
+          <Title>That timed out</Title>
+          <Body>The link request expired before it finished. Start over and it will only take a moment.</Body>
+          <button type="button" onClick={model.onReset} className={secondaryButtonClass}>
+            Start over
+          </button>
+        </Layout>
+      )
+
+    case "error":
+      return (
+        <Layout partner={warnIcon}>
+          <Title>Something went wrong</Title>
+          <Body>We could not finish linking your account. Give it another try.</Body>
+          <button type="button" onClick={model.onReset} className={secondaryButtonClass}>
+            Try again
+          </button>
+        </Layout>
+      )
+  }
+}

--- a/web/src/components/LogoPair.tsx
+++ b/web/src/components/LogoPair.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react"
+import { BetterLyricsLogo } from "@/components/BetterLyricsLogo"
+
+function PulseDots({ pulsing }: { pulsing: boolean }) {
+  return (
+    <span className={`link-pulse${pulsing ? "" : " link-pulse--static"}`} aria-hidden="true">
+      <span className="link-pulse-dot" />
+      <span className="link-pulse-dot" />
+      <span className="link-pulse-dot" />
+    </span>
+  )
+}
+
+const tileClass =
+  "grid size-12 shrink-0 place-items-center rounded-2xl border border-unison-border bg-unison-bg-elevated"
+
+export function LogoPair({ partner, pulsing = false }: { partner: ReactNode; pulsing?: boolean }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className={tileClass}>
+        <BetterLyricsLogo size={28} />
+      </span>
+      <PulseDots pulsing={pulsing} />
+      <span className={tileClass}>{partner}</span>
+    </div>
+  )
+}

--- a/web/src/components/UserProfileView.tsx
+++ b/web/src/components/UserProfileView.tsx
@@ -1,5 +1,6 @@
 import { IconCheck, IconCopy } from "@tabler/icons-react"
 import { type ReactNode, useCallback, useState } from "react"
+import { DiscordBadge } from "@/components/DiscordBadge"
 import { EmptyState } from "@/components/EmptyState"
 import { LeaderboardSection } from "@/components/LeaderboardSection"
 import { LoadingPlaceholder } from "@/components/LoadingPlaceholder"
@@ -64,7 +65,10 @@ export function UserProfileView({ keyId, title = "Profile" }: UserProfileViewPro
             className="size-16 shrink-0 rounded-full border border-unison-border bg-unison-bg-hover"
           />
           <div className="min-w-0 flex-1 space-y-1">
-            <p className="text-lg font-semibold text-unison-text">{data.displayName}</p>
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-lg font-semibold text-unison-text">{data.displayName}</p>
+              {data.discordLinked ? <DiscordBadge /> : null}
+            </div>
             <div className="flex items-center gap-2">
               <code title={data.keyId} className="font-mono text-xs text-unison-text-muted">
                 {`${data.keyId.slice(0, 6)}…${data.keyId.slice(-6)}`}

--- a/web/src/components/discord-ui.ts
+++ b/web/src/components/discord-ui.ts
@@ -1,0 +1,5 @@
+export const discordButtonClass =
+  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-[#5865f2] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#4752c4] disabled:cursor-not-allowed disabled:opacity-60"
+
+export const secondaryButtonClass =
+  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-unison-bg-elevated px-4 py-2.5 text-sm font-medium text-unison-text transition-colors hover:bg-unison-bg-hover disabled:cursor-not-allowed disabled:opacity-60"

--- a/web/src/hooks/useDiscordLink.ts
+++ b/web/src/hooks/useDiscordLink.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react"
+import { fetchChallenge, loadStoredSession } from "@/lib/auth"
+import { signInWithBetterLyrics } from "@/lib/extension"
+import { fetchLinkStatus, startDiscordLink, unlinkDiscord } from "@/lib/links"
+
+type Status = "loading" | "linked" | "unlinked"
+
+export interface DiscordLink {
+  status: Status
+  username: string | null
+  connecting: boolean
+  working: boolean
+  error: string | null
+  connect: () => Promise<void>
+  disconnect: () => Promise<void>
+}
+
+export function useDiscordLink({ enabled = true }: { enabled?: boolean } = {}): DiscordLink {
+  const [status, setStatus] = useState<Status>(enabled ? "loading" : "unlinked")
+  const [username, setUsername] = useState<string | null>(null)
+  const [connecting, setConnecting] = useState(false)
+  const [working, setWorking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    const stored = loadStoredSession()
+    if (!stored) {
+      setStatus("unlinked")
+      return
+    }
+    let cancelled = false
+    fetchLinkStatus(stored.sessionToken)
+      .then((s) => {
+        if (cancelled) return
+        setStatus(s.linked ? "linked" : "unlinked")
+        setUsername(s.linked ? s.discordUsername : null)
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("unlinked")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  const connect = useCallback(async () => {
+    setConnecting(true)
+    setError(null)
+    try {
+      const { nonce } = await fetchChallenge()
+      const signedBody = await signInWithBetterLyrics(nonce)
+      const { authorizeUrl } = await startDiscordLink(signedBody)
+      window.location.assign(authorizeUrl)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : ""
+      setError(
+        message.includes("cannot be linked")
+          ? "This account cannot be linked. It looks like a shared community account."
+          : "We could not start the link. Make sure Better Lyrics is installed, then try again.",
+      )
+      setConnecting(false)
+    }
+  }, [])
+
+  const disconnect = useCallback(async () => {
+    const stored = loadStoredSession()
+    if (!stored) return
+    setWorking(true)
+    setError(null)
+    try {
+      await unlinkDiscord(stored.sessionToken)
+      setStatus("unlinked")
+      setUsername(null)
+    } catch {
+      setError("We could not disconnect just now. Please try again.")
+    } finally {
+      setWorking(false)
+    }
+  }, [])
+
+  return { status, username, connecting, working, error, connect, disconnect }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -59,3 +59,53 @@ body {
     background-position: -200% 0;
   }
 }
+
+.link-pulse {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.link-pulse-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 9999px;
+  background: var(--color-unison-text-muted);
+  animation: link-pulse-fade 1.8s infinite ease-in-out;
+}
+
+.link-pulse-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.link-pulse-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes link-pulse-fade {
+  0%,
+  100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.link-pulse--static .link-pulse-dot {
+  animation: none;
+  opacity: 0.4;
+}
+
+.discord-badge {
+  border: 1px solid #5865f2;
+  background: color-mix(in hsl, var(--color-unison-bg), #5865f2);
+  color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link-pulse-dot {
+    animation: none;
+    opacity: 0.55;
+  }
+}

--- a/web/src/lib/dev-seed.ts
+++ b/web/src/lib/dev-seed.ts
@@ -95,6 +95,7 @@ export async function seedUserRank(keyId: string): Promise<UserRankResponse> {
       keyId,
       displayName: "Unknown Curator",
       lastVoteAt: null,
+      discordLinked: false,
     }
   }
   return {
@@ -107,6 +108,7 @@ export async function seedUserRank(keyId: string): Promise<UserRankResponse> {
     totalUpvotes: entry.totalUpvotes,
     rank: entry.rank,
     lastVoteAt: SEEDED_NOW - 3600,
+    discordLinked: true,
   }
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface UserStats {
   keyId: string
   displayName: string
   lastVoteAt: number | null
+  discordLinked: boolean
 }
 
 export interface RankedUserStats extends UserStats {

--- a/web/src/pages/CuratorsPage.tsx
+++ b/web/src/pages/CuratorsPage.tsx
@@ -13,6 +13,7 @@ const NOT_RANKED: UserRankResponse = {
   keyId: "",
   displayName: "",
   lastVoteAt: null,
+  discordLinked: false,
 }
 
 export function CuratorsPage() {

--- a/web/src/pages/DevLinkPreview.tsx
+++ b/web/src/pages/DevLinkPreview.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react"
+import { DiscordBadge } from "@/components/DiscordBadge"
+import { type DiscordSectionModel, DiscordSectionView } from "@/components/DiscordSection"
+import { LinkView, type LinkViewModel } from "@/components/LinkView"
+
+const noop = () => {}
+
+const linkStates: { label: string; model: LinkViewModel }[] = [
+  { label: "loading", model: { kind: "loading" } },
+  { label: "install", model: { kind: "install" } },
+  { label: "connect", model: { kind: "connect", connecting: false, error: null, onConnect: noop } },
+  { label: "connecting", model: { kind: "connect", connecting: true, error: null, onConnect: noop } },
+  {
+    label: "connect error",
+    model: {
+      kind: "connect",
+      connecting: false,
+      error: "We could not start the link. Make sure Better Lyrics is installed, then try again.",
+      onConnect: noop,
+    },
+  },
+  {
+    label: "existing",
+    model: { kind: "existing", name: "user#1234", working: false, error: null, onDisconnect: noop },
+  },
+  {
+    label: "existing (working)",
+    model: { kind: "existing", name: "user#1234", working: true, error: null, onDisconnect: noop },
+  },
+  { label: "linked", model: { kind: "linked", name: "user#1234" } },
+  { label: "blocked", model: { kind: "blocked" } },
+  { label: "expired", model: { kind: "expired", onReset: noop } },
+  { label: "error", model: { kind: "error", onReset: noop } },
+]
+
+const baseSection: Omit<DiscordSectionModel, "status"> = {
+  username: "user#1234",
+  connecting: false,
+  working: false,
+  error: null,
+  onConnect: noop,
+  onDisconnect: noop,
+}
+
+const sectionStates: { label: string; model: DiscordSectionModel }[] = [
+  { label: "unlinked", model: { ...baseSection, status: "unlinked", username: null } },
+  { label: "linked", model: { ...baseSection, status: "linked" } },
+  { label: "linked (working)", model: { ...baseSection, status: "linked", working: true } },
+  { label: "loading", model: { ...baseSection, status: "loading" } },
+]
+
+const tabClass = (active: boolean) =>
+  `cursor-pointer rounded-md border px-3 py-1.5 text-sm transition-colors ${
+    active
+      ? "border-unison-border-strong bg-unison-bg-hover text-unison-text"
+      : "border-unison-border bg-unison-bg-elevated text-unison-text-muted hover:text-unison-text"
+  }`
+
+export default function DevLinkPreview() {
+  const [linkIdx, setLinkIdx] = useState(1)
+  const [sectionIdx, setSectionIdx] = useState(1)
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-unison-text">LinkPage states</h2>
+        <div className="flex flex-wrap gap-2">
+          {linkStates.map((s, i) => (
+            <button key={s.label} type="button" className={tabClass(i === linkIdx)} onClick={() => setLinkIdx(i)}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+        <div className="rounded-lg border border-unison-border bg-unison-bg">
+          <LinkView model={linkStates[linkIdx].model} />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-unison-text">Me page Discord section</h2>
+        <div className="flex flex-wrap gap-2">
+          {sectionStates.map((s, i) => (
+            <button key={s.label} type="button" className={tabClass(i === sectionIdx)} onClick={() => setSectionIdx(i)}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+        <div className="max-w-md">
+          <DiscordSectionView model={sectionStates[sectionIdx].model} />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-unison-text">Public profile badge</h2>
+        <div className="flex items-center gap-3 rounded-lg border border-unison-border bg-unison-bg-elevated p-4">
+          <span className="text-lg font-semibold text-unison-text">Display Name</span>
+          <DiscordBadge />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/web/src/pages/LinkPage.tsx
+++ b/web/src/pages/LinkPage.tsx
@@ -1,194 +1,53 @@
-import { IconAlertTriangle, IconBrandDiscord, IconCircleCheck, IconLoader2 } from "@tabler/icons-react"
-import { useCallback, useEffect, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useSession } from "@/auth/useSession"
-import { BetterLyricsLogo } from "@/components/BetterLyricsLogo"
-import { fetchChallenge, loadStoredSession } from "@/lib/auth"
-import { signInWithBetterLyrics } from "@/lib/extension"
-import { fetchLinkStatus, startDiscordLink, unlinkDiscord } from "@/lib/links"
-
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 py-10 text-center">
-      <BetterLyricsLogo size={44} />
-      {children}
-    </div>
-  )
-}
-
-function Title({ children }: { children: React.ReactNode }) {
-  return <h1 className="text-xl font-semibold text-unison-text">{children}</h1>
-}
-
-function Body({ children }: { children: React.ReactNode }) {
-  return <p className="max-w-sm text-sm leading-relaxed text-unison-text-secondary">{children}</p>
-}
-
-const discordButtonClass =
-  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-[#5865f2] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#4752c4] disabled:cursor-not-allowed disabled:opacity-60"
-
-const secondaryButtonClass =
-  "inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-unison-bg-elevated px-4 py-2.5 text-sm font-medium text-unison-text transition-colors hover:bg-unison-bg-hover disabled:cursor-not-allowed disabled:opacity-60"
-
-function OutcomeScreen({ status, name, onReset }: { status: string; name: string | null; onReset: () => void }) {
-  if (status === "linked") {
-    return (
-      <Shell>
-        <IconCircleCheck className="size-12 text-emerald-400" stroke={1.5} />
-        <Title>You are all set</Title>
-        <Body>
-          Your Discord is linked to Better Lyrics{name ? ` as ${name}` : ""}. Your roles update on their own, so you can
-          head back to Discord now.
-        </Body>
-      </Shell>
-    )
-  }
-  if (status === "blocked") {
-    return (
-      <Shell>
-        <IconAlertTriangle className="size-12 text-amber-400" stroke={1.5} />
-        <Title>This account cannot be linked</Title>
-        <Body>
-          This looks like a shared community account, so it cannot be connected to a personal Discord. If that is a
-          surprise, reach out to a moderator.
-        </Body>
-      </Shell>
-    )
-  }
-  const isExpired = status === "expired"
-  return (
-    <Shell>
-      <IconAlertTriangle className="size-12 text-amber-400" stroke={1.5} />
-      <Title>{isExpired ? "That timed out" : "Something went wrong"}</Title>
-      <Body>
-        {isExpired
-          ? "The link request expired before it finished. Start over and it will only take a moment."
-          : "We could not finish linking your account. Give it another try."}
-      </Body>
-      <button type="button" onClick={onReset} className={secondaryButtonClass}>
-        {isExpired ? "Start over" : "Try again"}
-      </button>
-    </Shell>
-  )
-}
+import { LinkView, type LinkViewModel } from "@/components/LinkView"
+import { useDiscordLink } from "@/hooks/useDiscordLink"
 
 export function LinkPage() {
   const session = useSession()
   const [params, setParams] = useSearchParams()
   const outcome = params.get("status")
-
-  const [connecting, setConnecting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [existing, setExisting] = useState<{ username: string | null } | null>(null)
-  const [working, setWorking] = useState(false)
-
-  useEffect(() => {
-    if (outcome) return
-    const stored = loadStoredSession()
-    if (!stored) return
-    let cancelled = false
-    fetchLinkStatus(stored.sessionToken)
-      .then((s) => {
-        if (cancelled) return
-        setExisting(s.linked ? { username: s.discordUsername } : null)
-      })
-      .catch(() => {})
-    return () => {
-      cancelled = true
-    }
-  }, [outcome])
-
-  const connect = useCallback(async () => {
-    setConnecting(true)
-    setError(null)
-    try {
-      const { nonce } = await fetchChallenge()
-      const signedBody = await signInWithBetterLyrics(nonce)
-      const { authorizeUrl } = await startDiscordLink(signedBody)
-      window.location.assign(authorizeUrl)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : ""
-      setError(
-        message.includes("cannot be linked")
-          ? "This account cannot be linked. It looks like a shared community account."
-          : "We could not start the link. Make sure Better Lyrics is installed, then try again.",
-      )
-      setConnecting(false)
-    }
-  }, [])
-
-  const disconnect = useCallback(async () => {
-    const stored = loadStoredSession()
-    if (!stored) return
-    setWorking(true)
-    try {
-      await unlinkDiscord(stored.sessionToken)
-      setExisting(null)
-    } catch {
-      setError("We could not disconnect just now. Please try again.")
-    } finally {
-      setWorking(false)
-    }
-  }, [])
+  const link = useDiscordLink({ enabled: !outcome })
 
   if (outcome) {
-    return <OutcomeScreen status={outcome} name={params.get("name")} onReset={() => setParams({})} />
+    const name = params.get("name")
+    const onReset = () => setParams({})
+    const model: LinkViewModel =
+      outcome === "linked"
+        ? { kind: "linked", name }
+        : outcome === "blocked"
+          ? { kind: "blocked" }
+          : outcome === "expired"
+            ? { kind: "expired", onReset }
+            : { kind: "error", onReset }
+    return <LinkView model={model} />
   }
 
   if (session.status === "loading") {
-    return (
-      <Shell>
-        <IconLoader2 className="size-8 animate-spin text-unison-text-muted" stroke={1.5} />
-      </Shell>
-    )
+    return <LinkView model={{ kind: "loading" }} />
   }
 
   if (!session.extensionAvailable) {
-    return (
-      <Shell>
-        <Title>Install Better Lyrics first</Title>
-        <Body>
-          Linking happens through the Better Lyrics extension. Install it, then come back to this page to connect your
-          Discord.
-        </Body>
-        <a href="https://betterlyrics.org" target="_blank" rel="noopener noreferrer" className={secondaryButtonClass}>
-          Get Better Lyrics
-        </a>
-      </Shell>
-    )
+    return <LinkView model={{ kind: "install" }} />
   }
 
-  if (existing) {
+  if (link.status === "linked") {
     return (
-      <Shell>
-        <IconCircleCheck className="size-12 text-emerald-400" stroke={1.5} />
-        <Title>Connected to Discord</Title>
-        <Body>
-          Your account is linked{existing.username ? ` as ${existing.username}` : ""}. Roles update on their own.
-        </Body>
-        <button type="button" onClick={disconnect} disabled={working} className={secondaryButtonClass}>
-          {working ? "Disconnecting..." : "Disconnect"}
-        </button>
-      </Shell>
+      <LinkView
+        model={{
+          kind: "existing",
+          name: link.username,
+          working: link.working,
+          error: link.error,
+          onDisconnect: link.disconnect,
+        }}
+      />
     )
   }
 
   return (
-    <Shell>
-      <Title>Connect Better Lyrics to Discord</Title>
-      <Body>
-        Link once to earn your leaderboard roles and get credit for the songs you add. It takes two quick taps: confirm
-        it is you in Better Lyrics, then approve Discord.
-      </Body>
-      <button type="button" onClick={connect} disabled={connecting} className={discordButtonClass}>
-        {connecting ? (
-          <IconLoader2 className="size-5 animate-spin" stroke={1.5} />
-        ) : (
-          <IconBrandDiscord className="size-5" stroke={1.5} />
-        )}
-        {connecting ? "Connecting..." : "Connect with Discord"}
-      </button>
-      {error ? <p className="max-w-sm text-sm text-red-400">{error}</p> : null}
-    </Shell>
+    <LinkView
+      model={{ kind: "connect", connecting: link.connecting, error: link.error, onConnect: link.connect }}
+    />
   )
 }

--- a/web/src/pages/MePage.tsx
+++ b/web/src/pages/MePage.tsx
@@ -1,4 +1,5 @@
 import { useSession } from "@/auth/useSession"
+import { DiscordSection } from "@/components/DiscordSection"
 import { EmptyState } from "@/components/EmptyState"
 import { LeaderboardSection } from "@/components/LeaderboardSection"
 import { LoadingPlaceholder } from "@/components/LoadingPlaceholder"
@@ -25,6 +26,9 @@ export function MePage() {
       <UserProfileView keyId={session.identity.keyId} title="Me" />
       <LeaderboardSection title="Nickname" subtitle="How you appear across Unison.">
         <NicknameEditor />
+      </LeaderboardSection>
+      <LeaderboardSection title="Discord" subtitle="Link your account for leaderboard roles.">
+        <DiscordSection />
       </LeaderboardSection>
     </div>
   )

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,4 +1,5 @@
-import { RouterProvider, createBrowserRouter } from "react-router-dom"
+import { Suspense, lazy } from "react"
+import { type RouteObject, RouterProvider, createBrowserRouter } from "react-router-dom"
 import { AppLayout } from "./components/AppLayout"
 import { AboutPage } from "./pages/AboutPage"
 import { CuratorsPage } from "./pages/CuratorsPage"
@@ -10,6 +11,22 @@ import { QueuePage } from "./pages/QueuePage"
 import { SearchPage } from "./pages/SearchPage"
 import { SongsPage } from "./pages/SongsPage"
 import { UserPage } from "./pages/UserPage"
+
+// Dev-only state gallery for the link/profile UI. The import.meta.env.DEV branch
+// is statically false in production builds, so this whole block (and the lazy
+// chunk it references) is dropped from the prod bundle.
+const devRoutes: RouteObject[] = []
+if (import.meta.env.DEV) {
+  const DevLinkPreview = lazy(() => import("./pages/DevLinkPreview"))
+  devRoutes.push({
+    path: "dev/link",
+    element: (
+      <Suspense fallback={null}>
+        <DevLinkPreview />
+      </Suspense>
+    ),
+  })
+}
 
 const router = createBrowserRouter([
   {
@@ -26,6 +43,7 @@ const router = createBrowserRouter([
       { path: "about", element: <AboutPage /> },
       { path: "downloads", element: <DownloadsPage /> },
       { path: "link", element: <LinkPage /> },
+      ...devRoutes,
     ],
   },
 ])

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "/feed": "http://localhost:3000",
       "/requests": "http://localhost:3000",
       "/auth": "http://localhost:3000",
+      "/links": "http://localhost:3000",
       "/health": "http://localhost:3000",
     },
   },


### PR DESCRIPTION
## Overview

Redid the Discord link page to match the Better Lyrics sign-in popup: a logo pair with dots between the two icons that shimmer while it's connecting and go still once you land on a result. Connection status shows on profiles now too, a small Connected badge on public profiles and a connect/disconnect section on your own page, backed by a new flag on the curator stats endpoint. There's also a dev-only gallery at /dev/link for checking every state at once, and it's dropped from production builds.
