### PR TITLE
fix(lyrics): reject degenerate zero-duration TTML word timing

### DIFF
--- a/src/jobs/backfill-synctype.test.ts
+++ b/src/jobs/backfill-synctype.test.ts
@@ -90,6 +90,16 @@ const LINESYNC_TTML =
 
 const PLAIN_TTML = "<tt><body><div><p>Hello world</p></div></body></tt>"
 
+// Word spans present but mostly begin===end: stored as richsync, actually
+// degraded word-sync. Backfill must reclassify it down to linesync.
+const ZERO_DUR_TTML =
+	'<tt><body><div><p begin="0:00.0" end="0:02.0">' +
+	'<span begin="0:00.0" end="0:00.0">How</span> ' +
+	'<span begin="0:00.5" end="0:00.5">did</span> ' +
+	'<span begin="0:01.0" end="0:01.0">I</span> ' +
+	'<span begin="0:01.5" end="0:02.0">know</span>' +
+	"</p></div></body></tt>"
+
 describe("backfillSyncType", () => {
 	it("only updates rows whose detected sync_type differs from current", async () => {
 		const db = makeMockDB([
@@ -113,6 +123,22 @@ describe("backfillSyncType", () => {
 		expect(updates).toHaveLength(2)
 		expect(updates[0].params).toEqual(["richsync", 1, "linesync"])
 		expect(updates[1].params).toEqual(["plain", 3, "linesync"])
+	})
+
+	it("regression: reclassifies zero-duration-dominated richsync down to linesync", async () => {
+		const db = makeMockDB([
+			[{ id: 42, video_id: "v42", format: "ttml", lyrics: ZERO_DUR_TTML, sync_type: "richsync" }],
+			null,
+			[],
+		])
+		const cache = makeMockCache()
+		const env = makeEnv(db, cache)
+
+		const result = await backfillSyncType(env)
+
+		expect(result.changed).toBe(1)
+		const update = db.calls.find((c) => /UPDATE\s+lyrics/i.test(c.sql))
+		expect(update?.params).toEqual(["linesync", 42, "richsync"])
 	})
 
 	it("includes the WHERE-guard predicate against concurrent updates", async () => {

--- a/src/routes/lyrics.test.ts
+++ b/src/routes/lyrics.test.ts
@@ -195,6 +195,17 @@ const RICHSYNC_TTML =
 
 const PLAIN_LRC = "Just text\nNo timestamps"
 
+// Word spans present but 3 of 4 collapse to begin===end: the zero-duration
+// abuse signature. Should be rejected at submit, not stored as richsync.
+const DEGENERATE_TTML =
+	'<tt xmlns="http://www.w3.org/ns/ttml"><body><div>' +
+	'<p begin="0:00.0" end="0:02.0">' +
+	'<span begin="0:00.0" end="0:00.0">How</span> ' +
+	'<span begin="0:00.5" end="0:00.5">did</span> ' +
+	'<span begin="0:01.0" end="0:01.0">I</span> ' +
+	'<span begin="0:01.5" end="0:02.0">know</span>' +
+	"</p></div></body></tt>"
+
 async function buildSubmitRequest(
 	keyPair: GeneratedKeyPair,
 	keyId: string,
@@ -246,6 +257,39 @@ describe("POST /lyrics/submit syncType override", () => {
 		expect(insertCall).toBeDefined()
 		const syncTypeIndex = 12
 		expect(insertCall?.params[syncTypeIndex]).toBe("richsync")
+	})
+
+	it("rejects zero-duration-dominated TTML with an explanatory error", async () => {
+		const keyPair = await generateKeyPair()
+		const publicJwk = await exportPublicJwk(keyPair)
+		const keyId = await hashPublicKey(publicJwk)
+
+		const db = makeMockDB([
+			{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 },
+			{ id: 7, key_id: keyId },
+		])
+		const env = makeEnv(db)
+		const app = lyricsRoutes(env)
+
+		const req = await buildSubmitRequest(keyPair, keyId, {
+			videoId: "abc123",
+			song: "Song",
+			artist: "Artist",
+			duration: 200,
+			lyrics: DEGENERATE_TTML,
+			format: "ttml",
+			syncType: "richsync",
+		})
+
+		const res = await app.handle(req)
+		expect(res.status).toBe(400)
+
+		const body = (await res.json()) as { code: string; hint: string; error: string }
+		expect(body.code).toBe("TTML_ZERO_DURATION_WORDS")
+		expect(body.hint.toLowerCase()).toContain("word")
+		expect(body.hint.toLowerCase()).toContain("time")
+
+		expect(db.calls.find((c) => /INSERT INTO lyrics/i.test(c.sql))).toBeUndefined()
 	})
 
 	it("uses detected plain when client omits syncType for plain LRC content", async () => {

--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -25,6 +25,7 @@ import {
 	detectFormat,
 	detectPrettyPrintedTtml,
 	detectSyncType,
+	hasDegenerateWordTiming,
 	validateTtmlStructure,
 } from "@/utils/validation"
 import { Elysia, t } from "elysia"
@@ -368,6 +369,14 @@ export const lyricsRoutes = (env: Env) =>
 							hint: prettyPrintHint(prettyCheck.reason),
 						})
 					)
+				}
+
+				if (hasDegenerateWordTiming(lyricsContent, format)) {
+					log.warn("rejecting zero-duration word timing", {
+						keyId,
+						videoId: p.videoId as string,
+					})
+					return status(400, buildError(ErrorCode.TTML_ZERO_DURATION_WORDS))
 				}
 			}
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,6 +10,7 @@ export const ErrorCode = {
 	INVALID_DURATION: "INVALID_DURATION",
 	TTML_MALFORMED: "TTML_MALFORMED",
 	TTML_FORMATTED: "TTML_FORMATTED",
+	TTML_ZERO_DURATION_WORDS: "TTML_ZERO_DURATION_WORDS",
 	RATE_LIMITED: "RATE_LIMITED",
 	VARIANT_CAP_REACHED: "VARIANT_CAP_REACHED",
 	AUTH_REQUIRED: "AUTH_REQUIRED",
@@ -63,6 +64,10 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	TTML_FORMATTED: {
 		error: "Formatted TTML",
 		hint: "The TTML file has extra formatting that breaks the word-by-word timing. Try re-exporting it without any auto-formatting or pretty-printing.",
+	},
+	TTML_ZERO_DURATION_WORDS: {
+		error: "Zero-duration word timing",
+		hint: "Most words in this file start and end at the same timestamp, so there's no word-by-word timing to play back. This gets submitted as rich-sync but behaves like line-sync. Give each word a real start and end time, or submit it as line-synced lyrics instead.",
 	},
 	RATE_LIMITED: {
 		error: "Rate limited. Try again later.",

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { detectFormat, detectPrettyPrintedTtml, detectSyncType, validateTtmlStructure } from "./validation"
+import {
+	detectFormat,
+	detectPrettyPrintedTtml,
+	detectSyncType,
+	hasDegenerateWordTiming,
+	validateTtmlStructure,
+} from "./validation"
 
 describe("validateTtmlStructure", () => {
 	it("validates basic TTML structure", () => {
@@ -97,6 +103,98 @@ describe("detectSyncType TTML", () => {
 	it("returns plain on malformed/unparseable TTML rather than throwing", () => {
 		const ttml = "<tt><body><div><p>unclosed"
 		expect(detectSyncType(ttml, "ttml")).toBe("plain")
+	})
+})
+
+describe("detectSyncType TTML zero-duration word abuse", () => {
+	// Real shape from submitter d51999d6…: line-level timing on <p>, but the
+	// individual word spans collapse to begin===end. Only a minority of words
+	// carry real duration, so this is degraded word-sync, not karaoke richsync.
+	it("downgrades to linesync when the majority of word spans are zero-duration", () => {
+		const ttml = `<tt><body><div><p begin="0:16.645" end="0:18.621" ttm:agent="v1" composer:groupId="g1"><span begin="0:16.645" end="0:16.645">How</span> <span begin="0:17.129" end="0:17.129">did</span> <span begin="0:17.129" end="0:17.371">I</span> <span begin="0:17.371" end="0:17.371">find</span> <span begin="0:17.653" end="0:17.653">a</span> <span begin="0:17.653" end="0:17.653">girl</span> <span begin="0:18.137" end="0:18.137">like</span> <span begin="0:18.137" end="0:18.621">you?</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("linesync")
+	})
+
+	it("keeps richsync when every word span has positive duration", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">Hello</span> <span begin="0:00.5" end="0:01.0">there</span> <span begin="0:01.0" end="0:02.0">world</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("richsync")
+	})
+
+	it("keeps richsync when zero-duration words stay within tolerance (1 of 7 ~ 14%)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:07.0"><span begin="0:00.0" end="0:00.5">a</span> <span begin="0:01.0" end="0:01.5">b</span> <span begin="0:02.0" end="0:02.5">c</span> <span begin="0:03.0" end="0:03.0">d</span> <span begin="0:04.0" end="0:04.5">e</span> <span begin="0:05.0" end="0:05.5">f</span> <span begin="0:06.0" end="0:06.5">g</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("richsync")
+	})
+
+	it("downgrades to linesync when zero-duration words exceed tolerance (2 of 4 = 50%)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">a</span> <span begin="0:00.5" end="0:00.5">b</span> <span begin="0:01.0" end="0:01.5">c</span> <span begin="0:01.5" end="0:01.5">d</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("linesync")
+	})
+
+	it("keeps richsync when a zero-duration span is only punctuation, not a word", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">Hello</span><span begin="0:00.5" end="0:00.5">,</span> <span begin="0:00.5" end="0:01.0">world</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("richsync")
+	})
+
+	it("downgrades to linesync when word spans are all zero-duration even without line timing", () => {
+		const ttml = `<tt><body><div><p><span begin="0:00.0" end="0:00.0">a</span> <span begin="0:00.5" end="0:00.5">b</span> <span begin="0:01.0" end="0:01.0">c</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("linesync")
+	})
+
+	it("gives unparseable time formats the benefit of the doubt (stays richsync)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="10:00:00:05" end="10:00:00:05">a</span> <span begin="10:00:00:10" end="10:00:00:10">b</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("richsync")
+	})
+
+	it("ignores zero-duration whitespace spacer spans when scoring word timing", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">Hello</span><span begin="0:00.5" end="0:00.5"> </span><span begin="0:00.5" end="0:01.0">world</span></p></div></body></tt>`
+		expect(detectSyncType(ttml, "ttml")).toBe("richsync")
+	})
+})
+
+describe("hasDegenerateWordTiming", () => {
+	it("flags zero-dur-dominated word timing (the abuse signature)", () => {
+		const ttml = `<tt><body><div><p begin="0:16.645" end="0:18.621"><span begin="0:16.645" end="0:16.645">How</span> <span begin="0:17.129" end="0:17.129">did</span> <span begin="0:17.129" end="0:17.371">I</span> <span begin="0:17.371" end="0:17.371">find</span> <span begin="0:17.653" end="0:17.653">a</span> <span begin="0:17.653" end="0:17.653">girl</span> <span begin="0:18.137" end="0:18.137">like</span> <span begin="0:18.137" end="0:18.621">you?</span></p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(true)
+	})
+
+	it("does not flag genuine richsync with real word durations", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">Hello</span> <span begin="0:00.5" end="0:01.0">there</span> <span begin="0:01.0" end="0:02.0">world</span></p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(false)
+	})
+
+	it("does not flag zero-duration words within tolerance (1 of 7 ~ 14%)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:07.0"><span begin="0:00.0" end="0:00.5">a</span> <span begin="0:01.0" end="0:01.5">b</span> <span begin="0:02.0" end="0:02.5">c</span> <span begin="0:03.0" end="0:03.0">d</span> <span begin="0:04.0" end="0:04.5">e</span> <span begin="0:05.0" end="0:05.5">f</span> <span begin="0:06.0" end="0:06.5">g</span></p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(false)
+	})
+
+	it("flags when zero-duration words exceed tolerance (2 of 3 ~ 67%)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">Hello</span> <span begin="0:00.5" end="0:00.5">there</span> <span begin="0:01.0" end="0:01.0">world</span></p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(true)
+	})
+
+	it("does not flag a zero-duration punctuation/space span (true zero-dur non-words are fine)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="0:00.0" end="0:00.5">Hello</span><span begin="0:00.5" end="0:00.5"> </span><span begin="0:00.5" end="0:00.5">,</span> <span begin="0:00.5" end="0:01.0">world</span></p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(false)
+	})
+
+	it("does not flag genuine linesync (no word spans at all)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:05.0">Hello world</p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(false)
+	})
+
+	it("does not flag plain content", () => {
+		const ttml = "<tt><body><div><p>Hello world</p></div></body></tt>"
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(false)
+	})
+
+	it("never flags LRC (zero-dur applies only to TTML word spans)", () => {
+		const lrc = "[00:15.00]Hello <00:15.50>world"
+		expect(hasDegenerateWordTiming(lrc, "lrc")).toBe(false)
+	})
+
+	it("does not flag unparseable time formats (benefit of the doubt)", () => {
+		const ttml = `<tt><body><div><p begin="0:00.0" end="0:02.0"><span begin="10:00:00:05" end="10:00:00:05">a</span> <span begin="10:00:00:10" end="10:00:00:10">b</span></p></div></body></tt>`
+		expect(hasDegenerateWordTiming(ttml, "ttml")).toBe(false)
 	})
 })
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -122,32 +122,106 @@ const ttmlParser = new XMLParser({
 
 type ParsedNode = Record<string, unknown>
 
-function detectTtmlSyncType(ttml: string): "richsync" | "linesync" | "plain" {
+// A real word whose span starts and ends at the same timestamp is a
+// zero-duration word: it looks like richsync but plays back with no karaoke
+// sweep. Content only counts as richsync when at most this fraction of its
+// real words are zero-duration. Calibrated against the full corpus: legit
+// karaoke is 0% for ~80% of files and tails off through the low teens from
+// aligner rounding, while degraded/abusive files sit at 40%+. 0.2 clears the
+// legit tail and still catches the abuse. Whitespace and punctuation spacers
+// are never counted as words, so their genuinely zero durations never trip it.
+const RICHSYNC_MAX_ZERO_DURATION_RATIO = 0.2
+
+// A span only counts as a timed "word" when it carries an actual letter or
+// number. Spaces, punctuation, and other spacer glyphs can legitimately have
+// zero duration and must not be scored against the word timing.
+const WORD_CHAR_REGEX = /[\p{L}\p{N}]/u
+
+// Parses a TTML time expression to seconds. Handles clock-time
+// ([HH:]MM:SS[.fraction]) and offset-time (Nh/Nm/Ns/Nms). Returns null for
+// forms we can't compare (frames, ticks, SMPTE), so callers give those the
+// benefit of the doubt instead of misreading them as zero-duration.
+export function parseTtmlTime(value: string): number | null {
+	const v = value.trim()
+	const clock = v.match(/^(?:(\d+):)?(\d{1,2}):(\d{1,2})(?:\.(\d+))?$/)
+	if (clock) {
+		const hours = clock[1] ? Number(clock[1]) : 0
+		const minutes = Number(clock[2])
+		const seconds = Number(clock[3])
+		const fraction = clock[4] ? Number(`0.${clock[4]}`) : 0
+		return hours * 3600 + minutes * 60 + seconds + fraction
+	}
+	const offset = v.match(/^(\d+(?:\.\d+)?)(h|m|s|ms)$/)
+	if (offset) {
+		const n = Number(offset[1])
+		switch (offset[2]) {
+			case "h":
+				return n * 3600
+			case "m":
+				return n * 60
+			case "s":
+				return n
+			case "ms":
+				return n / 1000
+		}
+	}
+	return null
+}
+
+interface TtmlTiming {
+	hasLineTiming: boolean
+	sawWordSpan: boolean
+	comparableWords: number
+	positiveWords: number
+}
+
+function analyzeTtmlTiming(ttml: string): TtmlTiming | null {
 	let parsed: unknown[]
 	try {
 		parsed = ttmlParser.parse(declareMissingNamespaces(ttml)) as unknown[]
 	} catch {
-		return "plain"
+		return null
 	}
 
 	let hasLineTiming = false
-	let hasWordTiming = false
+	let sawWordSpan = false
+	let comparableWords = 0
+	let positiveWords = 0
 
-	function spanHasWordTiming(spanChildren: unknown[], attrs: ParsedNode | undefined): boolean {
-		if (attrs && typeof attrs["@_begin"] === "string" && typeof attrs["@_end"] === "string") {
-			return true
+	function directText(children: unknown[]): string {
+		let text = ""
+		for (const node of children) {
+			if (node && typeof node === "object" && "#text" in node) {
+				const value = (node as ParsedNode)["#text"]
+				if (typeof value === "string") text += value
+			}
+		}
+		return text.trim()
+	}
+
+	function visitSpan(spanChildren: unknown[], attrs: ParsedNode | undefined): void {
+		const begin = attrs?.["@_begin"]
+		const end = attrs?.["@_end"]
+		if (
+			typeof begin === "string" &&
+			typeof end === "string" &&
+			WORD_CHAR_REGEX.test(directText(spanChildren))
+		) {
+			sawWordSpan = true
+			const b = parseTtmlTime(begin)
+			const e = parseTtmlTime(end)
+			if (b !== null && e !== null) {
+				comparableWords++
+				if (e > b) positiveWords++
+			}
 		}
 		for (const node of spanChildren) {
 			if (typeof node !== "object" || node === null) continue
 			const el = node as ParsedNode
-			const childSpan = el.span
-			if (Array.isArray(childSpan)) {
-				if (spanHasWordTiming(childSpan, el[":@"] as ParsedNode | undefined)) {
-					return true
-				}
+			if (Array.isArray(el.span)) {
+				visitSpan(el.span, el[":@"] as ParsedNode | undefined)
 			}
 		}
-		return false
 	}
 
 	function visitParagraph(pChildren: unknown[], pAttrs: ParsedNode | undefined): void {
@@ -157,11 +231,8 @@ function detectTtmlSyncType(ttml: string): "richsync" | "linesync" | "plain" {
 		for (const node of pChildren) {
 			if (typeof node !== "object" || node === null) continue
 			const el = node as ParsedNode
-			const childSpan = el.span
-			if (Array.isArray(childSpan)) {
-				if (spanHasWordTiming(childSpan, el[":@"] as ParsedNode | undefined)) {
-					hasWordTiming = true
-				}
+			if (Array.isArray(el.span)) {
+				visitSpan(el.span, el[":@"] as ParsedNode | undefined)
 			}
 		}
 	}
@@ -183,7 +254,35 @@ function detectTtmlSyncType(ttml: string): "richsync" | "linesync" | "plain" {
 
 	walk(parsed)
 
-	if (hasWordTiming) return "richsync"
-	if (hasLineTiming) return "linesync"
+	return { hasLineTiming, sawWordSpan, comparableWords, positiveWords }
+}
+
+function detectTtmlSyncType(ttml: string): "richsync" | "linesync" | "plain" {
+	const timing = analyzeTtmlTiming(ttml)
+	if (!timing) return "plain"
+
+	const { hasLineTiming, sawWordSpan } = timing
+	if (sawWordSpan && !hasDegenerateTiming(timing)) return "richsync"
+	if (hasLineTiming || sawWordSpan) return "linesync"
 	return "plain"
+}
+
+// Shared verdict: real words exist that are zero-duration beyond the allowed
+// ratio. comparableWords === 0 means the times were unparseable, so we give
+// the file the benefit of the doubt.
+function hasDegenerateTiming(timing: TtmlTiming): boolean {
+	if (timing.comparableWords === 0) return false
+	const zeroDurationWords = timing.comparableWords - timing.positiveWords
+	return zeroDurationWords / timing.comparableWords > RICHSYNC_MAX_ZERO_DURATION_RATIO
+}
+
+// True when TTML carries real words that collapse to zero duration beyond the
+// allowed ratio: it looks like richsync but delivers no karaoke sweep. Genuine
+// linesync (no word spans), genuine richsync (real durations), zero-duration
+// spacers/punctuation, and unparseable time formats all return false.
+export function hasDegenerateWordTiming(content: string, format: LyricsFormat): boolean {
+	if (format !== "ttml") return false
+	const timing = analyzeTtmlTiming(content)
+	if (!timing) return false
+	return timing.sawWordSpan && hasDegenerateTiming(timing)
 }


### PR DESCRIPTION
## Overview

Some TTML was coming in tagged rich-sync but with most word timings collapsed to zero duration (begin equals end), so it took the rich-sync ranking boost while playing back like line-sync. A file now stays rich-sync only when most of its real words have a real duration; once zero-duration words dominate, it drops to line-sync and gets rejected at submit with a clear reason. Whitespace and punctuation don't count, since those can genuinely be zero-length.
