### PR TITLE
fix(exploration): sample in O(1) so vote counts can't freeze the event loop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,13 @@ import { closeRedis } from "@/infra/cache"
 import { closePool } from "@/infra/database"
 import { createEnv } from "@/infra/env"
 import { Logger, flushLogs } from "@/infra/logger"
+import { startWatchdog } from "@/infra/watchdog"
 import { backfillConfidence } from "@/jobs/backfill-confidence"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
 import { backfillLanguage } from "@/jobs/backfill-language"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
 import { backfillTextSearch } from "@/jobs/backfill-text-search"
+import { backfillVoteCounts } from "@/jobs/backfill-vote-counts"
 import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
 import { runDumpJob } from "@/jobs/dump"
 import { updateScores } from "@/jobs/score-updater"
@@ -227,6 +229,8 @@ const app = new Elysia({ adapter: node() })
 
 const port = process.env.PORT || "3000"
 log.info(`listening on port ${port}`)
+
+startWatchdog()
 log.info("spa serving", {
 	cwd: process.cwd(),
 	spaDist: SPA_DIST,
@@ -269,6 +273,12 @@ cleanupFulfilledRequests(env)
 		if (deleted > 0) log.info("cleanup fulfilled requests complete", { deleted })
 	})
 	.catch((err) => log.error("cleanup fulfilled requests failed", { error: (err as Error).message }))
