### PR TITLE
fix(search): match non-Latin song and artist names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { startWatchdog } from "@/infra/watchdog"
 import { backfillConfidence } from "@/jobs/backfill-confidence"
 import { backfillFormatDetection } from "@/jobs/backfill-format-detection"
 import { backfillLanguage } from "@/jobs/backfill-language"
+import { backfillNorms } from "@/jobs/backfill-norms"
 import { backfillSyncType } from "@/jobs/backfill-synctype"
 import { backfillTextSearch } from "@/jobs/backfill-text-search"
 import { backfillVoteCounts } from "@/jobs/backfill-vote-counts"
@@ -269,6 +270,12 @@ backfillConfidence(env)
 		if (updated > 0) log.info("confidence backfill complete", { updated })
 	})
 	.catch((err) => log.error("confidence backfill failed", { error: (err as Error).message }))
+
+backfillNorms(env)
+	.then(({ scanned, updated }) => {
+		if (updated > 0) log.info("norms backfill complete", { scanned, updated })
+	})
+	.catch((err) => log.error("norms backfill failed", { error: (err as Error).message }))
 
 cleanupFulfilledRequests(env)
 	.then(({ deleted }) => {

--- a/src/jobs/backfill-norms.test.ts
+++ b/src/jobs/backfill-norms.test.ts
@@ -1,0 +1,191 @@
+import type { Env } from "@/types"
+import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
+import { describe, expect, it } from "vitest"
+import { backfillNorms } from "./backfill-norms"
+
+interface StoreRow {
+	id: number
+	song: string
+	artist: string
+	album: string | null
+	song_norm: string
+	artist_norm: string
+	album_norm: string | null
+	deleted_at: number | null
+}
+
+function createStore(initial: Array<Partial<StoreRow> & { id: number }>) {
+	const rows: StoreRow[] = initial.map((r) => ({
+		song: "",
+		artist: "",
+		album: null,
+		song_norm: "",
+		artist_norm: "",
+		album_norm: null,
+		deleted_at: null,
+		...r,
+	}))
+	const updates: Array<{ id: number; params: unknown[] }> = []
+
+	const db = {
+		prepare(sql: string) {
+			return {
+				bind(...params: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							return null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							const afterId = Number(params[0])
+							const limit = Number(params[1])
+							const page = rows
+								.filter((r) => r.id > afterId && r.deleted_at === null)
+								.sort((a, b) => a.id - b.id)
+								.slice(0, limit)
+							return { results: page.map((r) => ({ ...r })) as unknown as T[] }
+						},
+						async run(): Promise<void> {
+							if (!/UPDATE/i.test(sql)) return
+							const [songNorm, artistNorm, albumNorm, id] = params
+							const row = rows.find((r) => r.id === id)
+							if (row) {
+								row.song_norm = songNorm as string
+								row.artist_norm = artistNorm as string
+								row.album_norm = albumNorm as string | null
+							}
+							updates.push({ id: id as number, params })
+						},
+					}
+				},
+			}
+		},
+	}
+
+	return { rows, updates, db }
+}
+
+function buildEnv(db: ReturnType<typeof createStore>["db"]): Env {
+	return {
+		DB: db,
+		CACHE: {
+			get: async () => null,
+			put: async () => undefined,
+			delete: async () => undefined,
+			keys: async () => [],
+		},
+		CACHE_TTL_SECONDS: "0",
+		RATE_LIMITER: { check: async () => ({ ok: true, remaining: 0 }) },
+	} as unknown as Env
+}
+
+describe("backfillNorms", () => {
+	describe("happy paths", () => {
+		it("recomputes empty norms for a Japanese row (regression: issue #54)", async () => {
+			const store = createStore([
+				{ id: 1, song: "いますぐ輪廻", artist: "なきそ", song_norm: "", artist_norm: "" },
+			])
+
+			const result = await backfillNorms(buildEnv(store.db))
+
+			expect(result).toEqual({ scanned: 1, updated: 1 })
+			expect(store.rows[0].song_norm).toBe(normalizeSong("いますぐ輪廻"))
+			expect(store.rows[0].artist_norm).toBe(normalizeArtist("なきそ"))
+			expect(store.rows[0].song_norm).toBe("いますぐ輪廻")
+			expect(store.rows[0].artist_norm).toBe("なきそ")
+		})
+
+		it("recomputes a stale album_norm", async () => {
+			const store = createStore([
+				{
+					id: 1,
+					song: "Song",
+					artist: "Artist",
+					album: "Café",
+					song_norm: "song",
+					artist_norm: "artist",
+					album_norm: "café",
+				},
+			])
+
+			const result = await backfillNorms(buildEnv(store.db))
+
+			expect(result).toEqual({ scanned: 1, updated: 1 })
+			expect(store.rows[0].album_norm).toBe(normalize("Café"))
+			expect(store.rows[0].album_norm).toBe("cafe")
+		})
+	})
+
+	describe("idempotence", () => {
+		it("leaves an already-correct Latin row untouched", async () => {
+			const store = createStore([
+				{
+					id: 1,
+					song: "Bohemian Rhapsody",
+					artist: "Queen",
+					song_norm: normalizeSong("Bohemian Rhapsody"),
+					artist_norm: normalizeArtist("Queen"),
+				},
+			])
+
+			const result = await backfillNorms(buildEnv(store.db))
+
+			expect(result).toEqual({ scanned: 1, updated: 0 })
+			expect(store.updates).toHaveLength(0)
+		})
+
+		it("advances the cursor and terminates when every row is already correct", async () => {
+			const store = createStore(
+				Array.from({ length: 5 }, (_, i) => ({
+					id: i + 1,
+					song: `Song ${i + 1}`,
+					artist: "Artist",
+					song_norm: normalizeSong(`Song ${i + 1}`),
+					artist_norm: normalizeArtist("Artist"),
+				}))
+			)
+
+			const result = await backfillNorms(buildEnv(store.db))
+
+			expect(result).toEqual({ scanned: 5, updated: 0 })
+			expect(store.updates).toHaveLength(0)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("skips soft-deleted rows", async () => {
+			const store = createStore([
+				{ id: 1, song: "今すぐ輪廻", artist: "なきそ", song_norm: "", deleted_at: 1700000000 },
+			])
+
+			const result = await backfillNorms(buildEnv(store.db))
+
+			expect(result).toEqual({ scanned: 0, updated: 0 })
+			expect(store.rows[0].song_norm).toBe("")
+		})
+
+		it("only updates the rows that actually changed", async () => {
+			const store = createStore([
+				{
+					id: 1,
+					song: "방탄소년단",
+					artist: "Artist",
+					song_norm: "",
+					artist_norm: normalizeArtist("Artist"),
+				},
+				{
+					id: 2,
+					song: "Correct",
+					artist: "Artist",
+					song_norm: normalizeSong("Correct"),
+					artist_norm: normalizeArtist("Artist"),
+				},
+			])
+
+			const result = await backfillNorms(buildEnv(store.db))
+
+			expect(result).toEqual({ scanned: 2, updated: 1 })
+			expect(store.updates.map((u) => u.id)).toEqual([1])
+			expect(store.rows[0].song_norm).toBe("방탄소년단")
+		})
+	})
+})

--- a/src/jobs/backfill-norms.ts
+++ b/src/jobs/backfill-norms.ts
@@ -1,0 +1,71 @@
+import { Logger } from "@/infra/logger"
+import type { Env } from "@/types"
+import { normalize, normalizeArtist, normalizeSong } from "@/utils/normalize"
+
+const log = new Logger("backfill-norms")
+const BATCH_SIZE = 200
+
+interface Row {
+	id: number
+	song: string
+	artist: string
+	album: string | null
+	song_norm: string
+	artist_norm: string
+	album_norm: string | null
+}
+
+export async function backfillNorms(env: Env): Promise<{ scanned: number; updated: number }> {
+	let scanned = 0
+	let updated = 0
+	let lastId = 0
+
+	while (true) {
+		const batch = await env.DB.prepare(
+			`SELECT id, song, artist, album, song_norm, artist_norm, album_norm
+			 FROM lyrics
+			 WHERE id > ? AND deleted_at IS NULL
+			 ORDER BY id ASC
+			 LIMIT ?`
+		)
+			.bind(lastId, BATCH_SIZE)
+			.all<Row>()
+
+		const rows = batch.results || []
+		if (rows.length === 0) break
+
+		for (const row of rows) {
+			scanned++
+			lastId = row.id
+
+			const songNorm = normalizeSong(row.song)
+			const artistNorm = normalizeArtist(row.artist)
+			const albumNorm = row.album ? normalize(row.album) : null
+
+			if (
+				songNorm === row.song_norm &&
+				artistNorm === row.artist_norm &&
+				albumNorm === row.album_norm
+			) {
+				continue
+			}
+
+			try {
+				await env.DB.prepare(
+					"UPDATE lyrics SET song_norm = ?, artist_norm = ?, album_norm = ? WHERE id = ?"
+				)
+					.bind(songNorm, artistNorm, albumNorm, row.id)
+					.run()
+				updated++
+			} catch (err) {
+				log.warn("update failed", { id: row.id, error: (err as Error).message })
+			}
+		}
+
+		log.info("backfill batch complete", { batch: rows.length, scanned, updated })
+
+		await new Promise((resolve) => setImmediate(resolve))
+	}
+
+	return { scanned, updated }
+}

--- a/src/utils/normalize.test.ts
+++ b/src/utils/normalize.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+import { normalize, normalizeArtist, normalizeSong } from "./normalize"
+
+describe("normalize", () => {
+	describe("happy paths", () => {
+		it("lowercases and trims", () => {
+			expect(normalize("  Hello World  ")).toBe("hello world")
+		})
+
+		it("removes ASCII punctuation and symbols", () => {
+			expect(normalize("Hello, World!")).toBe("hello world")
+		})
+
+		it("collapses runs of whitespace", () => {
+			expect(normalize("a\t\n  b")).toBe("a b")
+		})
+
+		it("folds Latin diacritics to base letters", () => {
+			expect(normalize("Beyoncé")).toBe("beyonce")
+			expect(normalize("Sigur Rós")).toBe("sigur ros")
+		})
+
+		it("keeps digits", () => {
+			expect(normalize("Area 51")).toBe("area 51")
+		})
+	})
+
+	describe("non-Latin scripts (regression: issue #54)", () => {
+		it("preserves Japanese kanji", () => {
+			expect(normalize("今すぐ輪廻")).toBe("今すぐ輪廻")
+		})
+
+		it("preserves Japanese hiragana", () => {
+			expect(normalize("いますぐ輪廻")).toBe("いますぐ輪廻")
+		})
+
+		it("preserves Japanese katakana", () => {
+			expect(normalize("ナキソ")).toBe("ナキソ")
+		})
+
+		it("preserves Korean hangul", () => {
+			expect(normalize("방탄소년단")).toBe("방탄소년단")
+		})
+
+		it("preserves Cyrillic and lowercases it", () => {
+			expect(normalize("Тату")).toBe("тату")
+		})
+
+		it("preserves Greek letters while folding accents", () => {
+			expect(normalize("Ελλάδα")).toBe("ελλαδα")
+		})
+
+		it("keeps CJK while still stripping punctuation around it", () => {
+			expect(normalize("「今すぐ輪廻」")).toBe("今すぐ輪廻")
+		})
+
+		it("preserves mixed Latin and CJK", () => {
+			expect(normalize("Naki 今すぐ")).toBe("naki 今すぐ")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns empty string for empty input", () => {
+			expect(normalize("")).toBe("")
+		})
+
+		it("returns empty string for whitespace only", () => {
+			expect(normalize("   ")).toBe("")
+		})
+
+		it("strips emoji as symbols", () => {
+			expect(normalize("hello 🎵 world")).toBe("hello world")
+		})
+
+		it("returns empty string for punctuation-only input", () => {
+			expect(normalize("!!!")).toBe("")
+		})
+	})
+})
+
+describe("normalizeSong", () => {
+	it("removes parenthetical suffixes", () => {
+		expect(normalizeSong("Song Title (Official Video)")).toBe("song title")
+		expect(normalizeSong("Song Title [Lyrics]")).toBe("song title")
+	})
+
+	it("removes trailing dash-qualified descriptors", () => {
+		expect(normalizeSong("Song Title - Official Music Video")).toBe("song title")
+	})
+
+	it("preserves a Japanese title (regression: issue #54)", () => {
+		expect(normalizeSong("今すぐ輪廻")).toBe("今すぐ輪廻")
+		expect(normalizeSong("いますぐ輪廻")).toBe("いますぐ輪廻")
+	})
+
+	it("preserves a Japanese title with an English descriptor suffix", () => {
+		expect(normalizeSong("いますぐ輪廻 (Official Audio)")).toBe("いますぐ輪廻")
+	})
+})
+
+describe("normalizeArtist", () => {
+	it("removes featured artists", () => {
+		expect(normalizeArtist("Drake feat. Rihanna")).toBe("drake")
+		expect(normalizeArtist("Drake ft. Rihanna")).toBe("drake")
+	})
+
+	it("normalizes ampersand to 'and'", () => {
+		expect(normalizeArtist("Simon & Garfunkel")).toBe("simon and garfunkel")
+	})
+
+	it("preserves a Japanese artist name (regression: issue #54)", () => {
+		expect(normalizeArtist("なきそ")).toBe("なきそ")
+	})
+})

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -9,7 +9,8 @@ export function normalize(input: string): string {
 			.normalize("NFD")
 			// biome-ignore lint/suspicious/noMisleadingCharacterClass: intentionally matching combining diacritical marks
 			.replace(/[\u0300-\u036f]/g, "")
-			.replace(/[^\w\s]/g, "") // Remove special characters
+			.normalize("NFC") // Recompose so kana voiced marks and hangul jamo survive the strip below
+			.replace(/[^\p{L}\p{N}\s]/gu, "") // Keep letters/numbers of all scripts, drop punctuation/symbols
 			.replace(/\s+/g, " ") // Collapse whitespace
 			.trim()
 	)


### PR DESCRIPTION
## Overview

Searching by a Japanese song or artist name returned the wrong song, or nothing at all. The normalizer stripped punctuation with an ASCII-only rule that also threw away every kanji, kana, hangul, and Cyrillic letter, so a title like 今すぐ輪廻 collapsed to an empty string and matched whatever happened to rank highest. Now it keeps letters from any script and recomposes voiced kana and hangul so they survive intact. Existing rows were stored with the broken values, so a startup job recomputes the norm columns for anything that changed. Fixes #54.
