### PR TITLE
feat(web): discord connection status, profile UI polish, and dev previews

### DIFF
--- a/src/db/leaderboard.ts
+++ b/src/db/leaderboard.ts
@@ -215,6 +215,7 @@ export interface CuratorLeaderboardRow {
 	fulfilledDemand: number
 	rank: number
 	nickname: string | null
+	discordLinked: boolean
 }
 
 interface CuratorRow {
@@ -226,6 +227,7 @@ interface CuratorRow {
 	fulfilled_count: number
 	fulfilled_demand: number
 	nickname: string | null
+	discord_linked: boolean
 }
 
 export async function getCuratorLeaderboard(
@@ -236,7 +238,8 @@ export async function getCuratorLeaderboard(
 		`SELECT u.key_id, u.reputation, u.nickname,
 		        agg.score, agg.submission_count, agg.total_upvotes,
 		        COALESCE(ff.fulfilled_count, 0) AS fulfilled_count,
-		        COALESCE(ff.fulfilled_demand, 0) AS fulfilled_demand
+		        COALESCE(ff.fulfilled_demand, 0) AS fulfilled_demand,
+		        (dl.key_id IS NOT NULL) AS discord_linked
 		 FROM (
 		   SELECT submitter_id,
 		          SUM(effective_score) AS score,
@@ -258,6 +261,7 @@ export async function getCuratorLeaderboard(
 		   WHERE l.deleted_at IS NULL AND NOT ${AUTO_HIDE_PREDICATE_JOINED}
 		   GROUP BY f.submitter_id
 		 ) ff ON ff.submitter_id = u.id
+		 LEFT JOIN discord_links dl ON dl.key_id = u.key_id
 		 ORDER BY agg.score DESC, u.key_id ASC
 		 LIMIT ?`
 	)
@@ -274,6 +278,7 @@ export async function getCuratorLeaderboard(
 		fulfilledDemand: Number(r.fulfilled_demand ?? 0),
 		rank: i + 1,
 		nickname: r.nickname ?? null,
+		discordLinked: Boolean(r.discord_linked),
 	}))
 }
 

--- a/src/routes/leaderboard.test.ts
+++ b/src/routes/leaderboard.test.ts
@@ -262,6 +262,38 @@ describe("GET /leaderboard/users", () => {
 		}
 		expect(json.data.curators[0].displayName).toBe("Alex")
 	})
