### PR TITLE
fix(votes): drop self-votes from effective score and add full recompute

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm -C web install --frozen-lockfile && pnpm -C web build",
     "db:migrate": "tsx src/db/migrate.ts",
     "db:migrate:prod": "DATABASE_URL=$DATABASE_URL tsx src/db/migrate.ts",
+    "scores:recompute": "tsx src/jobs/recompute-scores.ts",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint ./src --write && biome format ./src --write",
     "format": "biome format ./src --write",

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,7 +39,7 @@ export const config = {
 		min: 0.0,
 		max: 2.0,
 		consensusDelta: 0.1,
-		selfVoteWeight: 0.5,
+		selfVoteWeight: 0,
 		minVotesForConfidence: 3,
 		minScoreForConfidence: 0.5,
 		voteWeightFloor: 0.5,

--- a/src/jobs/recompute-scores.ts
+++ b/src/jobs/recompute-scores.ts
@@ -1,0 +1,20 @@
+import { closeRedis } from "@/infra/cache"
+import { closePool } from "@/infra/database"
+import { createEnv } from "@/infra/env"
+import { Logger } from "@/infra/logger"
+import { recomputeAllScores } from "@/jobs/score-updater"
+
+const log = new Logger("recompute")
+
+async function main() {
+	const env = createEnv()
+	const { updated } = await recomputeAllScores(env)
+	log.info("recompute finished", { updated })
+	await closePool()
+	await closeRedis()
+}
+
+main().catch((err) => {
+	log.error("recompute failed", { error: (err as Error).message })
+	process.exit(1)
+})

--- a/src/jobs/score-updater.test.ts
+++ b/src/jobs/score-updater.test.ts
@@ -4,6 +4,7 @@ import { config } from "@/config"
 import {
 	calculateScore,
 	recalculateScore,
+	recomputeAllScores,
 	updateReputations,
 	updateScores,
 } from "@/jobs/score-updater"
@@ -82,16 +83,37 @@ describe("calculateScore", () => {
 		expect(result.effective_score).toBeCloseTo(0.6, 2)
 	})
 
-	it("reduces self-vote weight by half", () => {
+	it("gives self-votes zero weight in effective_score", () => {
 		const votes = [
-			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 1 },
 			{ vote: 1, reputation: 1.0, avg_vote: 0.3, is_self_vote: 0 },
+			{ vote: -1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 1 },
 		]
 
 		const result = calculateScore(1, votes)
 
-		// (1 * 0.5 + 1 * 1.0) / (0.5 + 1.0) = 1.5 / 1.5 = 1.0
+		// self downvote is ignored: (1 * 1.0) / 1.0 = 1.0
 		expect(result.effective_score).toBe(1)
+		expect(result.vote_count).toBe(2)
+	})
+
+	it("regression: a lone self-vote yields zero effective_score, not a bootstrapped 1.0", () => {
+		const votes = [{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 1 }]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.effective_score).toBe(0)
+		expect(result.vote_count).toBe(1)
+	})
+
+	it("a self-vote does not contribute to the diversity bonus", () => {
+		const votes = [
+			{ vote: 1, reputation: 1.0, avg_vote: -0.5, is_self_vote: 1 },
+			{ vote: 1, reputation: 1.0, avg_vote: 0.5, is_self_vote: 0 },
+		]
+
+		const result = calculateScore(1, votes)
+
+		expect(result.diversity_bonus).toBe(0)
 	})
 
 	it("detects diversity bonus when both harsh and generous raters upvote", () => {
@@ -567,7 +589,7 @@ describe("reputation bounds", () => {
 	})
 
 	it("config has correct self-vote weight", () => {
-		expect(config.reputation.selfVoteWeight).toBe(0.5)
+		expect(config.reputation.selfVoteWeight).toBe(0)
 	})
 
 	it("config has correct minimum votes for confidence", () => {
@@ -612,5 +634,50 @@ describe("recalculateScore vote-count resync", () => {
 		)
 		expect(update?.params[2]).toBe(0)
 		expect(update?.params[3]).toBe(0)
+	})
+})
+
+describe("recomputeAllScores", () => {
+	it("recalculates every live lyric that has votes", async () => {
+		const { db, calls } = createMockDB([
+			[{ lyrics_id: 1 }, { lyrics_id: 2 }],
+			{ video_id: "v1", deleted_at: null },
+			[{ vote: 1, reputation: 1.0, avg_vote: 0.2, is_self_vote: 0 }],
+			{ video_id: "v2", deleted_at: null },
+			[{ vote: -1, reputation: 1.0, avg_vote: -0.1, is_self_vote: 0 }],
+		])
+		const env = { DB: db } as unknown as Env
+
+		const result = await recomputeAllScores(env)
+
+		expect(result.updated).toBe(2)
+		const updates = calls.filter(
+			(c) => c.sql.includes("UPDATE lyrics") && /effective_score\s*=\s*\?/.test(c.sql)
+		)
+		expect(updates).toHaveLength(2)
+	})
+
+	it("only scans live, voted rows", async () => {
+		const { db, calls } = createMockDB([[]])
+		const env = { DB: db } as unknown as Env
+
+		const result = await recomputeAllScores(env)
+
+		expect(result.updated).toBe(0)
+		expect(calls[0].sql).toMatch(/deleted_at\s+IS\s+NULL/i)
+		expect(calls[0].sql).toMatch(/vote_count\s*>\s*0/i)
+	})
+
+	it("skips the UPDATE for a row that was deleted after selection", async () => {
+		const { db, calls } = createMockDB([
+			[{ lyrics_id: 1 }],
+			{ video_id: "v1", deleted_at: 1700000000 },
+		])
+		const env = { DB: db } as unknown as Env
+
+		await recomputeAllScores(env)
+
+		const updates = calls.filter((c) => c.sql.includes("UPDATE lyrics"))
+		expect(updates).toHaveLength(0)
 	})
 })

--- a/src/jobs/score-updater.ts
+++ b/src/jobs/score-updater.ts
@@ -101,6 +101,21 @@ export async function updateScores(env: Env): Promise<{ updated: number }> {
 	return { updated }
 }
 
+export async function recomputeAllScores(env: Env): Promise<{ updated: number }> {
+	const rows = await env.DB.prepare(
+		"SELECT id AS lyrics_id FROM lyrics WHERE deleted_at IS NULL AND vote_count > 0"
+	).all<{ lyrics_id: number }>()
+
+	let updated = 0
+	for (const { lyrics_id } of rows.results || []) {
+		await recalculateScore(env, lyrics_id)
+		updated++
+	}
+
+	log.info("full score recompute complete", { updated })
+	return { updated }
+}
+
 async function applyAutoHidePenalty(env: Env): Promise<void> {
 	const penalty = config.moderation.autoHide.reputationPenalty
 	const minRep = config.reputation.min
@@ -156,8 +171,9 @@ export function calculateScore(lyricsId: number, votes: VoteWithUser[]): LyricsS
 
 	for (const v of votes) {
 		if (v.reputation < config.reputation.voteWeightFloor) continue
-		// Self-votes count less
 		const weight = v.is_self_vote ? v.reputation * config.reputation.selfVoteWeight : v.reputation
+		// A zero-weight vote realises to nothing: skip it from score and diversity alike.
+		if (weight <= 0) continue
 
 		weightedSum += v.vote * weight
 		totalWeight += weight


### PR DESCRIPTION
## Overview

Self-votes were weighted at half, but since the effective score is a weighted average, a submitter upvoting their own only lyric still resolved to a full score. Now that weight is zero, so a self-vote never moves ranking, and zero-weight votes drop out of the diversity and confidence signal too. Also added a recompute script to backfill existing rows in one pass after deploy, since scores otherwise only refresh as new votes come in.
