### PR TITLE
feat(web): braccato 1.1 lyrics renderer with the composer theme and click-to-play

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "format": "biome format --write ./src"
   },
   "dependencies": {
-    "@braccato/core": "^0.1.5",
+    "@braccato/core": "^1.1.0",
+    "@braccato/parsers": "^0.2.0",
     "@dicebear/collection": "^9.2.2",
     "@dicebear/core": "^9.2.2",
     "@tabler/icons-react": "^3.36.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       '@braccato/core':
-        specifier: ^0.1.5
-        version: 0.1.5
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@braccato/parsers':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@dicebear/collection':
         specifier: ^9.2.2
         version: 9.4.2(@dicebear/core@9.4.2)
@@ -221,11 +224,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@braccato/core@0.1.5':
-    resolution: {integrity: sha512-niByy5+OZpDtg8nIhjlOjYsltnAE10Yg8cXw8HPuno0sgLleOzTz0qhOgH8SN+zGJB19X9xV1OViySwYl+p2+Q==}
+  '@braccato/core@1.1.0':
+    resolution: {integrity: sha512-BBpwxZq6268HeImaJElD9dBSUcqZCgSon2tF0HlVNSCoqnIqr+FwNrkb99r20rZYCk+z6crOS4zmUw6xyxTHUg==}
 
-  '@braccato/parsers@0.1.1':
-    resolution: {integrity: sha512-S4LlT8vTMNiXvVUC5iaQiLvu8KUNZn7oAI0LRaQ0W75THlX/pTSEp3EoB3UBzI2F0k3ARvxL9qNuxpd3+WHmeQ==}
+  '@braccato/parsers@0.2.0':
+    resolution: {integrity: sha512-vHdNv7t1DQnKw7tWTc/AfrGsK/nHLiihqM/xLm0gbTE+iN9WNKsupQ/jAeheQHaQQzZNCYnZicnXb5cxiXjqwg==}
+
+  '@braccato/types@1.0.0':
+    resolution: {integrity: sha512-BHrCdJ5Uuc8IYJJqKT/4ULHkkbL8lk6KtAhfrx8bh3gC/huYwLDTBtOQAQSMriu3yMhV7TSvDd8L0loB5b1oeA==}
 
   '@dicebear/adventurer-neutral@9.4.2':
     resolution: {integrity: sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==}
@@ -595,11 +601,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lit-labs/ssr-dom-shim@1.6.0':
-    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
-
-  '@lit/reactive-element@2.1.2':
-    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -895,9 +898,6 @@ packages:
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
-
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -940,6 +940,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -1041,6 +1044,13 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1065,6 +1075,9 @@ packages:
   happy-dom@15.11.7:
     resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
     engines: {node: '>=18.0.0'}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1156,15 +1169,6 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lit-element@4.2.2:
-    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
-
-  lit-html@3.3.3:
-    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
-
-  lit@3.3.3:
-    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
-
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1188,6 +1192,10 @@ packages:
 
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1279,6 +1287,9 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -1408,6 +1419,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1563,12 +1578,16 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@braccato/core@0.1.5':
+  '@braccato/core@1.1.0':
     dependencies:
-      '@braccato/parsers': 0.1.1
-      lit: 3.3.3
+      '@braccato/types': 1.0.0
 
-  '@braccato/parsers@0.1.1': {}
+  '@braccato/parsers@0.2.0':
+    dependencies:
+      '@braccato/types': 1.0.0
+      fast-xml-parser: 5.10.1
+
+  '@braccato/types@1.0.0': {}
 
   '@dicebear/adventurer-neutral@9.4.2(@dicebear/core@9.4.2)':
     dependencies:
@@ -1830,11 +1849,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lit-labs/ssr-dom-shim@1.6.0': {}
-
-  '@lit/reactive-element@2.1.2':
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.6.0
+  '@nodable/entities@3.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -2062,8 +2077,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/trusted-types@2.0.7': {}
-
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -2121,6 +2134,8 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-styles@5.2.0: {}
+
+  anynum@1.0.1: {}
 
   aria-query@5.3.0:
     dependencies:
@@ -2220,6 +2235,20 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2236,6 +2265,8 @@ snapshots:
       entities: 4.5.0
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
+
+  is-unsafe@2.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -2296,22 +2327,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lit-element@4.2.2:
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.6.0
-      '@lit/reactive-element': 2.1.2
-      lit-html: 3.3.3
-
-  lit-html@3.3.3:
-    dependencies:
-      '@types/trusted-types': 2.0.7
-
-  lit@3.3.3:
-    dependencies:
-      '@lit/reactive-element': 2.1.2
-      lit-element: 4.2.2
-      lit-html: 3.3.3
-
   loupe@3.2.1: {}
 
   lru-cache@5.1.1:
@@ -2329,6 +2344,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   node-releases@2.0.44: {}
+
+  path-expression-matcher@1.6.2: {}
 
   pathe@2.0.3: {}
 
@@ -2429,6 +2446,10 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
 
   tailwind-merge@3.6.0: {}
 
@@ -2542,5 +2563,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xml-naming@0.3.0: {}
 
   yallist@3.1.1: {}

--- a/web/src/components/LyricsRenderer.test.tsx
+++ b/web/src/components/LyricsRenderer.test.tsx
@@ -1,40 +1,53 @@
+import type { Lyric } from "@braccato/parsers"
 import { cleanup, render } from "@testing-library/react"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import type { VariantFull } from "@/lib/types"
 
-vi.mock("@braccato/core", () => ({}))
-
-const createObjectURL = vi.fn()
-const revokeObjectURL = vi.fn()
-
-beforeEach(() => {
-  createObjectURL.mockReset()
-  revokeObjectURL.mockReset()
-  let counter = 0
-  createObjectURL.mockImplementation(() => `blob:fake-${++counter}`)
-  Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL })
-  Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: revokeObjectURL })
-})
+// Registering the custom element needs a layout engine happy-dom does not have. The component's
+// contract with it is the properties and events below, and those are what these exercise.
+vi.mock("@braccato/core/element", () => ({}))
 
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
 })
 