+
+backfillVoteCounts(env)
+	.then(({ repaired }) => {
+		if (repaired > 0) log.info("vote count backfill complete", { repaired })
+	})
+	.catch((err) => log.error("vote count backfill failed", { error: (err as Error).message }))
 
 process.on("unhandledRejection", (reason) => {
 	const err = reason instanceof Error ? reason : new Error(String(reason))

--- a/src/infra/watchdog.test.ts
+++ b/src/infra/watchdog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { shouldKill } from "./watchdog"
+import { respawnDecision, shouldKill } from "./watchdog"
 
 describe("shouldKill", () => {
 	it("does not kill while heartbeats are within the freeze window", () => {
@@ -28,5 +28,24 @@ describe("shouldKill", () => {
 		it("kills for an arbitrarily long freeze", () => {
 			expect(shouldKill(5 * 60 * 60 * 1000, 30_000)).toBe(true)
 		})
+	})
+})
+
+describe("respawnDecision", () => {
+	it("respawns and resets the streak when the worker ran past the grace window", () => {
+		expect(respawnDecision(60_000, 2)).toEqual({ respawn: true, fastFailures: 0 })
+	})
+
+	it("counts a fast exit as a failure and still respawns under the cap", () => {
+		expect(respawnDecision(500, 0)).toEqual({ respawn: true, fastFailures: 1 })
+		expect(respawnDecision(500, 1)).toEqual({ respawn: true, fastFailures: 2 })
+	})
+
+	it("gives up after too many fast failures in a row", () => {
+		expect(respawnDecision(500, 2)).toEqual({ respawn: false, fastFailures: 3 })
+	})
+
+	it("a healthy long run clears an earlier streak", () => {
+		expect(respawnDecision(30_000, 2)).toEqual({ respawn: true, fastFailures: 0 })
 	})
 })

--- a/src/infra/watchdog.test.ts
+++ b/src/infra/watchdog.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { shouldKill } from "./watchdog"
+
+describe("shouldKill", () => {
+	it("does not kill while heartbeats are within the freeze window", () => {
+		expect(shouldKill(5_000, 30_000)).toBe(false)
+	})
+
+	it("kills once the gap exceeds the freeze window", () => {
+		expect(shouldKill(30_001, 30_000)).toBe(true)
+	})
+
+	it("does not kill exactly at the threshold", () => {
+		expect(shouldKill(30_000, 30_000)).toBe(false)
+	})
+
+	describe("edge cases", () => {
+		it("is disabled for a zero or negative threshold", () => {
+			expect(shouldKill(1_000_000, 0)).toBe(false)
+			expect(shouldKill(1_000_000, -1)).toBe(false)
+		})
+
+		it("treats a non-finite gap as alive (startup grace, no false positive)", () => {
+			expect(shouldKill(Number.NaN, 30_000)).toBe(false)
+			expect(shouldKill(Number.POSITIVE_INFINITY, 30_000)).toBe(false)
+		})
+
+		it("kills for an arbitrarily long freeze", () => {
+			expect(shouldKill(5 * 60 * 60 * 1000, 30_000)).toBe(true)
+		})
+	})
+})

--- a/src/infra/watchdog.ts
+++ b/src/infra/watchdog.ts
@@ -4,6 +4,8 @@ import { Logger } from "./logger"
 const log = new Logger("watchdog")
 
 const DEFAULT_FREEZE_MS = 30_000
+const RESPAWN_GRACE_MS = 10_000
+const MAX_FAST_RESPAWNS = 3
 
 // A frozen event loop cannot run its own timers, so liveness has to be judged
 // from another thread. This is the decision the watchdog worker makes each tick.
@@ -13,6 +15,18 @@ export function shouldKill(msSinceHeartbeat: number, freezeMs: number): boolean 
 	if (!(freezeMs > 0)) return false
 	if (!Number.isFinite(msSinceHeartbeat)) return false
 	return msSinceHeartbeat > freezeMs
+}
+
+// Decide whether to respawn a worker that just exited. A worker that dies inside
+// the grace window counts as a fast failure; after too many in a row we stop so a
+// broken worker can't respawn forever. A worker that ran past the window resets
+// the streak.
+export function respawnDecision(
+	msAlive: number,
+	fastFailures: number
+): { respawn: boolean; fastFailures: number } {
+	const next = msAlive < RESPAWN_GRACE_MS ? fastFailures + 1 : 0
+	return { respawn: next < MAX_FAST_RESPAWNS, fastFailures: next }
 }
 
 // The worker runs on its own thread, unaffected by a blocked main loop. When the
@@ -41,12 +55,38 @@ export function startWatchdog(): void {
 		return
 	}
 
-	const worker = new Worker(WORKER_SOURCE, { eval: true, workerData: { freezeMs } })
-	worker.unref()
-	worker.on("error", (err) => log.error("watchdog worker error", { error: err.message }))
+	const beatMs = Math.max(1000, Math.floor(freezeMs / 10))
+	let fastFailures = 0
 
-	const beat = setInterval(() => worker.postMessage(0), Math.max(1000, Math.floor(freezeMs / 10)))
-	beat.unref()
+	const spawn = (): void => {
+		const spawnedAt = Date.now()
+		let worker: Worker
+		try {
+			worker = new Worker(WORKER_SOURCE, { eval: true, workerData: { freezeMs } })
+		} catch (err) {
+			// Never let a watchdog failure crash boot: run unprotected instead.
+			log.error("watchdog failed to start", { error: (err as Error).message })
+			return
+		}
+		worker.unref()
 
+		const beat = setInterval(() => worker.postMessage(0), beatMs)
+		beat.unref()
+
+		worker.on("error", (err) => log.error("watchdog worker error", { error: err.message }))
+		worker.on("exit", (code) => {
+			clearInterval(beat)
+			const decision = respawnDecision(Date.now() - spawnedAt, fastFailures)
+			fastFailures = decision.fastFailures
+			if (!decision.respawn) {
+				log.error("watchdog worker keeps dying, protection disabled", { code })
+				return
+			}
+			log.warn("watchdog worker exited, respawning", { code })
+			spawn()
+		})
+	}
+
+	spawn()
 	log.info("watchdog started", { freezeMs })
 }

--- a/src/infra/watchdog.ts
+++ b/src/infra/watchdog.ts
@@ -1,0 +1,52 @@
+import { Worker } from "node:worker_threads"
+import { Logger } from "./logger"
+
+const log = new Logger("watchdog")
+
+const DEFAULT_FREEZE_MS = 30_000
+
+// A frozen event loop cannot run its own timers, so liveness has to be judged
+// from another thread. This is the decision the watchdog worker makes each tick.
+// A non-positive threshold disables it; a non-finite gap (never heartbeated yet)
+// is treated as alive so startup grace isn't a false positive.
+export function shouldKill(msSinceHeartbeat: number, freezeMs: number): boolean {
+	if (!(freezeMs > 0)) return false
+	if (!Number.isFinite(msSinceHeartbeat)) return false
+	return msSinceHeartbeat > freezeMs
+}
+
+// The worker runs on its own thread, unaffected by a blocked main loop. When the
+// main thread stops heartbeating past the threshold it SIGKILLs the whole
+// process (SIGKILL hits the shared PID, taking down every thread) so Railway's
+// restart policy brings it back. shouldKill is inlined via toString so the exact
+// tested logic runs here.
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require("node:worker_threads")
+${shouldKill.toString()}
+const freezeMs = workerData.freezeMs
+let last = Date.now()
+parentPort.on("message", () => { last = Date.now() })
+setInterval(() => {
+	if (shouldKill(Date.now() - last, freezeMs)) {
+		process.stderr.write("[watchdog] event loop frozen for >" + freezeMs + "ms, killing process for restart\\n")
+		process.kill(process.pid, "SIGKILL")
+	}
+}, Math.max(1000, Math.floor(freezeMs / 5))).unref()
+`
+
+export function startWatchdog(): void {
+	const freezeMs = Number(process.env.WATCHDOG_FREEZE_MS ?? DEFAULT_FREEZE_MS)
+	if (!(freezeMs > 0)) {
+		log.info("watchdog disabled", { freezeMs })
+		return
+	}
+
+	const worker = new Worker(WORKER_SOURCE, { eval: true, workerData: { freezeMs } })
+	worker.unref()
+	worker.on("error", (err) => log.error("watchdog worker error", { error: err.message }))
+
+	const beat = setInterval(() => worker.postMessage(0), Math.max(1000, Math.floor(freezeMs / 10)))
+	beat.unref()
+
+	log.info("watchdog started", { freezeMs })
+}

--- a/src/jobs/backfill-vote-counts.test.ts
+++ b/src/jobs/backfill-vote-counts.test.ts
@@ -1,0 +1,69 @@
+import type { Env } from "@/types"
+import { describe, expect, it } from "vitest"
+import { backfillVoteCounts } from "./backfill-vote-counts"
+
+function createMockDB(queue: unknown[]) {
+	const calls: { sql: string; params: unknown[] }[] = []
+	const db = {
+		prepare(sql: string) {
+			let params: unknown[] = []
+			return {
+				bind(...args: unknown[]) {
+					params = args
+					return this
+				},
+				async first<T>(): Promise<T | null> {
+					calls.push({ sql, params })
+					return (queue.shift() as T) ?? null
+				},
+				async run(): Promise<void> {
+					calls.push({ sql, params })
+				},
+			}
+		},
+	}
+	return { db: db as unknown as Env["DB"], calls }
+}
+
+describe("backfillVoteCounts", () => {
+	it("does nothing and issues no UPDATE when no rows have drifted", async () => {
+		const { db, calls } = createMockDB([{ n: 0 }])
+
+		const result = await backfillVoteCounts({ DB: db } as unknown as Env)
+
+		expect(result.repaired).toBe(0)
+		expect(calls.some((c) => c.sql.includes("UPDATE lyrics"))).toBe(false)
+	})
+
+	it("recomputes upvotes and downvotes from the votes table when rows have drifted", async () => {
+		const { db, calls } = createMockDB([{ n: 7 }])
+
+		const result = await backfillVoteCounts({ DB: db } as unknown as Env)
+
+		expect(result.repaired).toBe(7)
+		const update = calls.find((c) => c.sql.includes("UPDATE lyrics"))
+		expect(update).toBeDefined()
+		expect(update?.sql).toMatch(/upvotes\s*=\s*\(SELECT COUNT/i)
+		expect(update?.sql).toMatch(/v\.vote\s*=\s*1/)
+		expect(update?.sql).toMatch(/v\.vote\s*=\s*-1/)
+	})
+
+	describe("edge cases", () => {
+		it("coerces a bigint-style count string to a number", async () => {
+			const { db } = createMockDB([{ n: "42" }])
+
+			const result = await backfillVoteCounts({ DB: db } as unknown as Env)
+
+			expect(result.repaired).toBe(42)
+		})
+
+		it("treats a missing count row as zero drift", async () => {
+			const { db, calls } = createMockDB([null])
+
+			const result = await backfillVoteCounts({ DB: db } as unknown as Env)
+
+			expect(result.repaired).toBe(0)
+			expect(calls.some((c) => c.sql.includes("UPDATE lyrics"))).toBe(false)
+		})
+	})
+})

--- a/src/jobs/backfill-vote-counts.ts
+++ b/src/jobs/backfill-vote-counts.ts
@@ -1,0 +1,32 @@
+import { Logger } from "@/infra/logger"
+import type { Env } from "@/types"
+
+const log = new Logger("backfill")
+
+// upvotes/downvotes were only ever maintained incrementally, while vote_count
+// gets resynced from the votes table by recalculateScore. The two could drift,
+// and a drifted row can be a cold challenger by vote_count while carrying a huge
+// upvotes/downvotes. Recompute both from the authoritative votes rows.
+// Idempotent: after the first run the WHERE guard matches nothing.
+export async function backfillVoteCounts(env: Env): Promise<{ repaired: number }> {
+	const drifted = await env.DB.prepare(
+		`SELECT COUNT(*) AS n FROM lyrics
+		 WHERE upvotes <> (SELECT COUNT(*) FROM votes v WHERE v.lyrics_id = lyrics.id AND v.vote = 1)
+		    OR downvotes <> (SELECT COUNT(*) FROM votes v WHERE v.lyrics_id = lyrics.id AND v.vote = -1)`
+	).first<{ n: number }>()
+
+	const repaired = Number(drifted?.n ?? 0)
+	if (repaired === 0) return { repaired: 0 }
+
+	await env.DB.prepare(
+		`UPDATE lyrics SET
+			upvotes = (SELECT COUNT(*) FROM votes v WHERE v.lyrics_id = lyrics.id AND v.vote = 1),
+			downvotes = (SELECT COUNT(*) FROM votes v WHERE v.lyrics_id = lyrics.id AND v.vote = -1),
+			updated_at = EXTRACT(EPOCH FROM NOW())::INTEGER
+		 WHERE upvotes <> (SELECT COUNT(*) FROM votes v WHERE v.lyrics_id = lyrics.id AND v.vote = 1)
+		    OR downvotes <> (SELECT COUNT(*) FROM votes v WHERE v.lyrics_id = lyrics.id AND v.vote = -1)`
+	).run()
+
+	log.info("vote count repair complete", { repaired })
+	return { repaired }
+}

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -578,3 +578,39 @@ describe("reputation bounds", () => {
 		expect(config.reputation.consensusDelta).toBe(0.1)
 	})
 })
+
+describe("recalculateScore vote-count resync", () => {
+	it("recomputes upvotes and downvotes from the votes rows so they cannot drift", async () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: 0.2, is_self_vote: 0 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.3, is_self_vote: 0 },
+			{ vote: -1, reputation: 1.0, avg_vote: -0.1, is_self_vote: 0 },
+		]
+		const { db, calls } = createMockDB([{ video_id: "v1", deleted_at: null }, votes])
+		const env = { DB: db } as unknown as Env
+
+		await recalculateScore(env, 1)
+
+		const update = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && /upvotes\s*=\s*\?/.test(c.sql)
+		)
+		expect(update).toBeDefined()
+		expect(update?.sql).toMatch(/downvotes\s*=\s*\?/)
+		// bind order: effective_score, vote_count, upvotes, downvotes, ...
+		expect(update?.params[2]).toBe(2)
+		expect(update?.params[3]).toBe(1)
+	})
+
+	it("zeroes upvotes and downvotes when a row has no votes", async () => {
+		const { db, calls } = createMockDB([{ video_id: "v1", deleted_at: null }, []])
+		const env = { DB: db } as unknown as Env
+
+		await recalculateScore(env, 1)
+
+		const update = calls.find(
+			(c) => c.sql.includes("UPDATE lyrics") && /upvotes\s*=\s*\?/.test(c.sql)
+		)
+		expect(update?.params[2]).toBe(0)
+		expect(update?.params[3]).toBe(0)
+	})
+})

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -37,12 +37,17 @@ export async function recalculateScore(env: Env, lyricsId: number): Promise<void
 		.bind(lyricsId)
 		.all<VoteWithUser>()
 
-	const update = calculateScore(lyricsId, votes.results || [])
+	const voteRows = votes.results || []
+	const update = calculateScore(lyricsId, voteRows)
+	const upvotes = voteRows.filter((v) => v.vote === 1).length
+	const downvotes = voteRows.filter((v) => v.vote === -1).length
 
 	await env.DB.prepare(`
 		UPDATE lyrics SET
 			effective_score = ?,
 			vote_count = ?,
+			upvotes = ?,
+			downvotes = ?,
 			diversity_bonus = ?,
 			confidence = ?,
 			score_updated_at = EXTRACT(EPOCH FROM NOW())::INTEGER
@@ -51,6 +56,8 @@ export async function recalculateScore(env: Env, lyricsId: number): Promise<void
 		.bind(
 			update.effective_score,
 			update.vote_count,
+			upvotes,
+			downvotes,
 			update.diversity_bonus,
 			update.confidence,
 			update.id

--- a/src/utils/exploration.test.ts
+++ b/src/utils/exploration.test.ts
@@ -205,3 +205,53 @@ describe("regressions", () => {
 		}
 	})
 })
