### PR TITLE
feat(web): add a docs tab with a multi-language lyrics fetch guide

### DIFF
--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -62,6 +62,9 @@ export function AppHeader() {
 					<NavLink to="/downloads" className={tabClass}>
 						Downloads
 					</NavLink>
+					<NavLink to="/docs" className={tabClass}>
+						Docs
+					</NavLink>
 				</nav>
 				<div className="hidden sm:flex sm:justify-self-end sm:w-full sm:max-w-xs">
 					<SearchBar />
@@ -106,6 +109,9 @@ export function AppHeader() {
 						</NavLink>
 						<NavLink to="/downloads" role="menuitem" onClick={closeMenu} className={tabClass}>
 							Downloads
+						</NavLink>
+						<NavLink to="/docs" role="menuitem" onClick={closeMenu} className={tabClass}>
+							Docs
 						</NavLink>
 					</nav>
 					<div className="flex items-center justify-end border-t border-unison-border pt-2">

--- a/web/src/components/CodeBlock.test.tsx
+++ b/web/src/components/CodeBlock.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { CodeBlock, type CodeTab, CodeTabs } from "./CodeBlock"
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("CodeBlock", () => {
+  it("renders the label and the code text", () => {
+    render(<CodeBlock code={'curl "https://unison.boidu.dev/lyrics?v=abc"'} language="bash" label="cURL" />)
+    expect(screen.getByText("cURL")).toBeTruthy()
+    expect(document.body.textContent).toContain("https://unison.boidu.dev/lyrics?v=abc")
+  })
+
+  it("highlights the bash command word with a color", () => {
+    render(<CodeBlock code={"# a note\ncurl https://x"} language="bash" label="cURL" />)
+    const cmd = screen.getByText("curl")
+    expect(cmd.tagName).toBe("SPAN")
+    expect(cmd.getAttribute("style") ?? "").toMatch(/color/)
+  })
+
+  it("copies the code to the clipboard", () => {
+    render(<CodeBlock code={"curl https://x"} language="bash" label="cURL" />)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("navigator", { clipboard: { writeText } })
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }))
+    expect(writeText).toHaveBeenCalledWith("curl https://x")
+  })
+})
+
+describe("CodeTabs", () => {
+  const tabs: CodeTab[] = [
+    { label: "cURL", language: "bash", code: 'curl "https://a"' },
+    { label: "JavaScript", language: "javascript", code: 'const x = await fetch("https://a")' },
+  ]
+
+  it("shows the first tab by default and switches on click", () => {
+    render(<CodeTabs tabs={tabs} />)
+    expect(document.body.textContent).toContain("curl")
+    expect(screen.getByRole("tab", { name: "cURL" }).getAttribute("aria-selected")).toBe("true")
+
+    fireEvent.click(screen.getByRole("tab", { name: "JavaScript" }))
+
+    expect(screen.getByRole("tab", { name: "JavaScript" }).getAttribute("aria-selected")).toBe("true")
+    expect(document.body.textContent).toContain("fetch")
+    expect(document.body.textContent).not.toContain("curl")
+  })
+
+  it("copies the active tab's code", () => {
+    render(<CodeTabs tabs={tabs} />)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("navigator", { clipboard: { writeText } })
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }))
+    expect(writeText).toHaveBeenCalledWith('curl "https://a"')
+  })
+})

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -1,0 +1,254 @@
+import { IconCheck, IconCopy } from "@tabler/icons-react"
+import { Highlight, type Language, themes } from "prism-react-renderer"
+import {
+  createContext,
+  Fragment,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
+import { cn } from "@/lib/cn"
+
+// bash is hand-tokenized; everything else is any language prism bundles (json, javascript, python, go, ...).
+export type CodeLang = Language | "bash"
+
+// Shared so picking a language in one CodeTabs switches every other one, and the choice survives reloads.
+interface CodeLangValue {
+  selected: string
+  setSelected: (label: string) => void
+}
+
+const CodeLangContext = createContext<CodeLangValue | null>(null)
+const STORAGE_KEY = "unison:docs:code-lang"
+
+export function CodeLangProvider({ children, fallback = "cURL" }: { children: ReactNode; fallback?: string }) {
+  const [selected, setSelectedState] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) ?? fallback
+    } catch {
+      return fallback
+    }
+  })
+  const setSelected = useCallback((label: string) => {
+    setSelectedState(label)
+    try {
+      localStorage.setItem(STORAGE_KEY, label)
+    } catch {
+      // storage may be unavailable (private mode); the in-memory choice still syncs across blocks
+    }
+  }, [])
+  return <CodeLangContext.Provider value={{ selected, setSelected }}>{children}</CodeLangContext.Provider>
+}
+
+const PLAIN = "#d6deeb"
+const preClass =
+  "unison-code-scroll overflow-x-auto px-4 py-3 pr-12 font-mono text-xs leading-relaxed [font-variant-ligatures:none]"
+
+// prism-react-renderer ships no bash grammar, so bash is tokenized by hand.
+// Colors track the nightOwl palette prism uses for json / javascript so every block reads as one theme.
+const BASH = {
+  command: "#82aaff",
+  string: "#addb67",
+  flag: "#c792ea",
+  comment: "#637777",
+} as const
+
+function highlightBashLine(line: string, lineIdx: number): ReactNode[] {
+  if (line.trimStart().startsWith("#")) {
+    return [
+      <span key={`${lineIdx}-c`} style={{ color: BASH.comment, fontStyle: "italic" }}>
+        {line}
+      </span>,
+    ]
+  }
+  if (line.length === 0) return [""]
+  const parts = line.split(/(\s+)/)
+  const out: ReactNode[] = []
+  let seenCommand = false
+  for (let i = 0; i < parts.length; i += 2) {
+    const word = parts[i] ?? ""
+    const ws = parts[i + 1] ?? ""
+    const key = `${lineIdx}-${i}`
+    if (word.length === 0) {
+      if (ws.length > 0) out.push(<span key={key}>{ws}</span>)
+      continue
+    }
+    let color: string | undefined
+    if (!seenCommand) {
+      color = BASH.command
+      seenCommand = true
+    } else if (/^--?\w/.test(word)) {
+      color = BASH.flag
+    } else if (word.startsWith('"') || word.startsWith("'")) {
+      color = BASH.string
+    }
+    out.push(
+      color ? (
+        <span key={key} style={{ color }}>
+          {word + ws}
+        </span>
+      ) : (
+        <span key={key}>{word + ws}</span>
+      ),
+    )
+  }
+  return out
+}
+
+function BashCode({ code }: { code: string }) {
+  const lines = code.split("\n")
+  return (
+    <>
+      {lines.map((line, lineIdx) => (
+        <Fragment key={`line-${lineIdx}-${line.slice(0, 8)}`}>
+          {lineIdx > 0 ? "\n" : null}
+          {highlightBashLine(line, lineIdx)}
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
+function PrismCode({ code, language }: { code: string; language: Language }) {
+  return (
+    <Highlight theme={themes.nightOwl} code={code} language={language}>
+      {({ tokens, getLineProps, getTokenProps }) => (
+        <>
+          {tokens.map((line, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: stable line indices
+            <div key={i} {...getLineProps({ line })}>
+              {line.map((token, j) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: stable token indices
+                <span key={j} {...getTokenProps({ token })} />
+              ))}
+            </div>
+          ))}
+        </>
+      )}
+    </Highlight>
+  )
+}
+
+function Highlighted({ code, language }: { code: string; language: CodeLang }) {
+  return language === "bash" ? <BashCode code={code} /> : <PrismCode code={code} language={language} />
+}
+
+function CopyButton({ value, label, className }: { value: string; label: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+  const onClick = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch (err) {
+      console.error("clipboard write failed", err)
+    }
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={copied ? "Copied" : label}
+      className={cn(
+        "group cursor-pointer rounded-md p-1 text-unison-text transition-colors hover:bg-unison-bg-hover",
+        className,
+      )}
+    >
+      {copied ? (
+        <IconCheck className="size-4 opacity-50 transition-opacity group-hover:opacity-100" stroke={1.5} />
+      ) : (
+        <IconCopy className="size-4 opacity-50 transition-opacity group-hover:opacity-100" stroke={1.5} />
+      )}
+    </button>
+  )
+}
+
+export function CodeBlock({ code, language, label }: { code: string; language: CodeLang; label?: string }) {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-unison-border/50 bg-unison-bg-elevated/50">
+      {label ? (
+        <div className="border-b border-unison-border/50 px-4 py-2">
+          <span className="text-xs font-medium text-unison-text-muted">{label}</span>
+        </div>
+      ) : null}
+      <pre className={preClass} style={{ color: PLAIN }}>
+        <Highlighted code={code} language={language} />
+      </pre>
+      <CopyButton value={code} label="Copy code" className="absolute right-2 top-2" />
+    </div>
+  )
+}
+
+export interface CodeTab {
+  label: string
+  code: string
+  language: CodeLang
+}
+
+export function CodeTabs({ tabs }: { tabs: CodeTab[] }) {
+  const shared = useContext(CodeLangContext)
+  const [localSelected, setLocalSelected] = useState(tabs[0]?.label ?? "")
+  const selected = shared ? shared.selected : localSelected
+  const setSelected = shared ? shared.setSelected : setLocalSelected
+
+  const found = tabs.findIndex((tab) => tab.label === selected)
+  const active = found >= 0 ? found : 0
+
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const [indicator, setIndicator] = useState({ left: 0, width: 0 })
+
+  const measure = useCallback(() => {
+    const el = tabRefs.current[active]
+    if (el) setIndicator({ left: el.offsetLeft, width: el.offsetWidth })
+  }, [active])
+
+  useLayoutEffect(() => {
+    measure()
+  }, [measure])
+
+  useEffect(() => {
+    window.addEventListener("resize", measure)
+    return () => window.removeEventListener("resize", measure)
+  }, [measure])
+
+  const current = tabs[active]
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-unison-border/50 bg-unison-bg-elevated/50">
+      <div role="tablist" className="relative flex gap-4 border-b border-unison-border/50 px-4">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.label}
+            ref={(el) => {
+              tabRefs.current[i] = el
+            }}
+            type="button"
+            role="tab"
+            aria-selected={i === active}
+            onClick={() => setSelected(tab.label)}
+            className={cn(
+              "cursor-pointer pb-2.5 pt-2 text-xs font-medium transition-colors",
+              i === active ? "text-unison-text" : "text-unison-text-secondary hover:text-unison-text",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <span
+          className="absolute bottom-0 h-0.5 rounded bg-unison-text transition-all duration-200"
+          style={{ left: indicator.left, width: indicator.width }}
+        />
+      </div>
+      <div className="relative">
+        <pre className={preClass} style={{ color: PLAIN }}>
+          <Highlighted code={current.code} language={current.language} />
+        </pre>
+        <CopyButton value={current.code} label="Copy code" className="absolute right-2 top-2" />
+      </div>
+    </div>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -125,6 +125,29 @@ select {
   color: #fff;
 }
 
+.unison-code-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-unison-border-strong) transparent;
+}
+
+.unison-code-scroll::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+.unison-code-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.unison-code-scroll::-webkit-scrollbar-thumb {
+  background: var(--color-unison-border-strong);
+  border-radius: 9999px;
+}
+
+.unison-code-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .link-pulse-dot {
     animation: none;

--- a/web/src/pages/DocsPage.test.tsx
+++ b/web/src/pages/DocsPage.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { DocsPage } from "./DocsPage"
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DocsPage />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe("DocsPage", () => {
+  it("documents the base URL and the primary fetch endpoint", () => {
+    renderPage()
+    expect(screen.getAllByText("https://unison.boidu.dev").length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/\/lyrics\?v=/).length).toBeGreaterThan(0)
+  })
+
+  it("documents search, variants, and single-id lookups", () => {
+    renderPage()
+    expect(screen.getAllByText(/\/lyrics\/search/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/\/lyrics\/variants\//).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/\/lyrics\/:id/).length).toBeGreaterThan(0)
+  })
+
+  it("no longer documents the legacy getLyrics endpoint", () => {
+    renderPage()
+    expect(screen.queryByText(/getLyrics/)).toBeNull()
+  })
+
+  it("offers the language tab set on every request example", () => {
+    renderPage()
+    // quickstart, song/artist, search, and variants each get a tab strip
+    expect(screen.getAllByRole("tablist").length).toBeGreaterThanOrEqual(4)
+    for (const lang of ["cURL", "JavaScript", "Python", "Go", "Rust"]) {
+      expect(screen.getAllByRole("tab", { name: lang }).length).toBeGreaterThanOrEqual(4)
+    }
+  })
+
+  it("switches a request example to the Python tab on click", () => {
+    renderPage()
+    fireEvent.click(screen.getAllByRole("tab", { name: "Python" })[0])
+    expect(document.body.textContent).toContain("import requests")
+  })
+
+  it("keeps the language choice in sync across every code block", () => {
+    renderPage()
+    fireEvent.click(screen.getAllByRole("tab", { name: "Go" })[0])
+    for (const tab of screen.getAllByRole("tab", { name: "Go" })) {
+      expect(tab.getAttribute("aria-selected")).toBe("true")
+    }
+    for (const tab of screen.getAllByRole("tab", { name: "cURL" })) {
+      expect(tab.getAttribute("aria-selected")).toBe("false")
+    }
+  })
+
+  it("explains the three lyric formats", () => {
+    renderPage()
+    const body = document.body.textContent ?? ""
+    expect(body).toContain("ttml")
+    expect(body).toContain("lrc")
+    expect(body).toContain("plain")
+  })
+
+  it("copies the quickstart example to the clipboard", () => {
+    renderPage()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("navigator", { clipboard: { writeText } })
+    const copyButtons = screen.getAllByRole("button", { name: /copy/i })
+    fireEvent.click(copyButtons[0])
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText.mock.calls[0][0]).toContain("unison.boidu.dev/lyrics")
+  })
+})

--- a/web/src/pages/DocsPage.tsx
+++ b/web/src/pages/DocsPage.tsx
@@ -1,0 +1,274 @@
+import type { ReactNode } from "react"
+import { type CodeTab, CodeBlock, CodeLangProvider, CodeTabs } from "@/components/CodeBlock"
+
+const BASE_URL = "https://unison.boidu.dev"
+
+const VIDEO_URL = "https://unison.boidu.dev/lyrics?v=dQw4w9WgXcQ"
+const SONG_ARTIST_URL = "https://unison.boidu.dev/lyrics?song=Never+Gonna+Give+You+Up&artist=Rick+Astley"
+const SEARCH_URL = "https://unison.boidu.dev/lyrics/search?q=never+gonna+give"
+const VARIANTS_URL = "https://unison.boidu.dev/lyrics/variants/dQw4w9WgXcQ?limit=5"
+
+// A GET in each language, generated from the URL so every reference section stays in lockstep.
+function fetchTabs(url: string): CodeTab[] {
+  return [
+    { label: "cURL", language: "bash", code: `curl "${url}"` },
+    {
+      label: "JavaScript",
+      language: "javascript",
+      code: `const res = await fetch("${url}")\nconst { success, data } = await res.json()`,
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `import requests\n\nbody = requests.get("${url}").json()`,
+    },
+    {
+      label: "Go",
+      language: "go",
+      code: `res, err := http.Get("${url}")\nif err != nil {\n    log.Fatal(err)\n}\ndefer res.Body.Close()\nbody, _ := io.ReadAll(res.Body)`,
+    },
+    {
+      label: "Rust",
+      language: "rust",
+      code: `let body = reqwest::blocking::get(\n    "${url}",\n)?\n.text()?;`,
+    },
+  ]
+}
+
+// The quickstart teaches the full round trip, so its snippets parse and use the result.
+const QUICKSTART_TABS: CodeTab[] = [
+  { label: "cURL", language: "bash", code: `curl "${VIDEO_URL}"` },
+  {
+    label: "JavaScript",
+    language: "javascript",
+    code: `const res = await fetch("${VIDEO_URL}")
+const { success, data } = await res.json()
+
+if (success) {
+  // data.format is "ttml" | "lrc" | "plain"
+  // data.lyrics holds the synced text in that format
+  render(data.lyrics, data.format)
+}`,
+  },
+  {
+    label: "Python",
+    language: "python",
+    code: `import requests
+
+res = requests.get("https://unison.boidu.dev/lyrics", params={"v": "dQw4w9WgXcQ"})
+body = res.json()
+
+if body["success"]:
+    data = body["data"]
+    # data["format"] is "ttml" | "lrc" | "plain"
+    render(data["lyrics"], data["format"])`,
+  },
+  {
+    label: "Go",
+    language: "go",
+    code: `res, err := http.Get("${VIDEO_URL}")
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+
+// body.data.lyrics holds the synced text in body.data.format
+body, _ := io.ReadAll(res.Body)
+fmt.Println(string(body))`,
+  },
+  {
+    label: "Rust",
+    language: "rust",
+    code: `// reqwest = { version = "0.12", features = ["blocking"] }
+let body = reqwest::blocking::get(
+    "${VIDEO_URL}",
+)?
+.text()?;
+
+// body.data.lyrics holds the synced text in body.data.format
+println!("{body}");`,
+  },
+]
+
+const VIDEO_RESPONSE = `{
+  "success": true,
+  "data": {
+    "id": 4821,
+    "videoId": "dQw4w9WgXcQ",
+    "song": "Never Gonna Give You Up",
+    "artist": "Rick Astley",
+    "album": "Whenever You Need Somebody",
+    "duration": 213,
+    "format": "ttml",
+    "syncType": "richsync",
+    "language": "en",
+    "score": 42,
+    "voteCount": 47,
+    "confidence": "high",
+    "lyrics": "<tt xmlns=\\"http://www.w3.org/ns/ttml\\"> ... </tt>"
+  }
+}`
+
+const SEARCH_RESPONSE = `{
+  "success": true,
+  "data": [
+    {
+      "id": 4821,
+      "videoId": "dQw4w9WgXcQ",
+      "song": "Never Gonna Give You Up",
+      "artist": "Rick Astley",
+      "format": "ttml",
+      "syncType": "richsync",
+      "confidence": "high",
+      "matchScore": 0.98
+    }
+  ]
+}`
+
+const ERROR_RESPONSE = `{
+  "success": false,
+  "error": "Not found",
+  "code": "NOT_FOUND",
+  "hint": "No lyrics matched that lookup yet."
+}`
+
+function Code({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded bg-unison-bg-elevated/60 px-1 py-0.5 font-mono text-[0.85em] text-unison-text">
+      {children}
+    </code>
+  )
+}
+
+export function DocsPage() {
+  return (
+    <CodeLangProvider>
+      <div className="max-w-2xl space-y-10">
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Fetching lyrics from Unison</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            Unison is a public database of community-synced lyrics, the community-fed source Better Lyrics reads from.
+            Each entry is keyed on a <Code>videoId</Code>. Reading from it needs no key and no sign-in. The base URL is{" "}
+            <Code>{BASE_URL}</Code>. Every <Code>/lyrics</Code> response is wrapped as{" "}
+            <Code>{"{ success, data }"}</Code>, so check <Code>success</Code> before you touch <Code>data</Code>. Reads
+            are rate limited to 120 requests per minute per IP.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Quickstart</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            If you have a video id, one call gets you the top-ranked lyrics for it. The synced text is in{" "}
+            <Code>data.lyrics</Code> and its format is in <Code>data.format</Code>.
+          </p>
+          <CodeTabs tabs={QUICKSTART_TABS} />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Fetch by video</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            <Code>GET /lyrics?v=&lt;videoId&gt;</Code> returns the single best version for that video. The fields you
+            need to render are <Code>lyrics</Code>, <Code>format</Code>, and <Code>syncType</Code>;{" "}
+            <Code>confidence</Code> tells you how much the community has vetted it. A miss returns <Code>404</Code>.
+          </p>
+          <CodeBlock code={VIDEO_RESPONSE} language="json" label="JSON response" />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Fetch by song and artist</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            No video id? Look up by <Code>song</Code> and <Code>artist</Code> instead. Both are matched
+            case-insensitively. Add <Code>album</Code> or <Code>duration</Code> (seconds, matched within a small
+            tolerance) when a title has more than one recording.
+          </p>
+          <CodeTabs tabs={fetchTabs(SONG_ARTIST_URL)} />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Search</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            <Code>GET /lyrics/search?q=&lt;text&gt;</Code> is for discovery. It returns ranked candidates with a{" "}
+            <Code>matchScore</Code> but no lyric body, so pick the <Code>videoId</Code> you want and fetch it with{" "}
+            <Code>/lyrics?v=</Code>. Passing <Code>song</Code> and <Code>artist</Code> instead of <Code>q</Code> runs an
+            exact match and does include the full records. Use <Code>limit</Code> to cap results.
+          </p>
+          <CodeTabs tabs={fetchTabs(SEARCH_URL)} />
+          <CodeBlock code={SEARCH_RESPONSE} language="json" label="JSON response" />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Other versions</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            A video can have several submitted versions. <Code>GET /lyrics/variants/:videoId</Code> lists them all,
+            best-ranked first (up to 50), so you can offer alternatives if the default is not the one you want.{" "}
+            <Code>GET /lyrics/:id</Code> fetches one specific version by its numeric id.
+          </p>
+          <CodeTabs tabs={fetchTabs(VARIANTS_URL)} />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Formats</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            The <Code>format</Code> field tells you how to read <Code>lyrics</Code>, and <Code>syncType</Code> tells you
+            how precise the timing is.
+          </p>
+          <ul className="space-y-1.5 text-sm leading-relaxed text-unison-text-secondary">
+            <li>
+              <Code>ttml</Code> is timed XML, the richest format. Pair it with <Code>syncType</Code>{" "}
+              <Code>richsync</Code> for word-by-word timing or <Code>linesync</Code> for per-line timing.
+            </li>
+            <li>
+              <Code>lrc</Code> is timestamped lines, the classic karaoke format.
+            </li>
+            <li>
+              <Code>plain</Code> is unsynced text, with <Code>syncType</Code> <Code>plain</Code>.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-unison-text">Errors and limits</h2>
+          <p className="text-sm leading-relaxed text-unison-text-secondary">
+            Failed <Code>/lyrics</Code> calls keep the envelope with <Code>success: false</Code> plus a{" "}
+            <Code>code</Code> and a human-readable <Code>error</Code> and <Code>hint</Code>. Common ones are{" "}
+            <Code>404</Code> when nothing matches and <Code>400</Code> when the query is missing a required param. Stay
+            under 120 requests per minute per IP or you get <Code>429</Code>.
+          </p>
+          <CodeBlock code={ERROR_RESPONSE} language="json" label="JSON response" />
+        </section>
+
+        <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-unison-border pt-6 text-xs text-unison-text-muted">
+          <div>
+            <span className="text-unison-text-secondary">Related projects</span>
+            <span className="px-1.5 opacity-60">·</span>
+            <a
+              href="https://betterlyrics.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-unison-text transition-colors hover:text-unison-text-secondary"
+            >
+              Better Lyrics
+            </a>
+            <span className="px-1.5 opacity-60">·</span>
+            <a
+              href="https://composer.boidu.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-unison-text transition-colors hover:text-unison-text-secondary"
+            >
+              Composer
+            </a>
+          </div>
+          <a
+            href="https://github.com/better-lyrics/unison"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-unison-text transition-colors hover:text-unison-text-secondary"
+          >
+            GitHub
+          </a>
+        </footer>
+      </div>
+    </CodeLangProvider>
+  )
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -3,6 +3,7 @@ import { type RouteObject, RouterProvider, createBrowserRouter } from "react-rou
 import { AppLayout } from "./components/AppLayout"
 import { AboutPage } from "./pages/AboutPage"
 import { CuratorsPage } from "./pages/CuratorsPage"
+import { DocsPage } from "./pages/DocsPage"
 import { DownloadsPage } from "./pages/DownloadsPage"
 import { LinkPage } from "./pages/LinkPage"
 import { LyricsPage } from "./pages/LyricsPage"
@@ -50,6 +51,7 @@ const router = createBrowserRouter([
       { path: "curator/:keyId", element: <UserPage /> },
       { path: "about", element: <AboutPage /> },
       { path: "downloads", element: <DownloadsPage /> },
+      { path: "docs", element: <DocsPage /> },
       { path: "link", element: <LinkPage /> },
       ...devRoutes,
     ],


### PR DESCRIPTION
## Overview

Adds a Docs tab: a read-only guide for fetching lyrics from Unison. Every request is shown in cURL, JavaScript, Python, Go, and Rust, and the language you pick carries across all the snippets.