+const TTML = `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata">
+  <body dur="00:00:12.000">
+    <div begin="00:00:01.000" end="00:00:08.000">
+      <p begin="00:00:01.000" end="00:00:04.000"><span begin="00:00:01.000" end="00:00:02.000">Hold </span><span begin="00:00:02.000" end="00:00:04.000">on</span></p>
+      <p begin="00:00:05.000" end="00:00:08.000">to what we made</p>
+    </div>
+  </body>
+</tt>`
+
+const LRC = "[ar:Beach House]\n[ti:Space Song]\n[00:01.00]Fall back into place\n[00:05.50]Black out the sun"
+
+const PLAIN = "Fall back into place\nBlack out the sun"
+
+type LyricsElement = HTMLElement & {
+  lyrics?: Lyric[] | null
+  theme?: string
+  currentTime?: number
+  playing?: boolean
+  renderer?: { noteUserScroll: () => void } | null
+}
+
 function makeVariant(overrides: Partial<VariantFull> = {}): VariantFull {
   return {
     id: 1,
-    videoId: "vid",
-    song: "Song",
-    artist: "Artist",
+    videoId: "RBtlPT23PTM",
+    song: "Space Song",
+    artist: "Beach House",
     format: "ttml",
     syncType: "richsync",
-    score: 1,
-    effectiveScore: 1,
-    voteCount: 1,
-    confidence: "low",
+    score: 4,
+    effectiveScore: 4.2,
+    voteCount: 6,
+    confidence: "high",
     hidden: false,
-    lyrics: "<tt><body><div><p>hello</p></div></body></tt>",
+    lyrics: TTML,
     ...overrides,
   }
 }
@@ -51,133 +64,156 @@ async function nextFrame(): Promise<void> {
   await new Promise<void>((r) => requestAnimationFrame(() => r()))
 }
 