+
+describe("regressions: divergent vote counts must not freeze the event loop", () => {
+	// score-updater resyncs vote_count from the votes table but leaves
+	// upvotes/downvotes untouched, so a challenger can be cold by vote_count
+	// while carrying a large (or corrupt) upvotes/downvotes. The pre-fix sampler
+	// summed `shape` exponentials, so such an arm spun the single event loop for
+	// minutes-to-forever. These lock the O(1) sampler: if the loop ever returns,
+	// they hang the suite.
+	it("returns instantly for an arm with billions of upvotes", () => {
+		const arms = [
+			{ id: "cold", upvotes: 1, downvotes: 0 },
+			{ id: "divergent", upvotes: 2_000_000_000, downvotes: 4 },
+		]
+		expect(arms).toContain(selectArm(arms, 42))
+	})
+
+	it("returns instantly for an arm with billions of downvotes", () => {
+		const arms = [{ id: "only", upvotes: 3, downvotes: 5_000_000_000 }]
+		expect(selectArm(arms, 1)).toBe(arms[0])
+	})
+
+	it("does not hang on a non-finite (Infinity) vote count", () => {
+		const arms = [
+			{ id: "sane", upvotes: 2, downvotes: 1 },
+			{ id: "corrupt", upvotes: Number.POSITIVE_INFINITY, downvotes: 0 },
+		]
+		expect(arms).toContain(selectArm(arms, 7))
+	})
+
+	it("handles NaN and negative vote counts without hanging", () => {
+		const arms = [
+			{ id: "nan", upvotes: Number.NaN, downvotes: 0 },
+			{ id: "neg", upvotes: -5, downvotes: -2 },
+			{ id: "ok", upvotes: 4, downvotes: 0 },
+		]
+		expect(arms).toContain(selectArm(arms, 9))
+	})
+
+	it("still favors a heavily-upvoted arm at large scale", () => {
+		const arms = [
+			{ id: "huge", upvotes: 10_000_000, downvotes: 0 },
+			{ id: "weak", upvotes: 0, downvotes: 5 },
+		]
+		let hugeCount = 0
+		for (let seed = 0; seed < 200; seed++) {
+			if (selectArm(arms, seed).id === "huge") hugeCount++
+		}
+		expect(hugeCount).toBeGreaterThan(195)
+	})
+})