+
+	it("exposes discordLinked per curator", async () => {
+		const db = makeMockDB([
+			[
+				{
+					key_id: "a".repeat(64),
+					reputation: 1.5,
+					score: 10,
+					submission_count: 4,
+					total_upvotes: 20,
+					discord_linked: true,
+				},
+				{
+					key_id: "b".repeat(64),
+					reputation: 1.2,
+					score: 5,
+					submission_count: 2,
+					total_upvotes: 8,
+					discord_linked: false,
+				},
+			],
+		])
+		const env = makeEnv(db)
+		const app = leaderboardRoutes(env)
+		const res = await app.handle(new Request("http://localhost/leaderboard/users"))
+		expect(res.status).toBe(200)
+		const json = (await res.json()) as {
+			data: { curators: Array<{ keyId: string; discordLinked: boolean }> }
+		}
+		expect(json.data.curators[0].discordLinked).toBe(true)
+		expect(json.data.curators[1].discordLinked).toBe(false)
+	})
 })
 
 describe("GET /leaderboard/songs cache hit", () => {

--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -31,6 +31,9 @@ type SessionState =
 
 const Ctx = createContext<SessionState | null>(null)
 
+// Exposed so dev preview pages can mount a fixture session around real pages.
+export { Ctx as SessionContext }
+
 export function useSessionState(): SessionState {
   const state = useContext(Ctx)
   if (!state) throw new Error("useSession must be used within <AuthProvider>")

--- a/web/src/components/CuratorRow.tsx
+++ b/web/src/components/CuratorRow.tsx
@@ -1,3 +1,4 @@
+import { IconBrandDiscordFilled } from "@tabler/icons-react"
 import { Link } from "react-router-dom"
 import { MedalRank } from "@/components/MedalRank"
 import { dicebearThumbsDataUri } from "@/lib/avatar"
@@ -33,6 +34,9 @@ export function CuratorRow({ entry, isSelf = false, appended = false }: CuratorR
         <div className="min-w-0 flex-1">
           <p className="flex items-center gap-2 truncate text-sm font-medium text-unison-text">
             <span className="truncate">{entry.displayName}</span>
+            {entry.discordLinked ? (
+              <IconBrandDiscordFilled className="size-4 shrink-0 text-unison-discord" title="Discord connected" />
+            ) : null}
             {isSelf ? (
               <span className="shrink-0 rounded bg-unison-text px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-unison-bg">
                 You

--- a/web/src/components/DiscordSection.tsx
+++ b/web/src/components/DiscordSection.tsx
@@ -1,5 +1,6 @@
 import { IconBrandDiscordFilled, IconLoader2 } from "@tabler/icons-react"
 import { discordButtonClass, secondaryButtonClass } from "@/components/discord-ui"
+import { editableCardClass } from "@/components/ui"
 import { useDiscordLink } from "@/hooks/useDiscordLink"
 
 export interface DiscordSectionModel {
@@ -12,12 +13,10 @@ export interface DiscordSectionModel {
   onDisconnect: () => void
 }
 
-const cardClass = "space-y-3 rounded-lg border border-unison-border bg-unison-bg-elevated p-4"
-
 export function DiscordSectionView({ model }: { model: DiscordSectionModel }) {
   if (model.status === "loading") {
     return (
-      <div className={cardClass}>
+      <div className={editableCardClass}>
         <IconLoader2 className="size-5 animate-spin text-unison-text-muted" stroke={1.5} />
       </div>
     )
@@ -25,7 +24,7 @@ export function DiscordSectionView({ model }: { model: DiscordSectionModel }) {
 
   if (model.status === "linked") {
     return (
-      <div className={cardClass}>
+      <div className={editableCardClass}>
         <p className="text-sm text-unison-text">
           Connected{model.username ? ` as ${model.username}` : ""}. Your roles update on their own.
         </p>
@@ -38,7 +37,7 @@ export function DiscordSectionView({ model }: { model: DiscordSectionModel }) {
   }
 
   return (
-    <div className={cardClass}>
+    <div className={editableCardClass}>
       <p className="text-sm text-unison-text-secondary">
         Link your Discord to earn leaderboard roles and get credit for the songs you add.
       </p>

--- a/web/src/components/NicknameEditor.test.tsx
+++ b/web/src/components/NicknameEditor.test.tsx
@@ -235,9 +235,7 @@ describe("NicknameEditor", () => {
       save.click()
     })
     await flush()
-    const putCall = router.calls.find(
-      (c) => c.url === "/auth/nickname" && (c.init?.method ?? "") === "PUT",
-    )
+    const putCall = router.calls.find((c) => c.url === "/auth/nickname" && (c.init?.method ?? "") === "PUT")
     expect(putCall).toBeTruthy()
     expect(JSON.parse(putCall?.init?.body as string)).toEqual({ nickname: "Alex" })
     expect(screen.getByTestId("nickname-status").textContent ?? "").toMatch(/saved/i)
@@ -271,7 +269,69 @@ describe("NicknameEditor", () => {
     expect(save.disabled).toBe(true)
   })
 
-  it("DELETEs /auth/nickname when Reset is clicked and updates the session displayName", async () => {
+  function resetRouter() {
+    return fetchRouter([
+      { match: (u) => u === "/auth/me", respond: meResponse },
+      {
+        match: (u, init) => u === "/auth/nickname" && init?.method === "DELETE",
+        respond: () => jsonResponse({ success: true, data: { keyId: valid.keyId, displayName: "GeneratedOne" } }),
+      },
+    ])
+  }
+
+  function findDelete(calls: { url: string; init?: RequestInit }[]) {
+    return calls.find((c) => c.url === "/auth/nickname" && (c.init?.method ?? "") === "DELETE")
+  }
+
+  it("DELETEs /auth/nickname when Reset is armed and then held to confirm", async () => {
+    const router = resetRouter()
+    vi.stubGlobal("fetch", router.fn)
+    await mountEditor()
+    const reset = screen.getByRole("button", { name: /reset/i })
+    await act(async () => {
+      fireEvent.click(reset)
+    })
+    expect(reset.textContent).toMatch(/hold to confirm/i)
+    await act(async () => {
+      fireEvent.pointerDown(reset)
+      vi.advanceTimersByTime(900)
+    })
+    await flush()
+    expect(findDelete(router.calls)).toBeTruthy()
+    const input = screen.getByLabelText(/nickname/i) as HTMLInputElement
+    expect(input.value).toBe("GeneratedOne")
+  })
+
+  it("arms on a single click but does not reset without a hold", async () => {
+    const router = resetRouter()
+    vi.stubGlobal("fetch", router.fn)
+    await mountEditor()
+    const reset = screen.getByRole("button", { name: /reset/i })
+    await act(async () => {
+      fireEvent.click(reset)
+    })
+    await flush()
+    expect(findDelete(router.calls)).toBeUndefined()
+    expect(reset.textContent).toMatch(/hold to confirm/i)
+  })
+
+  it("does not reset when the hold is released before it completes", async () => {
+    const router = resetRouter()
+    vi.stubGlobal("fetch", router.fn)
+    await mountEditor()
+    const reset = screen.getByRole("button", { name: /reset/i })
+    await act(async () => {
+      fireEvent.click(reset)
+      fireEvent.pointerDown(reset)
+      vi.advanceTimersByTime(400)
+      fireEvent.pointerUp(reset)
+      vi.advanceTimersByTime(900)
+    })
+    await flush()
+    expect(findDelete(router.calls)).toBeUndefined()
+  })
+
+  it("does not reset when the hold is released before it completes", async () => {
     const router = fetchRouter([
       { match: (u) => u === "/auth/me", respond: meResponse },
       {
@@ -281,16 +341,16 @@ describe("NicknameEditor", () => {
     ])
     vi.stubGlobal("fetch", router.fn)
     await mountEditor()
+    const reset = screen.getByRole("button", { name: /reset/i })
     await act(async () => {
-      screen.getByRole("button", { name: /reset/i }).click()
+      fireEvent.pointerDown(reset)
+      vi.advanceTimersByTime(400)
+      fireEvent.pointerUp(reset)
+      vi.advanceTimersByTime(900)
     })
     await flush()
-    const deleteCall = router.calls.find(
-      (c) => c.url === "/auth/nickname" && (c.init?.method ?? "") === "DELETE",
-    )
-    expect(deleteCall).toBeTruthy()
-    const input = screen.getByLabelText(/nickname/i) as HTMLInputElement
-    expect(input.value).toBe("GeneratedOne")
+    const deleteCall = router.calls.find((c) => c.url === "/auth/nickname" && (c.init?.method ?? "") === "DELETE")
+    expect(deleteCall).toBeUndefined()
   })
 
   it("surfaces Try again in a moment when the availability check returns 429", async () => {

--- a/web/src/components/NicknameEditor.test.tsx
+++ b/web/src/components/NicknameEditor.test.tsx
@@ -331,7 +331,7 @@ describe("NicknameEditor", () => {
     expect(findDelete(router.calls)).toBeUndefined()
   })
 
-  it("does not reset when the hold is released before it completes", async () => {
+  it("does not reset when hold starts without first arming", async () => {
     const router = fetchRouter([
       { match: (u) => u === "/auth/me", respond: meResponse },
       {

--- a/web/src/components/NicknameEditor.tsx
+++ b/web/src/components/NicknameEditor.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useSession } from "@/auth/useSession"
-import {
-  checkNicknameAvailability,
-  deleteNickname,
-  putNickname,
-} from "@/lib/nickname"
+import { editableCardClass } from "@/components/ui"
+import { checkNicknameAvailability, deleteNickname, putNickname } from "@/lib/nickname"
 
 const DEBOUNCE_MS = 350
 const RATE_LIMIT_COOLDOWN_MS = 5000
 const SAVED_FLASH_MS = 1500
+const HOLD_MS = 900
+const ARM_TIMEOUT_MS = 3000
 
 type State =
   | { kind: "idle" }
@@ -63,10 +62,15 @@ function inputValue(state: State, fallback: string): string {
 export function NicknameEditor() {
   const session = useSession()
   const [state, setState] = useState<State>({ kind: "idle" })
+  const [armed, setArmed] = useState(false)
+  const [holding, setHolding] = useState(false)
   const requestTokenRef = useRef(0)
   const debounceRef = useRef<number | null>(null)
   const cooldownRef = useRef<number | null>(null)
   const savedTimerRef = useRef<number | null>(null)
+  const holdTimerRef = useRef<number | null>(null)
+  const armTimerRef = useRef<number | null>(null)
+  const heldRef = useRef(false)
 
   const clearDebounce = useCallback(() => {
     if (debounceRef.current !== null) {
@@ -89,13 +93,37 @@ export function NicknameEditor() {
     }
   }, [])
 
+  const clearHold = useCallback(() => {
+    if (holdTimerRef.current !== null) {
+      window.clearTimeout(holdTimerRef.current)
+      holdTimerRef.current = null
+    }
+  }, [])
+
+  const clearArmTimer = useCallback(() => {
+    if (armTimerRef.current !== null) {
+      window.clearTimeout(armTimerRef.current)
+      armTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleDisarm = useCallback(() => {
+    clearArmTimer()
+    armTimerRef.current = window.setTimeout(() => {
+      armTimerRef.current = null
+      setArmed(false)
+    }, ARM_TIMEOUT_MS)
+  }, [clearArmTimer])
+
   useEffect(() => {
     return () => {
       clearDebounce()
       clearCooldown()
       clearSavedTimer()
+      clearHold()
+      clearArmTimer()
     }
-  }, [clearDebounce, clearCooldown, clearSavedTimer])
+  }, [clearDebounce, clearCooldown, clearSavedTimer, clearHold, clearArmTimer])
 
   const enterRateLimitedCooldown = useCallback(
     (value: string) => {
@@ -222,12 +250,58 @@ export function NicknameEditor() {
     }
   }
 
+  const armReset = () => {
+    if (resetDisabled || armed) return
+    setArmed(true)
+    scheduleDisarm()
+  }
+
+  const confirmReset = () => {
+    clearArmTimer()
+    clearHold()
+    setHolding(false)
+    setArmed(false)
+    void onReset()
+  }
+
+  const startHold = () => {
+    if (!armed || resetDisabled || holdTimerRef.current !== null) return
+    clearArmTimer()
+    setHolding(true)
+    holdTimerRef.current = window.setTimeout(() => {
+      holdTimerRef.current = null
+      setHolding(false)
+      setArmed(false)
+      void onReset()
+    }, HOLD_MS)
+  }
+
+  const cancelHold = () => {
+    if (holdTimerRef.current === null) return
+    clearHold()
+    setHolding(false)
+    if (armed) scheduleDisarm()
+  }
+
+  const onResetPointerDown = () => {
+    heldRef.current = armed
+    startHold()
+  }
+
+  const onResetClick = (e: { detail: number }) => {
+    if (heldRef.current) {
+      heldRef.current = false
+      return
+    }
+    if (!armed) {
+      armReset()
+      return
+    }
+    if (e.detail === 0) confirmReset()
+  }
+
   return (
-    <div
-      data-testid="nickname-editor"
-      data-state={state.kind}
-      className="space-y-3 rounded-lg border border-unison-border bg-unison-bg-elevated p-4"
-    >
+    <div data-testid="nickname-editor" data-state={state.kind} className={editableCardClass}>
       <div className="space-y-1">
         <label htmlFor="nickname-input" className="text-[10px] uppercase tracking-wider text-unison-text-muted">
           Nickname
@@ -262,11 +336,21 @@ export function NicknameEditor() {
         </button>
         <button
           type="button"
-          onClick={onReset}
           disabled={resetDisabled}
-          className="cursor-pointer rounded-md px-3 py-1.5 text-sm text-unison-text-secondary transition-colors hover:bg-unison-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={onResetClick}
+          onPointerDown={onResetPointerDown}
+          onPointerUp={cancelHold}
+          onPointerLeave={cancelHold}
+          onPointerCancel={cancelHold}
+          aria-label={armed ? "Hold to confirm reset" : "Reset to default"}
+          className="relative cursor-pointer select-none overflow-hidden rounded-md bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-300 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Reset to default
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 left-0 bg-red-500/30"
+            style={{ width: holding ? "100%" : "0%", transition: `width ${holding ? HOLD_MS : 200}ms linear` }}
+          />
+          <span className="relative">{armed ? "Hold to confirm" : "Reset to default"}</span>
         </button>
       </div>
     </div>

--- a/web/src/components/ui.ts
+++ b/web/src/components/ui.ts
@@ -1,0 +1,3 @@
+// Translucent surface for cards that hold buttons or editable content, so the
+// controls inside read against the panel instead of matching the page elevation.
+export const editableCardClass = "space-y-3 rounded-lg border border-unison-surface bg-unison-surface p-4"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -6,20 +6,24 @@
   --color-unison-bg: #28292c;
   --color-unison-bg-elevated: #3e3e41;
   --color-unison-bg-hover: rgba(255, 255, 255, 0.06);
+  --color-unison-surface: rgba(255, 255, 255, 0.05);
   --color-unison-border: rgba(255, 255, 255, 0.1);
   --color-unison-border-strong: rgba(255, 255, 255, 0.18);
   --color-unison-text: #f5f5f7;
   --color-unison-text-secondary: rgba(245, 245, 247, 0.72);
   --color-unison-text-muted: rgba(245, 245, 247, 0.48);
   --color-unison-warn: #f5a623;
-  --color-unison-medal-gold: #FFC83D;
-  --color-unison-medal-silver: #C0C7D1;
-  --color-unison-medal-bronze: #CD7F32;
+  --color-unison-discord: hsl(235 86% 75%);
+  --color-unison-medal-gold: #ffc83d;
+  --color-unison-medal-silver: #c0c7d1;
+  --color-unison-medal-bronze: #cd7f32;
   --font-sans: "Satoshi", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
 }
 
@@ -34,6 +38,24 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Native select popups ignore the control's own background, so dark them here. */
+option,
+optgroup {
+  background-color: var(--color-unison-bg-elevated);
+  color: var(--color-unison-text);
+}
+
+/* Custom chevron so it sits off the right edge instead of glued to the border. */
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='%23f5f5f7'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M6%209l6%206%206-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.625rem center;
+  background-size: 1rem;
+  padding-right: 2rem;
 }
 
 .unison-shimmer-text {

--- a/web/src/lib/dev-seed.ts
+++ b/web/src/lib/dev-seed.ts
@@ -3,12 +3,13 @@ import type {
   CuratorsLeaderboardResponse,
   SongsLeaderboardResponse,
   UserRankResponse,
+  UserSubmission,
   UserSubmissionsResponse,
 } from "./types"
 
 const SEEDED_NOW = Math.floor(Date.now() / 1000)
 
-const SEED_CURATORS: CuratorLeaderboardEntry[] = [
+export const SEED_CURATORS: CuratorLeaderboardEntry[] = [
   {
     keyId: "a".repeat(64),
     displayName: "Aurora Wynter",
@@ -17,6 +18,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 87,
     totalUpvotes: 540,
     rank: 1,
+    discordLinked: true,
   },
   {
     keyId: "b".repeat(64),
@@ -26,6 +28,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 65,
     totalUpvotes: 410,
     rank: 2,
+    discordLinked: false,
   },
   {
     keyId: "c".repeat(64),
@@ -35,6 +38,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 52,
     totalUpvotes: 312,
     rank: 3,
+    discordLinked: true,
   },
   {
     keyId: "d".repeat(64),
@@ -44,6 +48,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 41,
     totalUpvotes: 220,
     rank: 4,
+    discordLinked: false,
   },
   {
     keyId: "e".repeat(64),
@@ -53,6 +58,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 33,
     totalUpvotes: 180,
     rank: 5,
+    discordLinked: false,
   },
   {
     keyId: "f".repeat(64),
@@ -62,6 +68,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 21,
     totalUpvotes: 95,
     rank: 12,
+    discordLinked: true,
   },
   {
     keyId: "g".repeat(64),
@@ -71,6 +78,7 @@ const SEED_CURATORS: CuratorLeaderboardEntry[] = [
     submissionCount: 9,
     totalUpvotes: 32,
     rank: 137,
+    discordLinked: false,
   },
 ]
 
@@ -112,7 +120,102 @@ export async function seedUserRank(keyId: string): Promise<UserRankResponse> {
   }
 }
 
+const SEED_SUBMISSIONS: UserSubmission[] = [
+  {
+    id: 1,
+    videoId: "dQw4w9WgXcQ",
+    song: "Never Gonna Give You Up",
+    artist: "Rick Astley",
+    album: "Whenever You Need Somebody",
+    duration: 213,
+    format: "ttml",
+    syncType: "richsync",
+    language: "en",
+    effectiveScore: 48.2,
+    voteCount: 51,
+    confidence: "high",
+    createdAt: SEEDED_NOW - 3600,
+    hidden: false,
+  },
+  {
+    id: 2,
+    videoId: "60ItHLz5WEA",
+    song: "Faded",
+    artist: "Alan Walker",
+    duration: 212,
+    format: "lrc",
+    syncType: "linesync",
+    language: "en",
+    effectiveScore: 31.0,
+    voteCount: 34,
+    confidence: "high",
+    createdAt: SEEDED_NOW - 2 * 86400,
+    hidden: false,
+  },
+  {
+    id: 3,
+    videoId: "kJQP7kiw5Fk",
+    song: "Despacito",
+    artist: "Luis Fonsi",
+    duration: 281,
+    format: "lrc",
+    syncType: "linesync",
+    language: "es",
+    effectiveScore: 22.5,
+    voteCount: 28,
+    confidence: "medium",
+    createdAt: SEEDED_NOW - 5 * 86400,
+    hidden: false,
+  },
+  {
+    id: 4,
+    videoId: "JGwWNGJdvx8",
+    song: "Shape of You",
+    artist: "Ed Sheeran",
+    duration: 234,
+    format: "plain",
+    syncType: "plain",
+    language: "en",
+    effectiveScore: 9.1,
+    voteCount: 12,
+    confidence: "low",
+    createdAt: SEEDED_NOW - 12 * 86400,
+    hidden: false,
+  },
+  {
+    id: 5,
+    videoId: "RgKAFK5djSk",
+    song: "See You Again",
+    artist: "Wiz Khalifa",
+    duration: 229,
+    format: "ttml",
+    syncType: "richsync",
+    language: "en",
+    effectiveScore: 14.7,
+    voteCount: 19,
+    confidence: "medium",
+    createdAt: SEEDED_NOW - 20 * 86400,
+    hidden: true,
+  },
+  {
+    id: 6,
+    videoId: "fJ9rUzIMcZQ",
+    song: "Bohemian Rhapsody",
+    artist: "Queen",
+    album: "A Night at the Opera",
+    duration: 354,
+    format: "lrc",
+    syncType: "linesync",
+    language: "en",
+    effectiveScore: 40.3,
+    voteCount: 44,
+    confidence: "high",
+    createdAt: SEEDED_NOW - 30 * 86400,
+    hidden: false,
+  },
+]
+
 export async function seedUserSubmissions(_keyId: string): Promise<UserSubmissionsResponse> {
   await delay()
-  return { submissions: [] }
+  return { submissions: SEED_SUBMISSIONS }
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface CuratorLeaderboardEntry {
   submissionCount: number
   totalUpvotes: number
   rank: number
+  discordLinked: boolean
 }
 
 export interface SongsLeaderboardResponse {

--- a/web/src/pages/AboutPage.tsx
+++ b/web/src/pages/AboutPage.tsx
@@ -4,12 +4,9 @@ export function AboutPage() {
   return (
     <div className="max-w-2xl space-y-10">
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold text-unison-text">
-          What Unison is
-        </h2>
+        <h2 className="text-lg font-semibold text-unison-text">What Unison is</h2>
         <p className="text-sm leading-relaxed text-unison-text-secondary">
-          A public database for synced lyrics on YouTube Music. Everything in
-          here was submitted by someone using{" "}
+          A public database for synced lyrics on YouTube Music. Everything in here was submitted by someone using{" "}
           <a
             href="https://betterlyrics.org"
             target="_blank"
@@ -18,44 +15,34 @@ export function AboutPage() {
           >
             Better Lyrics
           </a>
-          , the browser extension for YT Music. Better Lyrics checks a few
-          sources when it overlays lyrics on a song; Unison is the community-fed
-          one.
+          , the browser extension for YT Music. Better Lyrics checks a few sources when it overlays lyrics on a song;
+          Unison is the community-fed one.
         </p>
       </section>
 
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold text-unison-text">
-          How the leaderboards work
-        </h2>
+        <h2 className="text-lg font-semibold text-unison-text">How the leaderboards work</h2>
         <p className="text-sm leading-relaxed text-unison-text-secondary">
-          Two song boards. Most Wanted is songs nobody's submitted lyrics for
-          yet, ranked by reputation-weighted demand. One request from a
-          long-time contributor outranks a hundred from throwaway accounts, so
-          the top of the board reflects what people actually care about and not
-          who has the most browser tabs open. Needs Fixing is the inverse: songs
-          that already have synced lyrics, but enough listeners flagged the
-          timing for it to be worth a second pass.
+          Two song boards. Most Wanted is songs nobody's submitted lyrics for yet, ranked by reputation-weighted demand.
+          One request from a long-time contributor outranks a hundred from throwaway accounts, so the top of the board
+          reflects what people actually care about and not who has the most browser tabs open. Needs Fixing is the
+          inverse: songs that already have synced lyrics, but enough listeners flagged the timing for it to be worth a
+          second pass.
         </p>
         <p className="text-sm leading-relaxed text-unison-text-secondary">
-          The Leaderboard ranks people by submission volume and how much of that
-          work survived voting. Names like "BrightVivaceRoll" come from each
-          contributor's public key, which means no accounts and no usernames to
-          fight over.
+          The Leaderboard ranks people by submission volume and how much of that work survived voting. Names like
+          "BrightVivaceRoll" come from each contributor's public key, which means no accounts and no usernames to fight
+          over.
         </p>
       </section>
 
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold text-unison-text">
-          How to contribute
-        </h2>
+        <h2 className="text-lg font-semibold text-unison-text">How to contribute</h2>
         <p className="text-sm leading-relaxed text-unison-text-secondary">
-          Install Better Lyrics. With a YT Music song open, the player footer
-          has the buttons you need. Click "Request lyrics" to push a song onto
-          Most Wanted, or report bad sync on a song that already has lyrics to
-          feed it into Needs Fixing. To submit lyrics yourself, click "Submit
-          lyrics with Unison" at the bottom of the page; if you don't have a
-          synced version handy,{" "}
+          Install Better Lyrics. With a YT Music song open, the player footer has the buttons you need. Click "Request
+          lyrics" to push a song onto Most Wanted, or report bad sync on a song that already has lyrics to feed it into
+          Needs Fixing. To submit lyrics yourself, click "Submit lyrics with Unison" at the bottom of the page; if you
+          don't have a synced version handy,{" "}
           <a
             href="https://composer.boidu.dev"
             target="_blank"
@@ -64,23 +51,47 @@ export function AboutPage() {
           >
             Composer
           </a>{" "}
-          lets you sync lyrics yourself. Voting on existing submissions is what
-          decides which version Better Lyrics shows everyone else by default.
+          lets you sync lyrics yourself. Voting on existing submissions is what decides which version Better Lyrics
+          shows everyone else by default.
         </p>
         <p className="text-sm leading-relaxed text-unison-text-secondary">
-          You don't need to sign in to use any of this. If you do, your row on
-          the Leaderboard gets marked when you're ranked, and there's a /me page
-          with your stats. It reuses the keypair Better Lyrics already keeps for
-          you, so there's nothing extra to set up.
+          You don't need to sign in to use any of this. If you do, your row on the Leaderboard gets marked when you're
+          ranked, and there's a /me page with your stats. It reuses the chunk of your identity Better Lyrics already
+          keeps for you, so there's nothing extra to set up.
+        </p>
+      </section>
+
+      <section className="rounded-2xl border border-unison-border/50 bg-unison-bg-elevated/50 px-3.5 py-2.5 text-sm leading-relaxed text-pretty text-unison-text-secondary">
+        Heads up: signing in with Better Lyrics doesn't work in Firefox yet. You'll need a Chromium browser like Chrome
+        or Edge for now.
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-unison-text">Linking Discord</h2>
+        <p className="text-sm leading-relaxed text-unison-text-secondary">
+          Signed-in users can connect a Discord account from the /me page. It earns you roles in our server that mirror
+          where you sit on the Leaderboard, and it drops a small Discord mark next to your name across Unison so the
+          linked curators are easy to spot. The same page is where you set a nickname, if going by a key-derived name
+          like "BrightVivaceRoll" isn't your thing, or you can edit it from Better Lyrics under the Identity tab.
+        </p>
+        <p className="text-sm leading-relaxed text-unison-text-secondary">
+          The server is also where we hang out and talk shop, fixing bad sync and figuring out what to build next. If
+          you're contributing here, come join us at{" "}
+          <a
+            href="https://discord.gg/UsHE3d5fWF"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-unison-text transition-colors hover:text-unison-text-secondary"
+          >
+            discord.gg/UsHE3d5fWF
+          </a>
+          .
         </p>
       </section>
 
       <p className="text-sm leading-relaxed text-unison-text-secondary">
         Want the whole database? A daily snapshot is published at{" "}
-        <Link
-          to="/downloads"
-          className="text-unison-text transition-colors hover:text-unison-text-secondary"
-        >
+        <Link to="/downloads" className="text-unison-text transition-colors hover:text-unison-text-secondary">
           /downloads
         </Link>
         .
@@ -118,5 +129,5 @@ export function AboutPage() {
         </a>
       </footer>
     </div>
-  );
+  )
 }

--- a/web/src/pages/DevCuratorsPreview.tsx
+++ b/web/src/pages/DevCuratorsPreview.tsx
@@ -1,0 +1,15 @@
+import { CuratorRow } from "@/components/CuratorRow"
+import { LeaderboardSection } from "@/components/LeaderboardSection"
+import { SEED_CURATORS } from "@/lib/dev-seed"
+
+export default function DevCuratorsPreview() {
+  return (
+    <LeaderboardSection title="Leaderboard" subtitle="Fixtures: Discord icon shows for linked curators.">
+      <ul className="space-y-2">
+        {SEED_CURATORS.map((entry, i) => (
+          <CuratorRow key={entry.keyId} entry={entry} isSelf={i === 0} />
+        ))}
+      </ul>
+    </LeaderboardSection>
+  )
+}

--- a/web/src/pages/DevIndex.tsx
+++ b/web/src/pages/DevIndex.tsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom"
+
+const previews = [
+  { to: "/dev/link", title: "Link UI", desc: "Every state of the link page and Discord section." },
+  { to: "/dev/curators", title: "Curators", desc: "Leaderboard rows with Discord icons, from fixtures." },
+  { to: "/dev/me", title: "Me page", desc: "Profile, nickname, and Discord cards from fixtures." },
+]
+
+export default function DevIndex() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-base font-semibold text-unison-text">Dev previews</h2>
+      <ul className="space-y-2">
+        {previews.map((p) => (
+          <li key={p.to}>
+            <Link
+              to={p.to}
+              className="block rounded-lg border border-unison-border bg-unison-bg-elevated p-4 transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover"
+            >
+              <p className="text-sm font-medium text-unison-text">{p.title}</p>
+              <p className="text-xs text-unison-text-muted">{p.desc}</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/web/src/pages/DevMePreview.tsx
+++ b/web/src/pages/DevMePreview.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react"
+import { SessionContext } from "@/auth/AuthProvider"
+import { type DiscordSectionModel, DiscordSectionView } from "@/components/DiscordSection"
+import { LeaderboardSection } from "@/components/LeaderboardSection"
+import { NicknameEditor } from "@/components/NicknameEditor"
+import { UserProfileView } from "@/components/UserProfileView"
+import { SEED_CURATORS } from "@/lib/dev-seed"
+
+// Mirrors the Me page against a fixture session so the profile and nickname
+// cards render with seed data, while the Discord card is swappable across its
+// states. Nickname save/reset hit no backend here.
+const curator = SEED_CURATORS[0]
+const fakeSession = {
+  status: "signed-in",
+  extensionAvailable: true,
+  identity: {
+    keyId: curator.keyId,
+    displayName: curator.displayName,
+    expiresAt: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+  },
+  signOut: () => {},
+  updateDisplayName: (_displayName: string) => {},
+} as const
+
+const baseSection: Omit<DiscordSectionModel, "status"> = {
+  username: "aurora#1234",
+  connecting: false,
+  working: false,
+  error: null,
+  onConnect: () => {},
+  onDisconnect: () => {},
+}
+
+const sectionStates: { label: string; model: DiscordSectionModel }[] = [
+  { label: "unlinked", model: { ...baseSection, status: "unlinked", username: null } },
+  { label: "linked", model: { ...baseSection, status: "linked" } },
+  { label: "linked (working)", model: { ...baseSection, status: "linked", working: true } },
+  { label: "error", model: { ...baseSection, status: "linked", error: "We could not disconnect just now." } },
+  { label: "loading", model: { ...baseSection, status: "loading" } },
+]
+
+const tabClass = (active: boolean) =>
+  `cursor-pointer rounded-md border px-3 py-1.5 text-sm transition-colors ${
+    active
+      ? "border-unison-border-strong bg-unison-bg-hover text-unison-text"
+      : "border-unison-border bg-unison-bg-elevated text-unison-text-muted hover:text-unison-text"
+  }`
+
+export default function DevMePreview() {
+  const [sectionIdx, setSectionIdx] = useState(1)
+
+  return (
+    <SessionContext.Provider value={fakeSession}>
+      <div className="space-y-6">
+        <UserProfileView keyId={curator.keyId} title="Me" />
+        <LeaderboardSection title="Nickname" subtitle="How you appear across Unison.">
+          <NicknameEditor />
+        </LeaderboardSection>
+        <LeaderboardSection title="Discord" subtitle="Link your account for leaderboard roles.">
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              {sectionStates.map((s, i) => (
+                <button
+                  key={s.label}
+                  type="button"
+                  className={tabClass(i === sectionIdx)}
+                  onClick={() => setSectionIdx(i)}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+            <DiscordSectionView model={sectionStates[sectionIdx].model} />
+          </div>
+        </LeaderboardSection>
+      </div>
+    </SessionContext.Provider>
+  )
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from "react"
+import { type ComponentType, Suspense, lazy } from "react"
 import { type RouteObject, RouterProvider, createBrowserRouter } from "react-router-dom"
 import { AppLayout } from "./components/AppLayout"
 import { AboutPage } from "./pages/AboutPage"
@@ -17,15 +17,23 @@ import { UserPage } from "./pages/UserPage"
 // chunk it references) is dropped from the prod bundle.
 const devRoutes: RouteObject[] = []
 if (import.meta.env.DEV) {
-  const DevLinkPreview = lazy(() => import("./pages/DevLinkPreview"))
-  devRoutes.push({
-    path: "dev/link",
-    element: (
-      <Suspense fallback={null}>
-        <DevLinkPreview />
-      </Suspense>
-    ),
-  })
+  const devPages: { path: string; load: () => Promise<{ default: ComponentType }> }[] = [
+    { path: "dev", load: () => import("./pages/DevIndex") },
+    { path: "dev/link", load: () => import("./pages/DevLinkPreview") },
+    { path: "dev/curators", load: () => import("./pages/DevCuratorsPreview") },
+    { path: "dev/me", load: () => import("./pages/DevMePreview") },
+  ]
+  for (const { path, load } of devPages) {
+    const Page = lazy(load)
+    devRoutes.push({
+      path,
+      element: (
+        <Suspense fallback={null}>
+          <Page />
+        </Suspense>
+      ),
+    })
+  }
 }
 
 const router = createBrowserRouter([


### PR DESCRIPTION
## Overview

Curators with a linked Discord now show a small mark on the leaderboard, backed by a new field on the curators endpoint. On /me, the editable cards got a translucent surface so their buttons stand out, the native dropdowns render dark, and "reset to default" became a click-to-arm, hold-to-confirm action so a nickname isn't one stray click from gone. Also added dev-only preview routes for these pages and refreshed the about copy to cover Discord linking and the Firefox sign-in gap.