+function elementIn(container: HTMLElement): LyricsElement {
+  const el = container.querySelector("braccato-lyrics")
+  if (!el) throw new Error("<braccato-lyrics> never rendered")
+  return el as LyricsElement
+}
+
 describe("LyricsRenderer", () => {
-  it("creates a blob URL from the variant lyrics and assigns it to src", async () => {
+  it("hands the element the lines parsed out of a ttml variant, syllables included", async () => {
     const Renderer = await importRenderer()
-    const variant = makeVariant()
+    const { container } = render(<Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />)
+    const lyrics = elementIn(container).lyrics
+    expect(lyrics).toHaveLength(2)
+    expect(lyrics?.[0]).toMatchObject({ startTimeMs: 1000, durationMs: 3000, words: "Hold on" })
+    expect(lyrics?.[0].parts?.map((p) => p.words)).toEqual(["Hold ", "on"])
+    expect(lyrics?.[1]).toMatchObject({ startTimeMs: 5000, words: "to what we made" })
+  })
+
+  it("parses an lrc variant with the lrc parser rather than guessing at the body", async () => {
+    const Renderer = await importRenderer()
     const { container } = render(
-      <Renderer variant={variant} getCurrentTimeMs={zero} getPlaying={stopped} />,
+      <Renderer variant={makeVariant({ format: "lrc", lyrics: LRC })} getCurrentTime={zero} getPlaying={stopped} />,
     )
-    const el = container.querySelector("braccato-lyrics") as HTMLElement
-    expect(el).toBeTruthy()
-    expect(createObjectURL).toHaveBeenCalledTimes(1)
-    expect(el.getAttribute("src")).toMatch(/^blob:fake-1$/)
+    const lyrics = elementIn(container).lyrics
+    expect(lyrics).toHaveLength(2)
+    expect(lyrics?.[0]).toMatchObject({ startTimeMs: 1000, words: "Fall back into place" })
+    expect(lyrics?.[1]).toMatchObject({ startTimeMs: 5500, words: "Black out the sun" })
   })
 
-  it("uses application/ttml+xml for the ttml format", async () => {
+  it("parses a plain variant into untimed lines", async () => {
     const Renderer = await importRenderer()
-    render(
-      <Renderer variant={makeVariant({ format: "ttml" })} getCurrentTimeMs={zero} getPlaying={stopped} />,
+    const { container } = render(
+      <Renderer variant={makeVariant({ format: "plain", lyrics: PLAIN })} getCurrentTime={zero} getPlaying={stopped} />,
     )
-    const blob = createObjectURL.mock.calls[0][0] as Blob
-    expect(blob.type).toBe("application/ttml+xml")
+    expect(elementIn(container).lyrics).toEqual([
+      { startTimeMs: 0, words: "Fall back into place", durationMs: 0 },
+      { startTimeMs: 0, words: "Black out the sun", durationMs: 0 },
+    ])
   })
 
-  it("uses text/lrc for the lrc format", async () => {
+  it("drives currentTime in seconds and playing on the element from the getters every frame", async () => {
     const Renderer = await importRenderer()
-    render(
-      <Renderer
-        variant={makeVariant({ format: "lrc", lyrics: "[00:10.00]hi" })}
-        getCurrentTimeMs={zero}
-        getPlaying={stopped}
-      />,
-    )
-    const blob = createObjectURL.mock.calls[0][0] as Blob
-    expect(blob.type).toBe("text/lrc")
-  })
-
-  it("uses text/plain for the plain format", async () => {
-    const Renderer = await importRenderer()
-    render(
-      <Renderer
-        variant={makeVariant({ format: "plain", lyrics: "hi" })}
-        getCurrentTimeMs={zero}
-        getPlaying={stopped}
-      />,
-    )
-    const blob = createObjectURL.mock.calls[0][0] as Blob
-    expect(blob.type).toBe("text/plain")
-  })
-
-  it("drives currentTime and playing on the element from the getters every frame", async () => {
-    const Renderer = await importRenderer()
-    let nowMs = 1234
+    let now = 12.5
     let isPlaying = true
     const { container } = render(
-      <Renderer
-        variant={makeVariant()}
-        getCurrentTimeMs={() => nowMs}
-        getPlaying={() => isPlaying}
-      />,
+      <Renderer variant={makeVariant()} getCurrentTime={() => now} getPlaying={() => isPlaying} />,
     )
-    const el = container.querySelector("braccato-lyrics") as HTMLElement & {
-      currentTime?: number
-      playing?: boolean
-    }
+    const el = elementIn(container)
     await nextFrame()
-    expect(el.currentTime).toBe(1234)
+    expect(el.currentTime).toBe(12.5)
     expect(el.playing).toBe(true)
 
-    nowMs = 5000
+    now = 61
     isPlaying = false
     await nextFrame()
-    expect(el.currentTime).toBe(5000)
+    expect(el.currentTime).toBe(61)
     expect(el.playing).toBe(false)
   })
 
-  it("revokes the blob URL on unmount", async () => {
-    const Renderer = await importRenderer()
-    const { unmount } = render(
-      <Renderer variant={makeVariant()} getCurrentTimeMs={zero} getPlaying={stopped} />,
-    )
-    unmount()
-    expect(revokeObjectURL).toHaveBeenCalled()
-    const arg = revokeObjectURL.mock.calls[0][0]
-    expect(arg).toMatch(/^blob:fake-/)
-  })
-
-  it("invokes onLineClick with the time in seconds when the element fires braccato:line-click", async () => {
+  it("invokes onLineClick with the seconds the element asked to seek to", async () => {
     const Renderer = await importRenderer()
     const onLineClick = vi.fn()
     const { container } = render(
-      <Renderer
-        variant={makeVariant()}
-        getCurrentTimeMs={zero}
-        getPlaying={stopped}
-        onLineClick={onLineClick}
-      />,
+      <Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} onLineClick={onLineClick} />,
     )
-    const el = container.querySelector("braccato-lyrics") as HTMLElement
-    el.dispatchEvent(new CustomEvent("braccato:line-click", { detail: { time: 4500, lineIndex: 2 } }))
+    elementIn(container).dispatchEvent(new CustomEvent("braccato:line-click", { detail: { timeS: 4.5 } }))
     expect(onLineClick).toHaveBeenCalledWith(4.5)
   })
 
-  it("does not throw when braccato:line-click fires without a detail.time", async () => {
+  it("hands the element the theme, whose comments carry the engine settings", async () => {
     const Renderer = await importRenderer()
-    const onLineClick = vi.fn()
-    const { container } = render(
-      <Renderer
-        variant={makeVariant()}
-        getCurrentTimeMs={zero}
-        getPlaying={stopped}
-        onLineClick={onLineClick}
-      />,
-    )
-    const el = container.querySelector("braccato-lyrics") as HTMLElement
-    expect(() => el.dispatchEvent(new CustomEvent("braccato:line-click", { detail: {} }))).not.toThrow()
-    expect(onLineClick).not.toHaveBeenCalled()
+    const { container } = render(<Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />)
+    const theme = elementIn(container).theme ?? ""
+    expect(theme).toContain("blyrics-target-scroll-pos-ratio")
+    expect(theme).toContain(".blyrics-container")
   })
 
-  it("registers the braccato:line-click listener once across re-renders and dispatches to the latest handler", async () => {
+  it("tells the renderer about a user scroll so autoscroll steps aside", async () => {
     const Renderer = await importRenderer()
-    const variant = makeVariant()
-    const addEventListener = vi.spyOn(HTMLElement.prototype, "addEventListener")
-    try {
+    const { container } = render(<Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />)
+    const el = elementIn(container)
+    const noteUserScroll = vi.fn()
+    el.renderer = { noteUserScroll }
+    el.dispatchEvent(new Event("scroll"))
+    expect(noteUserScroll).toHaveBeenCalledTimes(1)
+  })
+
+  describe("edge cases", () => {
+    it("forwards a line click at the very start of the song", async () => {
+      const Renderer = await importRenderer()
+      const onLineClick = vi.fn()
+      const { container } = render(
+        <Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} onLineClick={onLineClick} />,
+      )
+      elementIn(container).dispatchEvent(new CustomEvent("braccato:line-click", { detail: { timeS: 0 } }))
+      expect(onLineClick).toHaveBeenCalledWith(0)
+    })
+
+    it("renders an empty line list for an empty ttml body rather than throwing", async () => {
+      const Renderer = await importRenderer()
+      const { container } = render(
+        <Renderer
+          variant={makeVariant({ lyrics: "<tt><body></body></tt>" })}
+          getCurrentTime={zero}
+          getPlaying={stopped}
+        />,
+      )
+      expect(elementIn(container).lyrics).toEqual([])
+    })
+
+    it("stays quiet when no onLineClick was given", async () => {
+      const Renderer = await importRenderer()
+      const { container } = render(<Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />)
+      expect(() =>
+        elementIn(container).dispatchEvent(new CustomEvent("braccato:line-click", { detail: { timeS: 3 } })),
+      ).not.toThrow()
+    })
+  })
+
+  describe("error paths", () => {
+    it("ignores a line click whose detail carries no time", async () => {
+      const Renderer = await importRenderer()
+      const onLineClick = vi.fn()
+      const { container } = render(
+        <Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} onLineClick={onLineClick} />,
+      )
+      const el = elementIn(container)
+      expect(() => el.dispatchEvent(new CustomEvent("braccato:line-click", { detail: {} }))).not.toThrow()
+      expect(() => el.dispatchEvent(new CustomEvent("braccato:line-click"))).not.toThrow()
+      expect(onLineClick).not.toHaveBeenCalled()
+    })
+
+    it("survives a scroll while the element is between renderers", async () => {
+      const Renderer = await importRenderer()
+      const { container } = render(<Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />)
+      const el = elementIn(container)
+      el.renderer = null
+      expect(() => el.dispatchEvent(new Event("scroll"))).not.toThrow()
+    })
+  })
+
+  describe("invariants", () => {
+    it("registers each listener once across re-renders and dispatches to the latest handler", async () => {
+      const Renderer = await importRenderer()
+      const variant = makeVariant()
+      const addEventListener = vi.spyOn(HTMLElement.prototype, "addEventListener")
       const calls: string[] = []
       const { container, rerender } = render(
         <Renderer
           variant={variant}
-          getCurrentTimeMs={zero}
+          getCurrentTime={zero}
           getPlaying={stopped}
           onLineClick={(s) => calls.push(`first:${s}`)}
         />,
@@ -185,43 +221,67 @@ describe("LyricsRenderer", () => {
       rerender(
         <Renderer
           variant={variant}
-          getCurrentTimeMs={zero}
+          getCurrentTime={zero}
           getPlaying={stopped}
           onLineClick={(s) => calls.push(`second:${s}`)}
         />,
       )
+      // React registers a scroll listener of its own on the root container, so count only the ones
+      // that landed on the element itself.
+      const el = elementIn(container)
+      const registered = addEventListener.mock.calls
+        .filter((_, i) => addEventListener.mock.contexts[i] === el)
+        .map((args) => args[0])
+      expect(registered.filter((name) => name === "braccato:line-click")).toHaveLength(1)
+      expect(registered.filter((name) => name === "scroll")).toHaveLength(1)
+
+      el.dispatchEvent(new CustomEvent("braccato:line-click", { detail: { timeS: 1 } }))
+      expect(calls).toEqual(["second:1"])
+    })
+
+    it("re-parses only when the variant body or format changes", async () => {
+      const Renderer = await importRenderer()
+      const { container, rerender } = render(
+        <Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />,
+      )
+      const el = elementIn(container)
+      const first = el.lyrics
+
+      rerender(<Renderer variant={makeVariant({ score: 99 })} getCurrentTime={zero} getPlaying={stopped} />)
+      expect(el.lyrics).toBe(first)
+
       rerender(
         <Renderer
-          variant={variant}
-          getCurrentTimeMs={zero}
+          variant={makeVariant({ id: 2, format: "lrc", lyrics: LRC })}
+          getCurrentTime={zero}
           getPlaying={stopped}
-          onLineClick={(s) => calls.push(`third:${s}`)}
         />,
       )
-      const lineClickRegistrations = addEventListener.mock.calls.filter((args) => args[0] === "braccato:line-click")
-      expect(lineClickRegistrations).toHaveLength(1)
-      const el = container.querySelector("braccato-lyrics") as HTMLElement
-      el.dispatchEvent(new CustomEvent("braccato:line-click", { detail: { time: 1000 } }))
-      expect(calls).toEqual(["third:1"])
-    } finally {
-      addEventListener.mockRestore()
-    }
+      expect(el.lyrics).not.toBe(first)
+      expect(el.lyrics?.[0]).toMatchObject({ words: "Fall back into place" })
+    })
+
+    it("stops driving the clock once unmounted", async () => {
+      const Renderer = await importRenderer()
+      const getCurrentTime = vi.fn(() => 0)
+      const { unmount } = render(
+        <Renderer variant={makeVariant()} getCurrentTime={getCurrentTime} getPlaying={stopped} />,
+      )
+      await nextFrame()
+      expect(getCurrentTime).toHaveBeenCalled()
+      unmount()
+      getCurrentTime.mockClear()
+      await nextFrame()
+      await nextFrame()
+      expect(getCurrentTime).not.toHaveBeenCalled()
+    })
   })
 
-  it("creates a new blob URL when the variant changes", async () => {
-    const Renderer = await importRenderer()
-    const { rerender } = render(
-      <Renderer variant={makeVariant()} getCurrentTimeMs={zero} getPlaying={stopped} />,
-    )
-    expect(createObjectURL).toHaveBeenCalledTimes(1)
-    rerender(
-      <Renderer
-        variant={makeVariant({ id: 2, lyrics: "different" })}
-        getCurrentTimeMs={zero}
-        getPlaying={stopped}
-      />,
-    )
-    expect(createObjectURL).toHaveBeenCalledTimes(2)
-    expect(revokeObjectURL).toHaveBeenCalledTimes(1)
+  describe("regressions", () => {
+    it("regression: never asks the element to fetch the body over the network", async () => {
+      const Renderer = await importRenderer()
+      const { container } = render(<Renderer variant={makeVariant()} getCurrentTime={zero} getPlaying={stopped} />)
+      expect(elementIn(container).hasAttribute("src")).toBe(false)
+    })
   })
 })

--- a/web/src/components/LyricsRenderer.tsx
+++ b/web/src/components/LyricsRenderer.tsx
@@ -1,45 +1,55 @@
-import "@braccato/core"
-import type { BraccatoElement } from "@braccato/core"
-import { useEffect, useRef, useState } from "react"
+import "@braccato/core/element"
+import type { BraccatoLyricsElement, LineClickDetail } from "@braccato/core/element"
+import { LRCParser, type LyricParser, PlainParser, TTMLParser } from "@braccato/parsers"
+import { useEffect, useMemo, useRef } from "react"
+import braccatoTheme from "@/components/braccato-theme.css?raw"
 import type { LyricsFormat, VariantFull } from "@/lib/types"
 
 interface LyricsRendererProps {
   variant: VariantFull
-  getCurrentTimeMs: () => number
+  getCurrentTime: () => number
   getPlaying: () => boolean
   onLineClick?: (timeSeconds: number) => void
 }
 
-const MIME_BY_FORMAT: Record<LyricsFormat, string> = {
-  ttml: "application/ttml+xml",
-  lrc: "text/lrc",
-  plain: "text/plain",
+const PARSER_BY_FORMAT: Record<LyricsFormat, LyricParser> = {
+  ttml: TTMLParser,
+  lrc: LRCParser,
+  plain: PlainParser,
 }
 
-export function LyricsRenderer({ variant, getCurrentTimeMs, getPlaying, onLineClick }: LyricsRendererProps) {
-  const elementRef = useRef<BraccatoElement>(null)
-  const [blobUrl, setBlobUrl] = useState<string | null>(null)
+export function LyricsRenderer({ variant, getCurrentTime, getPlaying, onLineClick }: LyricsRendererProps) {
+  const elementRef = useRef<BraccatoLyricsElement>(null)
+
+  // No duration to hand the parser: the player reports one only once the iframe is ready, and each
+  // parser keeps the lengths the document already states when it goes without.
+  const lyrics = useMemo(() => PARSER_BY_FORMAT[variant.format].parse(variant.lyrics), [variant.lyrics, variant.format])
+
+  // Ahead of the lyrics write: the theme carries the settings the lines are built against, and
+  // writing it rebuilds the view.
+  useEffect(() => {
+    const el = elementRef.current
+    if (el) el.theme = braccatoTheme
+  }, [])
 
   useEffect(() => {
-    const blob = new Blob([variant.lyrics], { type: MIME_BY_FORMAT[variant.format] })
-    const url = URL.createObjectURL(blob)
-    setBlobUrl(url)
-    return () => URL.revokeObjectURL(url)
-  }, [variant.lyrics, variant.format])
+    const el = elementRef.current
+    if (el) el.lyrics = lyrics
+  }, [lyrics])
 
   useEffect(() => {
     let frameId: number
     const tick = () => {
       const el = elementRef.current
       if (el) {
-        el.currentTime = getCurrentTimeMs()
+        el.currentTime = getCurrentTime()
         el.playing = getPlaying()
       }
       frameId = requestAnimationFrame(tick)
     }
     frameId = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(frameId)
-  }, [getCurrentTimeMs, getPlaying])
+  }, [getCurrentTime, getPlaying])
 
   const onLineClickRef = useRef(onLineClick)
   useEffect(() => {
@@ -49,27 +59,21 @@ export function LyricsRenderer({ variant, getCurrentTimeMs, getPlaying, onLineCl
   useEffect(() => {
     const el = elementRef.current
     if (!el) return
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ time?: number }>).detail
-      if (detail?.time == null) return
-      onLineClickRef.current?.(detail.time / 1000)
+    const seek = (e: Event) => {
+      const detail = (e as CustomEvent<LineClickDetail>).detail
+      if (detail?.timeS == null) return
+      onLineClickRef.current?.(detail.timeS)
     }
-    el.addEventListener("braccato:line-click", handler)
-    return () => el.removeEventListener("braccato:line-click", handler)
+    // The element stopped watching its own scroller, since the scroller may be one it does not own.
+    // Without this, scrolling away never pauses autoscroll and the next frame yanks the view back.
+    const noteUserScroll = () => el.renderer?.noteUserScroll()
+    el.addEventListener("braccato:line-click", seek)
+    el.addEventListener("scroll", noteUserScroll, { passive: true })
+    return () => {
+      el.removeEventListener("braccato:line-click", seek)
+      el.removeEventListener("scroll", noteUserScroll)
+    }
   }, [])
 
-  return (
-    <braccato-lyrics
-      ref={elementRef}
-      src={blobUrl ?? undefined}
-      className="mx-auto block h-[420px] w-full max-w-3xl"
-      style={
-        {
-          "--braccato-font-family": "'Satoshi', sans-serif",
-          "--braccato-font-size": "2rem",
-          "--braccato-inactive-opacity": "0.2",
-        } as React.CSSProperties
-      }
-    />
-  )
+  return <braccato-lyrics ref={elementRef} className="mx-auto h-[420px] w-full max-w-3xl" />
 }

--- a/web/src/components/braccato-theme.css
+++ b/web/src/components/braccato-theme.css
@@ -1,0 +1,38 @@
+/* Cherry-picked from the Sustain theme in the braccato repo (demo/theme-sustain.css),
+   minus its webfont, its font declarations, its distance blur ramp, and its agent
+   alignment (lyrics.css already ships that). Passed to the element as a string. */
+
+/* blyrics-target-scroll-pos-ratio = 0.5; */
+
+.blyrics-container {
+  --blyrics-font-weight: 600;
+  --blyrics-padding: 1.25rem;
+  --blyrics-wobble-duration: 1s;
+  --blyrics-word-wobble-transform-from: translateY(0);
+  --blyrics-word-wobble-transform-peak: translateY(-0.005em);
+  --blyrics-word-wobble-transform-settle: translateY(-0.028em);
+  --blyrics-word-wobble-transform-to: translateY(-0.0375em);
+}
+
+.blyrics-container > div {
+  transition: transform 0.166s var(--blyrics-anim-delay, 0s);
+}
+
+.blyrics-container > div:hover {
+  transform: scale(1.01);
+  transition: transform 0.3s ease;
+}
+
+.blyrics-background-lyric {
+  font-size: 0.9em;
+}
+
+/* Only a word held past blyrics-long-word-threshold glows. */
+.blyrics--word::after {
+  --blyrics-glow-color: color(display-p3 1 1 1 / 0.0001);
+}
+
+.blyrics--word[data-long-word]::after,
+.blyrics--word[data-long-word] > .blyrics-word-highlight {
+  --blyrics-glow-color: color(display-p3 1 1 1 / 1);
+}

--- a/web/src/hooks/useYouTubePlayer.test.tsx
+++ b/web/src/hooks/useYouTubePlayer.test.tsx
@@ -17,6 +17,7 @@ class FakePlayer {
   currentTime = 0
   state = 2
   seeks: Array<{ seconds: number; allowSeekAhead: boolean }> = []
+  plays = 0
   onReady?: () => void
   static instances: FakePlayer[] = []
 
@@ -40,6 +41,11 @@ class FakePlayer {
     if (!this.ready) throw new TypeError("seekTo is not a function")
     this.seeks.push({ seconds, allowSeekAhead })
     this.currentTime = seconds
+  }
+  playVideo() {
+    if (!this.ready) throw new TypeError("playVideo is not a function")
+    this.plays++
+    this.state = PlayerState.PLAYING
   }
   destroy() {
     this.destroyed = true
@@ -80,7 +86,7 @@ describe("useYouTubePlayer", () => {
     const { result } = renderHook(() => useYouTubePlayer(null))
     expect(typeof result.current.ref).toBe("function")
     expect(typeof result.current.seekTo).toBe("function")
-    expect(result.current.getCurrentTimeMs()).toBe(0)
+    expect(result.current.getCurrentTime()).toBe(0)
     expect(result.current.getPlaying()).toBe(false)
     expect(document.querySelectorAll("script[data-unison-yt-loader]").length).toBe(0)
   })
@@ -135,13 +141,13 @@ describe("useYouTubePlayer", () => {
     })
   })
 
-  it("getters read currentTime in ms and playing-state directly from the player", async () => {
+  it("getters read currentTime in seconds and playing-state directly from the player", async () => {
     installYT()
-    let getCurrentTimeMs: (() => number) | null = null
+    let getCurrentTime: (() => number) | null = null
     let getPlaying: (() => boolean) | null = null
     function CaptureHarness() {
       const player = useYouTubePlayer("abc")
-      getCurrentTimeMs = player.getCurrentTimeMs
+      getCurrentTime = player.getCurrentTime
       getPlaying = player.getPlaying
       return createElement("div", { ref: player.ref })
     }
@@ -151,8 +157,8 @@ describe("useYouTubePlayer", () => {
     })
     const player = FakePlayer.instances[0]
     expect(player).toBeDefined()
-    if (getCurrentTimeMs === null || getPlaying === null) throw new Error("getters never captured")
-    const readTime: () => number = getCurrentTimeMs
+    if (getCurrentTime === null || getPlaying === null) throw new Error("getters never captured")
+    const readTime: () => number = getCurrentTime
     const readPlaying: () => boolean = getPlaying
 
     act(() => {
@@ -160,7 +166,7 @@ describe("useYouTubePlayer", () => {
     })
 
     player.currentTime = 2.5
-    expect(readTime()).toBe(2500)
+    expect(readTime()).toBe(2.5)
 
     player.state = PlayerState.PLAYING
     expect(readPlaying()).toBe(true)
@@ -258,11 +264,11 @@ describe("useYouTubePlayer readiness gating", () => {
   // LyricsRenderer calls these every frame, so an unguarded pre-ready call threw
   // and killed the loop forever ("barely works most of the time"). These lock in
   // that the hook never touches the player before onReady.
-  it("regression: getCurrentTimeMs returns 0 and does not throw before the player is ready", async () => {
+  it("regression: getCurrentTime returns 0 and does not throw before the player is ready", async () => {
     await mountFor("abc")
     expect(FakePlayer.instances[0].ready).toBe(false)
-    expect(() => result.getCurrentTimeMs()).not.toThrow()
-    expect(result.getCurrentTimeMs()).toBe(0)
+    expect(() => result.getCurrentTime()).not.toThrow()
+    expect(result.getCurrentTime()).toBe(0)
     unmount()
   })
 
@@ -280,18 +286,40 @@ describe("useYouTubePlayer readiness gating", () => {
     unmount()
   })
 
+  it("regression: play is a no-op and does not throw before the player is ready", async () => {
+    await mountFor("abc")
+    expect(() => result.play()).not.toThrow()
+    expect(FakePlayer.instances[0].plays).toBe(0)
+    unmount()
+  })
+
+  it("play starts the underlying player once it is ready", async () => {
+    await mountFor("abc")
+    const player = FakePlayer.instances[0]
+    act(() => {
+      player.fireReady()
+    })
+    expect(result.getPlaying()).toBe(false)
+    act(() => {
+      result.play()
+    })
+    expect(player.plays).toBe(1)
+    expect(result.getPlaying()).toBe(true)
+    unmount()
+  })
+
   it("starts reading real player values only once onReady fires", async () => {
     await mountFor("abc")
     const player = FakePlayer.instances[0]
     player.currentTime = 3
     player.state = 1
-    expect(result.getCurrentTimeMs()).toBe(0)
+    expect(result.getCurrentTime()).toBe(0)
     expect(result.getPlaying()).toBe(false)
 
     act(() => {
       player.fireReady()
     })
-    expect(result.getCurrentTimeMs()).toBe(3000)
+    expect(result.getCurrentTime()).toBe(3)
     expect(result.getPlaying()).toBe(true)
     unmount()
   })
@@ -309,7 +337,7 @@ describe("useYouTubePlayer readiness gating", () => {
     act(() => {
       FakePlayer.instances[0].fireReady()
     })
-    expect(result.getCurrentTimeMs).toBeDefined()
+    expect(result.getCurrentTime).toBeDefined()
 
     rendered.rerender(createElement(Harness2, { videoId: "def" }))
     await act(async () => {
@@ -317,14 +345,14 @@ describe("useYouTubePlayer readiness gating", () => {
     })
     const next = FakePlayer.instances[1]
     expect(next.ready).toBe(false)
-    expect(() => result.getCurrentTimeMs()).not.toThrow()
-    expect(result.getCurrentTimeMs()).toBe(0)
+    expect(() => result.getCurrentTime()).not.toThrow()
+    expect(result.getCurrentTime()).toBe(0)
 
     next.currentTime = 5
     act(() => {
       next.fireReady()
     })
-    expect(result.getCurrentTimeMs()).toBe(5000)
+    expect(result.getCurrentTime()).toBe(5)
     rendered.unmount()
   })
 })

--- a/web/src/hooks/useYouTubePlayer.ts
+++ b/web/src/hooks/useYouTubePlayer.ts
@@ -4,6 +4,7 @@ interface YTPlayer {
   getCurrentTime(): number
   getPlayerState(): number
   seekTo(seconds: number, allowSeekAhead: boolean): void
+  playVideo(): void
   destroy(): void
 }
 
@@ -81,9 +82,10 @@ export function __resetForTests(): void {
 
 export interface UseYouTubePlayerResult {
   ref: (node: HTMLDivElement | null) => void
-  getCurrentTimeMs: () => number
+  getCurrentTime: () => number
   getPlaying: () => boolean
   seekTo: (seconds: number) => void
+  play: () => void
 }
 
 export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult {
@@ -135,10 +137,16 @@ export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult
     player.seekTo(seconds, true)
   }, [])
 
-  const getCurrentTimeMs = useCallback(() => {
+  const play = useCallback(() => {
+    const player = playerRef.current
+    if (!player || !readyRef.current) return
+    player.playVideo()
+  }, [])
+
+  const getCurrentTime = useCallback(() => {
     const player = playerRef.current
     if (!player || !readyRef.current) return 0
-    return player.getCurrentTime() * 1000
+    return player.getCurrentTime()
   }, [])
 
   const getPlaying = useCallback(() => {
@@ -147,5 +155,5 @@ export function useYouTubePlayer(videoId: string | null): UseYouTubePlayerResult
     return player.getPlayerState() === YT_STATE_PLAYING
   }, [])
 
-  return { ref: setNode, getCurrentTimeMs, getPlaying, seekTo }
+  return { ref: setNode, getCurrentTime, getPlaying, seekTo, play }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,6 +1,10 @@
 @import url("https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Geist+Mono:wght@500;600&display=swap");
 @import "tailwindcss";
+/* Layered so the unlayered :root block below outranks it whatever the import order resolves to. */
+@import "@braccato/core/styles/variables.css" layer(braccato-defaults);
+@import "@braccato/core/styles/lyrics.css";
+@import "@braccato/core/styles/instrumental.css";
 
 @theme {
   --color-unison-bg: #28292c;
@@ -38,6 +42,49 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Braccato lyrics view. These must stay on :root: variables.css derives the active and inactive
+   lyric colours from --blyrics-text-color there, so setting it lower down never reaches them. */
+:root {
+  --blyrics-text-color: var(--color-unison-text);
+  --blyrics-inactive-opacity: 0.2;
+  --blyrics-font-size: 2rem;
+}
+
+/* The element is the scroller braccato autoscrolls, which is what centres the active line. The
+   scrollbar stays hidden until the reader takes over, matching what 0.1.x drew in its shadow root. */
+braccato-lyrics {
+  display: block;
+  /* Spelling out x: a lone overflow-y computes overflow-x to auto rather than visible, so a line
+     wider than the box (or the theme's hover scale) draws a horizontal scrollbar. */
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+braccato-lyrics::-webkit-scrollbar {
+  display: none;
+}
+
+braccato-lyrics:has(.blyrics-user-scrolling) {
+  scrollbar-color: color-mix(in srgb, var(--color-unison-text) 15%, transparent) transparent;
+  scrollbar-width: thin;
+}
+
+braccato-lyrics:has(.blyrics-user-scrolling)::-webkit-scrollbar {
+  display: block;
+  width: 6px;
+}
+
+braccato-lyrics:has(.blyrics-user-scrolling)::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-unison-text) 15%, transparent);
+  border-radius: 3px;
+}
+
+/* lyrics.css spends --blyrics-padding-bottom but hardcodes the top. */
+braccato-lyrics .blyrics-container {
+  padding-top: var(--blyrics-padding-top, 2rem);
 }
 
 /* Native select popups ignore the control's own background, so dark them here. */

--- a/web/src/pages/LyricsPage.test.tsx
+++ b/web/src/pages/LyricsPage.test.tsx
@@ -4,17 +4,17 @@ import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { VariantFull, VariantSummary } from "@/lib/types"
 
-vi.mock("@braccato/core", () => ({}))
-
 const seekTo = vi.fn()
+const play = vi.fn()
 let lastLineClick: ((seconds: number) => void) | null = null
 
 vi.mock("@/hooks/useYouTubePlayer", () => ({
   useYouTubePlayer: () => ({
-    ref: { current: null },
-    currentTimeMs: 0,
-    playing: false,
+    ref: () => {},
+    getCurrentTime: () => 0,
+    getPlaying: () => false,
     seekTo,
+    play,
   }),
 }))
 
@@ -94,6 +94,7 @@ function renderAt(initialEntries: string[]) {
 
 beforeEach(() => {
   seekTo.mockReset()
+  play.mockReset()
   lastLineClick = null
   fetchVariants.mockReset()
   fetchVariant.mockReset()
@@ -256,12 +257,14 @@ describe("LyricsPage", () => {
     expect(controls.getAttribute("data-user-vote")).toBe("-1")
   })
 
-  it("invokes seekTo on the player when the renderer fires an onLineClick", async () => {
+  it("seeks and starts the player when the renderer fires an onLineClick", async () => {
     fetchVariants.mockResolvedValue({ variants: [makeSummary({ id: 1 })] })
     fetchVariant.mockResolvedValue({ variant: makeFull({ id: 1 }) })
     renderAt(["/song/v1"])
     await waitFor(() => expect(lastLineClick).not.toBeNull())
     lastLineClick?.(8.5)
     expect(seekTo).toHaveBeenCalledWith(8.5)
+    // Seeking a paused player leaves it paused, so the click has to say play as well.
+    expect(play).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/pages/LyricsPage.tsx
+++ b/web/src/pages/LyricsPage.tsx
@@ -42,7 +42,9 @@ export function LyricsPage() {
 	}, [location.key, navigate])
 
 	const safeVideoId = videoId ?? ""
-	const { ref, getCurrentTimeMs, getPlaying, seekTo } = useYouTubePlayer(safeVideoId.length > 0 ? safeVideoId : null)
+	const { ref, getCurrentTime, getPlaying, seekTo, play } = useYouTubePlayer(
+		safeVideoId.length > 0 ? safeVideoId : null,
+	)
 
 	const variantsQuery = useQuery({
 		queryKey: ["lyrics", "variants", safeVideoId],
@@ -77,7 +79,15 @@ export function LyricsPage() {
 		[params, setParams],
 	)
 
-	const handleLineClick = useCallback((seconds: number) => seekTo(seconds), [seekTo])
+	// Seeking a paused player leaves it paused, so clicking a line would land on the line and sit
+	// there in silence.
+	const handleLineClick = useCallback(
+		(seconds: number) => {
+			seekTo(seconds)
+			play()
+		},
+		[seekTo, play],
+	)
 
 	const [copyState, setCopyState] = useState<CopyState>("idle")
 	const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -222,7 +232,7 @@ export function LyricsPage() {
 							) : mode === "synced" ? (
 								<LyricsRenderer
 									variant={variant}
-									getCurrentTimeMs={getCurrentTimeMs}
+									getCurrentTime={getCurrentTime}
 									getPlaying={getPlaying}
 									onLineClick={handleLineClick}
 								/>

--- a/web/src/types/braccato.d.ts
+++ b/web/src/types/braccato.d.ts
@@ -1,20 +1,10 @@
 import "react"
-import type { BraccatoElement } from "@braccato/core"
+import type { BraccatoLyricsElement } from "@braccato/core/element"
 
 declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
-      "braccato-lyrics": React.DetailedHTMLProps<
-        React.HTMLAttributes<HTMLElement> & {
-          source?: string
-          src?: string
-          playing?: boolean
-          "current-time"?: number
-          "scroll-mode"?: "internal" | "external"
-          dir?: "auto" | "ltr" | "rtl"
-        },
-        BraccatoElement
-      >
+      "braccato-lyrics": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, BraccatoLyricsElement>
     }
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -24,5 +24,8 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: false,
+    // Vitest stubs every .css import to "" unless it is opted in, and that swallows the braccato
+    // theme, which is a string handed to the element rather than a stylesheet the page loads.
+    css: { include: [/braccato-theme\.css/] },
   },
 })


### PR DESCRIPTION
## Overview

Braccato 1.0 dropped the Lit component and became the Better Lyrics engine itself, so almost none of the old integration survives. It renders into light DOM, takes seconds instead of milliseconds, and no longer fetches or parses anything, so lyrics get parsed up front with `@braccato/parsers` and handed over as an array instead of a blob URL. Picked up composer's theme while I was in here, wired the scroll listener back up (the element stopped watching its own scroller), and made a line click start playback instead of landing on a paused player.