--- a/src/utils/exploration.ts
+++ b/src/utils/exploration.ts
@@ -45,14 +45,38 @@ function mulberry32(seed: number) {
 	}
 }
 
-function gammaInt(shape: number, rand: () => number): number {
-	let sum = 0
-	for (let i = 0; i < shape; i++) {
-		// map [0, 1) to (0, 1] so the log argument is never zero
-		const u = 1 - rand()
-		sum -= Math.log(u)
+// Standard normal via Box-Muller. u1 is mapped to (0, 1] so log never sees zero.
+function sampleNormal(rand: () => number): number {
+	const u1 = 1 - rand()
+	const u2 = rand()
+	return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+}
+
+// Draw from Gamma(shape, 1) in constant time (Marsaglia-Tsang). The previous
+// implementation summed `shape` exponentials, so an arm whose vote count grew
+// large (upvotes/downvotes drift from the separately resynced vote_count) spun
+// the event loop for minutes to forever. Non-finite or non-positive shapes come
+// only from corrupt counts; they are clamped so they can never spin.
+function sampleGamma(shape: number, rand: () => number): number {
+	if (!(shape > 0)) return 0
+	const k = Number.isFinite(shape) ? shape : Number.MAX_SAFE_INTEGER
+	if (k < 1) {
+		return sampleGamma(k + 1, rand) * (1 - rand()) ** (1 / k)
 	}
-	return sum
+	const d = k - 1 / 3
+	const c = 1 / Math.sqrt(9 * d)
+	for (;;) {
+		let x: number
+		let v: number
+		do {
+			x = sampleNormal(rand)
+			v = 1 + c * x
+		} while (v <= 0)
+		v = v * v * v
+		const u = rand()
+		if (u < 1 - 0.0331 * x * x * x * x) return d * v
+		if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v
+	}
 }
 
 export function selectArm<T extends { upvotes: number; downvotes: number }>(
@@ -71,8 +95,8 @@ export function selectArm<T extends { upvotes: number; downvotes: number }>(
 	let bestTheta = -1
 
 	for (const arm of challengers) {
-		const ga = gammaInt(arm.upvotes + 1, rand)
-		const gb = gammaInt(arm.downvotes + 1, rand)
+		const ga = sampleGamma(arm.upvotes + 1, rand)
+		const gb = sampleGamma(arm.downvotes + 1, rand)
 		const total = ga + gb
 		const theta = total === 0 ? 0.5 : ga / total
 		if (theta > bestTheta) {


### PR DESCRIPTION
## Overview

The API kept freezing for hours with no crash and no logs. The exploration slot's Thompson sampling looped once per vote when drawing a challenger, so an arm whose vote tally had drifted large would peg the event loop until a manual restart. Swapped in a constant-time sampler so vote counts stop driving the work.

Also closed the drift itself (score recalcs resynced the total but not the up and down tallies) with a repair for rows already off, and added a watchdog thread that restarts the app if the loop ever locks up again, since Railway healthchecks only gate deploys and never catch a hung process.
