### PR TITLE
feat(migrations): self-service account migration for the butler bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ wrangler.toml
 
 # CLI utils
 cli/
+
+# Local-only ops scripts
+scripts/local/

--- a/schema.sql
+++ b/schema.sql
@@ -272,9 +272,6 @@ CREATE INDEX IF NOT EXISTS translation_cache_expires_idx ON translation_cache (e
 CREATE INDEX IF NOT EXISTS translation_cache_video_idx   ON translation_cache (video_id);
 CREATE INDEX IF NOT EXISTS translation_cache_to_lang_idx ON translation_cache (to_lang);
 
--- Account migration audit + reversible snapshot.
--- One row per migration that reached preview. The snapshot JSONB holds the full
--- pre-image of every touched row so a commit can be undone even after the fact.
 CREATE TABLE IF NOT EXISTS migration_requests (
     id BIGSERIAL PRIMARY KEY,
     session_id TEXT,

--- a/schema.sql
+++ b/schema.sql
@@ -271,3 +271,26 @@ ALTER TABLE translation_cache ADD COLUMN IF NOT EXISTS failure_count INT NOT NUL
 CREATE INDEX IF NOT EXISTS translation_cache_expires_idx ON translation_cache (expires_at);
 CREATE INDEX IF NOT EXISTS translation_cache_video_idx   ON translation_cache (video_id);
 CREATE INDEX IF NOT EXISTS translation_cache_to_lang_idx ON translation_cache (to_lang);
+
+-- Account migration audit + reversible snapshot.
+-- One row per migration that reached preview. The snapshot JSONB holds the full
+-- pre-image of every touched row so a commit can be undone even after the fact.
+CREATE TABLE IF NOT EXISTS migration_requests (
+    id BIGSERIAL PRIMARY KEY,
+    session_id TEXT,
+    discord_id TEXT NOT NULL,
+    old_key TEXT NOT NULL,
+    new_key TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('preview', 'committed', 'failed')),
+    moved_submissions INTEGER NOT NULL DEFAULT 0,
+    moved_votes INTEGER NOT NULL DEFAULT 0,
+    moved_reports INTEGER NOT NULL DEFAULT 0,
+    moved_fulfillments INTEGER NOT NULL DEFAULT 0,
+    collisions_dropped INTEGER NOT NULL DEFAULT 0,
+    snapshot JSONB,
+    error TEXT,
+    created_at INTEGER NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW())::INTEGER),
+    updated_at INTEGER NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW())::INTEGER)
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_requests_discord ON migration_requests(discord_id);

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export const config = {
 
 	migration: {
 		sessionTtlSeconds: 900, // time to open the new extension and finish the OAuth prove
+		commitLockSeconds: 60,
 	},
 
 	reputation: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,10 @@ export const config = {
 		blacklistedKeyIds: new Set<string>([COMMUNITY_KEY_ID]),
 	},
 
+	migration: {
+		sessionTtlSeconds: 900, // time to open the new extension and finish the OAuth prove
+	},
+
 	reputation: {
 		default: 1.0,
 		min: 0.0,

--- a/src/db/account-migration.integration.test.ts
+++ b/src/db/account-migration.integration.test.ts
@@ -295,4 +295,51 @@ describeIntegration("account migration (integration)", () => {
 		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [OLD_KEY])).toBe(1)
 		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])).toBe(0)
 	})
+
+	it("applies the new key's nickname when keepNickname is 'new', and restore reverts it", async () => {
+		await pool.query("INSERT INTO public_keys (key_id, public_key) VALUES ($1, 'x'), ($2, 'y')", [
+			OLD_KEY,
+			NEW_KEY,
+		])
+		const oldUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id, nickname, nickname_updated_at) VALUES ($1, 'Caplump', 1) RETURNING id",
+			[OLD_KEY]
+		)
+		await pool.query(
+			"INSERT INTO users (key_id, nickname, nickname_updated_at) VALUES ($1, 'tropicawhale', 1)",
+			[NEW_KEY]
+		)
+
+		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
+		if ("error" in plan) throw new Error(plan.error)
+		expect(plan.oldNickname).toBe("Caplump")
+		expect(plan.newNickname).toBe("tropicawhale")
+
+		const auditId = await createPreviewAudit(env, {
+			sessionId: "sess-3",
+			discordId: "disc-1",
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			counts: plan.counts,
+		})
+		const result = await runMigration(env, {
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			keepNickname: "new",
+		})
+		if ("error" in result) throw new Error(result.error)
+		await markAuditCommitted(env, auditId, result.moved, result.snapshot)
+
+		const survivor = await one<{ nickname: string }>("SELECT nickname FROM users WHERE id = $1", [
+			oldUser.id,
+		])
+		expect(survivor.nickname).toBe("tropicawhale")
+
+		expect(await restoreFromSnapshot(env, auditId)).toEqual({ restored: true })
+		const reverted = await one<{ nickname: string }>("SELECT nickname FROM users WHERE id = $1", [
+			oldUser.id,
+		])
+		expect(reverted.nickname).toBe("Caplump")
+		expect(await num("SELECT count(*)::int n FROM users WHERE nickname = 'tropicawhale'", [])).toBe(1)
+	})
 })

--- a/src/db/account-migration.integration.test.ts
+++ b/src/db/account-migration.integration.test.ts
@@ -7,7 +7,7 @@ import {
 	computeMigrationPlan,
 	createPreviewAudit,
 	getAudit,
-	markAuditCommitted,
+	markAuditFailed,
 	restoreFromSnapshot,
 	runMigration,
 } from "./account-migration"
@@ -157,9 +157,8 @@ describeIntegration("account migration (integration)", () => {
 			newKey: NEW_KEY,
 			counts: plan.counts,
 		})
-		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY })
+		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
 		if ("error" in result) throw new Error(result.error)
-		await markAuditCommitted(env, auditId, result.moved, result.snapshot)
 
 		expect(result.moved).toEqual({
 			submissions: 2,
@@ -262,12 +261,12 @@ describeIntegration("account migration (integration)", () => {
 			newKey: NEW_KEY,
 			counts: plan.counts,
 		})
-		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY })
+		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
 		if ("error" in result) throw new Error(result.error)
-		await markAuditCommitted(env, auditId, result.moved, result.snapshot)
 
 		const audit = await getAudit(env, auditId)
 		expect(audit?.status).toBe("committed")
+		expect(audit?.snapshot).not.toBeNull()
 
 		const restore = await restoreFromSnapshot(env, auditId)
 		expect(restore).toEqual({ restored: true })
@@ -326,9 +325,9 @@ describeIntegration("account migration (integration)", () => {
 			oldKey: OLD_KEY,
 			newKey: NEW_KEY,
 			keepNickname: "new",
+			migrationId: auditId,
 		})
 		if ("error" in result) throw new Error(result.error)
-		await markAuditCommitted(env, auditId, result.moved, result.snapshot)
 
 		const survivor = await one<{ nickname: string }>("SELECT nickname FROM users WHERE id = $1", [
 			oldUser.id,
@@ -341,5 +340,67 @@ describeIntegration("account migration (integration)", () => {
 		])
 		expect(reverted.nickname).toBe("Caplump")
 		expect(await num("SELECT count(*)::int n FROM users WHERE nickname = 'tropicawhale'", [])).toBe(1)
+	})
+
+	it("markAuditFailed does not clobber an already-committed audit row", async () => {
+		await pool.query("INSERT INTO public_keys (key_id, public_key) VALUES ($1, 'x'), ($2, 'y')", [
+			OLD_KEY,
+			NEW_KEY,
+		])
+		await pool.query("INSERT INTO users (key_id) VALUES ($1)", [OLD_KEY])
+
+		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
+		if ("error" in plan) throw new Error(plan.error)
+		const auditId = await createPreviewAudit(env, {
+			sessionId: "sess-fail",
+			discordId: "disc-1",
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			counts: plan.counts,
+		})
+		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
+		if ("error" in result) throw new Error(result.error)
+
+		await markAuditFailed(env, auditId, "late failure")
+
+		const audit = await getAudit(env, auditId)
+		expect(audit?.status).toBe("committed")
+		expect(audit?.error).toBeNull()
+	})
+
+	it("refuses to restore and preserves interim activity created after commit", async () => {
+		await pool.query("INSERT INTO public_keys (key_id, public_key) VALUES ($1, 'x'), ($2, 'y')", [
+			OLD_KEY,
+			NEW_KEY,
+		])
+		const oldUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id) VALUES ($1) RETURNING id",
+			[OLD_KEY]
+		)
+		await pool.query("INSERT INTO users (key_id) VALUES ($1)", [NEW_KEY])
+		await insertLyric(oldUser.id, "vidL1")
+
+		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
+		if ("error" in plan) throw new Error(plan.error)
+		const auditId = await createPreviewAudit(env, {
+			sessionId: "sess-interim",
+			discordId: "disc-1",
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			counts: plan.counts,
+		})
+		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
+		if ("error" in result) throw new Error(result.error)
+
+		// survivor (now NEW_KEY, id = oldUser.id) casts a vote after commit
+		const l2 = await insertLyric(oldUser.id, "vidL2")
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)", [
+			l2,
+			oldUser.id,
+		])
+
+		expect(await restoreFromSnapshot(env, auditId)).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		expect(await num("SELECT count(*)::int n FROM votes WHERE lyrics_id = $1", [l2])).toBe(1)
+		expect((await getAudit(env, auditId))?.status).toBe("committed")
 	})
 })

--- a/src/db/account-migration.integration.test.ts
+++ b/src/db/account-migration.integration.test.ts
@@ -1,0 +1,298 @@
+import { readFileSync } from "node:fs"
+import pg from "pg"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { D1Compat } from "@/infra/database"
+import type { Env } from "@/types"
+import {
+	computeMigrationPlan,
+	createPreviewAudit,
+	getAudit,
+	markAuditCommitted,
+	restoreFromSnapshot,
+	runMigration,
+} from "./account-migration"
+
+const { Pool } = pg
+
+const shouldRun = process.env.RUN_INTEGRATION === "1"
+const describeIntegration = shouldRun ? describe : describe.skip
+
+const OLD_KEY = `${"a".repeat(58)}oldkey`
+const NEW_KEY = `${"b".repeat(58)}newkey`
+
+describeIntegration("account migration (integration)", () => {
+	const url = process.env.INTEGRATION_DATABASE_URL ?? process.env.DATABASE_URL
+	let pool: pg.Pool
+	let env: Env
+
+	const one = async <T>(sql: string, params: unknown[] = []): Promise<T> =>
+		(await pool.query(sql, params)).rows[0] as T
+	const num = async (sql: string, params: unknown[] = []): Promise<number> =>
+		Number((await pool.query(sql, params)).rows[0].n)
+
+	beforeAll(async () => {
+		if (!url) throw new Error("INTEGRATION_DATABASE_URL or DATABASE_URL is required")
+		pool = new Pool({ connectionString: url })
+		const schema = readFileSync(new URL("../../schema.sql", import.meta.url), "utf-8")
+		await pool.query(schema)
+		env = { DB: new D1Compat(pool) } as unknown as Env
+	})
+
+	afterAll(async () => {
+		await pool.end()
+	})
+
+	async function wipe() {
+		await pool.query("DELETE FROM migration_requests")
+		await pool.query("DELETE FROM request_fulfillments")
+		await pool.query("DELETE FROM lyrics_requests")
+		await pool.query("DELETE FROM requested_songs")
+		await pool.query("DELETE FROM votes")
+		await pool.query("DELETE FROM reports")
+		await pool.query("DELETE FROM lyrics")
+		await pool.query("DELETE FROM discord_links")
+		await pool.query("DELETE FROM users")
+		await pool.query("DELETE FROM public_keys")
+	}
+
+	async function insertLyric(submitterId: number, videoId: string): Promise<number> {
+		const row = await one<{ id: number }>(
+			`INSERT INTO lyrics (video_id, song, artist, duration, song_norm, artist_norm, lyrics, format, sync_type, submitter_id)
+			 VALUES ($1, 'Song', 'Artist', 180, 'song', 'artist', 'gz', 'lrc', 'linesync', $2) RETURNING id`,
+			[videoId, submitterId]
+		)
+		return row.id
+	}
+
+	beforeEach(wipe)
+
+	it("merges the new user into the survivor and preserves totals", async () => {
+		const OTHER_KEY = `${"c".repeat(58)}other0`
+		await pool.query(
+			"INSERT INTO public_keys (key_id, public_key) VALUES ($1, 'x'), ($2, 'y'), ($3, 'z')",
+			[OLD_KEY, NEW_KEY, OTHER_KEY]
+		)
+		const oldUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id) VALUES ($1) RETURNING id",
+			[OLD_KEY]
+		)
+		const newUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id) VALUES ($1) RETURNING id",
+			[NEW_KEY]
+		)
+		const otherUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id) VALUES ($1) RETURNING id",
+			[OTHER_KEY]
+		)
+
+		// old user submitted L1; new user submitted L2 and L3; a third party submitted L4
+		const l1 = await insertLyric(oldUser.id, "vidL1")
+		const l2 = await insertLyric(newUser.id, "vidL2")
+		const l3 = await insertLyric(newUser.id, "vidL3")
+		const l4 = await insertLyric(otherUser.id, "vidL4")
+
+		// both voted on L1 (collision); new also voted on L2/L3 (self) and L4 (not self)
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
+			l1,
+			oldUser.id,
+		])
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,-1,0)", [
+			l1,
+			newUser.id,
+		])
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)", [
+			l2,
+			newUser.id,
+		])
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
+			l3,
+			newUser.id,
+		])
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
+			l4,
+			newUser.id,
+		])
+
+		// both reported L1 (collision)
+		await pool.query(
+			"INSERT INTO reports (lyrics_id, user_id, reason) VALUES ($1,$2,'spam'),($3,$4,'other')",
+			[l1, oldUser.id, l1, newUser.id]
+		)
+
+		// a fulfillment credited to the new user
+		await pool.query(
+			"INSERT INTO request_fulfillments (video_id, lyrics_id, submitter_id, demand_snapshot, request_count_snapshot) VALUES ($1,$2,$3,1.0,1)",
+			["vidL2", l2, newUser.id]
+		)
+
+		// extension requests: both keys requested vidR (collision), new also requested vidR2
+		await pool.query(
+			"INSERT INTO requested_songs (video_id, song, artist) VALUES ('vidR','s','a'),('vidR2','s','a')"
+		)
+		await pool.query(
+			"INSERT INTO lyrics_requests (video_id, requester_id, requester_type) VALUES ('vidR',$1,'extension'),('vidR',$2,'extension'),('vidR2',$2,'extension')",
+			[OLD_KEY, NEW_KEY]
+		)
+
+		// discord link on the old key only
+		await pool.query(
+			"INSERT INTO discord_links (discord_id, key_id, discord_username) VALUES ('disc-1', $1, 'alice')",
+			[OLD_KEY]
+		)
+
+		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
+		if ("error" in plan) throw new Error(plan.error)
+		expect(plan.counts).toEqual({
+			submissions: 2,
+			votes: 4,
+			reports: 1,
+			fulfillments: 1,
+			collisions: 3, // 1 vote + 1 report + 1 request
+		})
+
+		const auditId = await createPreviewAudit(env, {
+			sessionId: "sess-1",
+			discordId: "disc-1",
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			counts: plan.counts,
+		})
+		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY })
+		if ("error" in result) throw new Error(result.error)
+		await markAuditCommitted(env, auditId, result.moved, result.snapshot)
+
+		expect(result.moved).toEqual({
+			submissions: 2,
+			votes: 4,
+			reports: 1,
+			fulfillments: 1,
+			collisionsDropped: 3,
+		})
+
+		// invariants (mirrors scripts/local/migrate-account.cjs)
+		expect(await num("SELECT count(*)::int n FROM lyrics WHERE submitter_id = $1", [oldUser.id])).toBe(3)
+		expect(await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [oldUser.id])).toBe(4) // 1+4-1
+		expect(await num("SELECT count(*)::int n FROM reports WHERE user_id = $1", [oldUser.id])).toBe(1) // 1+1-1
+		expect(await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [OLD_KEY])).toBe(0)
+		expect(await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [NEW_KEY])).toBe(1)
+		expect(await num("SELECT count(*)::int n FROM users WHERE id = $1", [newUser.id])).toBe(0)
+		const survivor = await one<{ key_id: string; vote_count: number }>(
+			"SELECT key_id, vote_count FROM users WHERE id = $1",
+			[oldUser.id]
+		)
+		expect(survivor.key_id).toBe(NEW_KEY)
+		expect(survivor.vote_count).toBe(4)
+		// is_self_vote recomputed from the merged submitter/voter relationship:
+		// L1/L2/L3 are the survivor's own submissions (self), L4 is the third party's (not self)
+		expect(
+			await num(
+				"SELECT count(*)::int n FROM votes WHERE user_id = $1 AND is_self_vote = 1",
+				[oldUser.id]
+			)
+		).toBe(3)
+		expect(
+			await num(
+				"SELECT count(*)::int n FROM votes WHERE user_id = $1 AND is_self_vote = 0",
+				[oldUser.id]
+			)
+		).toBe(1)
+		// discord link followed to the new key
+		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])).toBe(1)
+		// extension requests deduped and relabelled
+		expect(
+			await num("SELECT count(*)::int n FROM lyrics_requests WHERE requester_id = $1", [NEW_KEY])
+		).toBe(2)
+		expect(
+			await num("SELECT count(*)::int n FROM lyrics_requests WHERE requester_id = $1", [OLD_KEY])
+		).toBe(0)
+	})
+
+	it("restores the exact pre-image after a committed migration", async () => {
+		await pool.query("INSERT INTO public_keys (key_id, public_key) VALUES ($1, 'x'), ($2, 'y')", [
+			OLD_KEY,
+			NEW_KEY,
+		])
+		const oldUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id, reputation) VALUES ($1, 1.3) RETURNING id",
+			[OLD_KEY]
+		)
+		const newUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id, reputation) VALUES ($1, 0.9) RETURNING id",
+			[NEW_KEY]
+		)
+		const l1 = await insertLyric(oldUser.id, "vidL1")
+		const l2 = await insertLyric(newUser.id, "vidL2")
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
+			l1,
+			oldUser.id,
+		])
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,-1,0)", [
+			l1,
+			newUser.id,
+		])
+		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)", [
+			l2,
+			newUser.id,
+		])
+		await pool.query(
+			"INSERT INTO discord_links (discord_id, key_id, discord_username) VALUES ('disc-1', $1, 'alice')",
+			[OLD_KEY]
+		)
+
+		const before = {
+			usersOld: await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [OLD_KEY]),
+			usersNew: await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [NEW_KEY]),
+			oldVotes: await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [oldUser.id]),
+			newVotes: await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [newUser.id]),
+			l2Submitter: (await one<{ submitter_id: number }>(
+				"SELECT submitter_id FROM lyrics WHERE id = $1",
+				[l2]
+			)).submitter_id,
+			newRep: (await one<{ reputation: number }>("SELECT reputation FROM users WHERE id = $1", [
+				newUser.id,
+			])).reputation,
+		}
+
+		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
+		if ("error" in plan) throw new Error(plan.error)
+		const auditId = await createPreviewAudit(env, {
+			sessionId: "sess-2",
+			discordId: "disc-1",
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			counts: plan.counts,
+		})
+		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY })
+		if ("error" in result) throw new Error(result.error)
+		await markAuditCommitted(env, auditId, result.moved, result.snapshot)
+
+		const audit = await getAudit(env, auditId)
+		expect(audit?.status).toBe("committed")
+
+		const restore = await restoreFromSnapshot(env, auditId)
+		expect(restore).toEqual({ restored: true })
+
+		expect(await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [OLD_KEY])).toBe(
+			before.usersOld
+		)
+		expect(await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [NEW_KEY])).toBe(
+			before.usersNew
+		)
+		expect(await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [oldUser.id])).toBe(
+			before.oldVotes
+		)
+		expect(await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [newUser.id])).toBe(
+			before.newVotes
+		)
+		expect(
+			(await one<{ submitter_id: number }>("SELECT submitter_id FROM lyrics WHERE id = $1", [l2]))
+				.submitter_id
+		).toBe(before.l2Submitter)
+		expect(
+			(await one<{ reputation: number }>("SELECT reputation FROM users WHERE id = $1", [newUser.id]))
+				.reputation
+		).toBe(before.newRep)
+		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [OLD_KEY])).toBe(1)
+		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])).toBe(0)
+	})
+})

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -64,7 +64,7 @@ describe("computeMigrationPlan", () => {
 
 	it("relabel case: new key has no user, only request collisions can be non-zero", async () => {
 		const db = makeMockDB([
-			{ id: 1 }, // old user
+			{ id: 1, nickname: "oldnick" }, // old user
 			null, // new user (none)
 			{ n: 2 }, // request collisions
 		])
@@ -72,14 +72,16 @@ describe("computeMigrationPlan", () => {
 		expect(result).toEqual({
 			oldUserId: 1,
 			newUserId: null,
+			oldNickname: "oldnick",
+			newNickname: null,
 			counts: { submissions: 0, votes: 0, reports: 0, fulfillments: 0, collisions: 2 },
 		})
 	})
 
-	it("merge case: projects moved counts and total collisions", async () => {
+	it("merge case: projects moved counts, collisions, and both nicknames", async () => {
 		const db = makeMockDB([
-			{ id: 1 }, // old user
-			{ id: 2 }, // new user
+			{ id: 1, nickname: "oldnick" }, // old user
+			{ id: 2, nickname: "newnick" }, // new user
 			{ n: 5 }, // submissions on new user
 			{ n: 9 }, // votes on new user
 			{ n: 1 }, // reports on new user
@@ -92,6 +94,8 @@ describe("computeMigrationPlan", () => {
 		expect(result).toEqual({
 			oldUserId: 1,
 			newUserId: 2,
+			oldNickname: "oldnick",
+			newNickname: "newnick",
 			counts: { submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisions: 3 + 1 + 4 },
 		})
 	})
@@ -110,7 +114,7 @@ describe("computeMigrationPlan", () => {
 	})
 })
 
-function mergeSeed() {
+function mergeSeed(): unknown[] {
 	return [
 		{ id: 1 }, // old user
 		{ id: 2 }, // new user
@@ -231,6 +235,45 @@ describe("runMigration (merge case)", () => {
 		const db = makeMockDB([null])
 		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
 		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
+	})
+})
+
+describe("runMigration nickname handling", () => {
+	function seedWithNewNickname() {
+		const seed = mergeSeed()
+		seed[4] = [
+			{ id: 1, key_id: "oldkey", nickname: "oldnick" },
+			{ id: 2, key_id: "newkey", nickname: "newnick" },
+		]
+		return seed
+	}
+
+	it("keeps the survivor's nickname by default (no nickname update)", async () => {
+		const db = makeMockDB(seedWithNewNickname())
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
+	})
+
+	it("applies the new key's nickname to the survivor when keepNickname is 'new'", async () => {
+		const db = makeMockDB(seedWithNewNickname())
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new" })
+		const call = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
+		expect(call).toBeDefined()
+		expect(call?.params[0]).toBe("newnick")
+		expect(call?.params[call.params.length - 1]).toBe(1) // survivor id
+		// nickname is applied only after the new user row is deleted (frees the unique nickname_lower)
+		expect(idx(db.calls, "DELETE FROM users")).toBeLessThan(idx(db.calls, "UPDATE users SET nickname"))
+	})
+
+	it("falls back to the old nickname when keepNickname is 'new' but the new key has none", async () => {
+		const seed = mergeSeed()
+		seed[4] = [
+			{ id: 1, key_id: "oldkey", nickname: "oldnick" },
+			{ id: 2, key_id: "newkey", nickname: null },
+		]
+		const db = makeMockDB(seed)
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new" })
+		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
 	})
 })
 

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -4,7 +4,6 @@ import {
 	computeMigrationPlan,
 	createPreviewAudit,
 	getAudit,
-	markAuditCommitted,
 	markAuditFailed,
 	restoreFromSnapshot,
 	runMigration,
@@ -151,7 +150,7 @@ function mergeSeed(): unknown[] {
 describe("runMigration (merge case)", () => {
 	it("returns moved counts and collisionsDropped from the snapshot and collision queries", async () => {
 		const db = makeMockDB(mergeSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		if ("error" in result) throw new Error(`unexpected error: ${result.error}`)
 		expect(result.moved).toEqual({
 			submissions: 2,
@@ -164,7 +163,7 @@ describe("runMigration (merge case)", () => {
 
 	it("captures a snapshot of every touched table", async () => {
 		const db = makeMockDB(mergeSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		if ("error" in result) throw new Error("unexpected error")
 		expect(Object.keys(result.snapshot).sort()).toEqual(
 			[
@@ -183,7 +182,7 @@ describe("runMigration (merge case)", () => {
 
 	it("reports affected lyrics and video ids for cache busting and score recompute", async () => {
 		const db = makeMockDB(mergeSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		if ("error" in result) throw new Error("unexpected error")
 		expect(result.affectedLyricsIds).toEqual(expect.arrayContaining([10, 11, 12, 20, 21]))
 		expect(result.affectedVideoIds).toEqual(expect.arrayContaining(["vidA", "vidB", "vidC"]))
@@ -191,7 +190,7 @@ describe("runMigration (merge case)", () => {
 
 	it("dedupes votes/reports before re-pointing, deletes the new user before relabel", async () => {
 		const db = makeMockDB(mergeSeed())
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		const calls = db.calls
 		expect(idx(calls, "DELETE FROM votes")).toBeLessThan(idx(calls, "UPDATE votes SET user_id"))
 		expect(idx(calls, "DELETE FROM reports")).toBeLessThan(idx(calls, "UPDATE reports SET user_id"))
@@ -204,7 +203,7 @@ describe("runMigration (merge case)", () => {
 
 	it("regression: lyrics_requests dedup keeps the survivor's (old key) request and drops the new key's dup", async () => {
 		const db = makeMockDB(mergeSeed())
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		const del = db.calls.find(
 			(c) => c.sql.includes("DELETE FROM lyrics_requests") && c.sql.includes("requester_type")
 		)
@@ -220,20 +219,24 @@ describe("runMigration (merge case)", () => {
 			{ discord_id: "disc-old", key_id: "oldkey" }, // old link
 			{ discord_id: "disc-new", key_id: "newkey" }, // new link
 		])
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		expect(result).toEqual({ error: "BOTH_KEYS_LINKED" })
 		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(false)
 	})
 
 	it("rejects SAME_KEY defensively", async () => {
 		const db = makeMockDB([])
-		const result = await runMigration(makeEnv(db), { oldKey: "samekey", newKey: "samekey" })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "samekey",
+			newKey: "samekey",
+			migrationId: 7,
+		})
 		expect(result).toEqual({ error: "SAME_KEY" })
 	})
 
 	it("reports OLD_KEY_NO_USER when the old key has no user row", async () => {
 		const db = makeMockDB([null])
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
 	})
 })
@@ -250,13 +253,13 @@ describe("runMigration nickname handling", () => {
 
 	it("keeps the survivor's nickname by default (no nickname update)", async () => {
 		const db = makeMockDB(seedWithNewNickname())
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
 	})
 
 	it("applies the new key's nickname to the survivor when keepNickname is 'new'", async () => {
 		const db = makeMockDB(seedWithNewNickname())
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new" })
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
 		const call = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
 		expect(call).toBeDefined()
 		expect(call?.params[0]).toBe("newnick")
@@ -272,8 +275,34 @@ describe("runMigration nickname handling", () => {
 			{ id: 2, key_id: "newkey", nickname: null },
 		]
 		const db = makeMockDB(seed)
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new" })
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
 		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
+	})
+})
+
+describe("runMigration audit", () => {
+	it("writes the committed audit row inside the migration transaction", async () => {
+		const db = makeMockDB(mergeSeed())
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const auditUpdate = db.calls.find(
+			(c) => c.sql.includes("UPDATE migration_requests") && c.sql.includes("status = 'committed'")
+		)
+		expect(auditUpdate).toBeDefined()
+		expect(auditUpdate?.params[auditUpdate.params.length - 1]).toBe(7)
+		expect(
+			auditUpdate?.params.some((p) => typeof p === "string" && p.includes('"users"'))
+		).toBe(true)
+	})
+
+	it("does not write a committed audit row on an error short-circuit", async () => {
+		const db = makeMockDB([null]) // old user missing
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
+		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
+		expect(db.calls.some((c) => c.sql.includes("UPDATE migration_requests"))).toBe(false)
 	})
 })
 
@@ -297,7 +326,7 @@ describe("runMigration (relabel case)", () => {
 
 	it("does not re-point votes or reports (no colliding user row), but relabels requests and the key", async () => {
 		const db = makeMockDB(relabelSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		if ("error" in result) throw new Error("unexpected error")
 		expect(result.moved).toEqual({
 			submissions: 0,
@@ -310,6 +339,30 @@ describe("runMigration (relabel case)", () => {
 		expect(db.calls.some((c) => c.sql.includes("DELETE FROM users"))).toBe(false)
 		expect(idx(db.calls, "UPDATE lyrics_requests SET requester_id")).toBeGreaterThanOrEqual(0)
 		expect(idx(db.calls, "UPDATE users SET key_id")).toBeGreaterThanOrEqual(0)
+	})
+
+	it("regression: does not count null-submitter lyrics (deleted-by rows) as moved submissions", async () => {
+		const db = makeMockDB([
+			{ id: 1 }, // old user
+			null, // new user (relabel case)
+			{ discord_id: "disc-old", key_id: "oldkey" }, // old link
+			null, // new link
+			[{ id: 1, key_id: "oldkey" }], // users snapshot
+			[], // votes snapshot
+			[], // reports snapshot
+			[{ id: 99, submitter_id: null, video_id: "vidX" }], // lyrics snapshot: pulled in via deleted_by_user_id
+			[], // fulfillments snapshot
+			[{ discord_id: "disc-old", key_id: "oldkey" }], // discord snapshot
+			[], // requests snapshot
+			{ n: 0 }, // request collisions
+		])
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
+		if ("error" in result) throw new Error("unexpected error")
+		expect(result.moved.submissions).toBe(0)
 	})
 })
 
@@ -331,26 +384,12 @@ describe("migration audit", () => {
 		expect(insert.params).toEqual(["sess-1", "disc-1", "oldkey", "newkey", 5, 9, 1, 2, 3])
 	})
 
-	it("markAuditCommitted writes committed status, moved counts, and the JSON snapshot", async () => {
-		const db = makeMockDB([])
-		const snapshot = { users: [{ id: 1 }] }
-		await markAuditCommitted(
-			makeEnv(db),
-			42,
-			{ submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisionsDropped: 3 },
-			snapshot as never
-		)
-		const update = db.calls[0]
-		expect(update.sql).toContain("status = 'committed'")
-		expect(update.params).toContain(JSON.stringify(snapshot))
-		expect(update.params[update.params.length - 1]).toBe(42)
-	})
-
 	it("markAuditFailed records the error and failed status", async () => {
 		const db = makeMockDB([])
 		await markAuditFailed(makeEnv(db), 42, "boom")
 		const update = db.calls[0]
 		expect(update.sql).toContain("status = 'failed'")
+		expect(update.sql).toContain("status <> 'committed'")
 		expect(update.params).toEqual(["boom", 42])
 	})
 
@@ -421,6 +460,22 @@ describe("restoreFromSnapshot", () => {
 	it("refuses to restore a non-committed migration", async () => {
 		const db = makeMockDB([{ id: 7, status: "preview", old_key: "o", new_key: "n", snapshot: {} }])
 		expect(await restoreFromSnapshot(makeEnv(db), 7)).toEqual({ error: "NOT_COMMITTED" })
+	})
+
+	it("refuses and mutates nothing when the survivor has interim activity after commit", async () => {
+		const db = makeMockDB([
+			committedAuditRow(), // getAudit
+			[{ id: 11 }, { id: 999 }], // current votes: snapshot's 11 + interim 999
+			// current reports all() -> [] from the empty queue
+		])
+		const result = await restoreFromSnapshot(makeEnv(db), 7)
+		expect(result).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		expect(
+			db.calls.some(
+				(c) =>
+					c.sql.startsWith("DELETE") || c.sql.startsWith("UPDATE") || c.sql.startsWith("INSERT")
+			)
+		).toBe(false)
 	})
 
 	it("reverses the migration: survivor first, new user re-inserted, leaf tables delete+reinsert, lyrics updated", async () => {

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 import type { Env } from "@/types"
-import { computeMigrationPlan } from "./account-migration"
+import { computeMigrationPlan, runMigration } from "./account-migration"
+
+function idx(calls: { sql: string }[], needle: string): number {
+	return calls.findIndex((c) => c.sql.includes(needle))
+}
 
 interface DBCall {
 	sql: string
@@ -27,7 +31,6 @@ function makeMockDB(queue: unknown[] = []) {
 						},
 						async run(): Promise<void> {
 							calls.push({ sql, params: args })
-							queue.shift()
 						},
 					}
 				},
@@ -96,5 +99,165 @@ describe("computeMigrationPlan", () => {
 			(c) => c.sql.includes("votes") && c.sql.includes("lyrics_id IN (SELECT lyrics_id FROM votes")
 		)
 		expect(voteCollision).toBeDefined()
+	})
+})
+
+function mergeSeed() {
+	return [
+		{ id: 1 }, // old user
+		{ id: 2 }, // new user
+		{ discord_id: "disc-old", key_id: "oldkey" }, // old link
+		null, // new link
+		[
+			{ id: 1, key_id: "oldkey" },
+			{ id: 2, key_id: "newkey" },
+		], // users snapshot
+		[
+			{ user_id: 1, lyrics_id: 10 },
+			{ user_id: 1, lyrics_id: 11 },
+			{ user_id: 2, lyrics_id: 11 },
+			{ user_id: 2, lyrics_id: 12 },
+		], // votes snapshot
+		[{ user_id: 2, lyrics_id: 11 }], // reports snapshot (new user has 1)
+		[
+			{ id: 10, submitter_id: 1, video_id: "vidA" },
+			{ id: 20, submitter_id: 2, video_id: "vidB" },
+			{ id: 21, submitter_id: 2, video_id: "vidC" },
+		], // lyrics snapshot
+		[{ submitter_id: 2 }, { submitter_id: 2 }, { submitter_id: 1 }], // fulfillments snapshot
+		[{ discord_id: "disc-old", key_id: "oldkey" }], // discord snapshot
+		[
+			{ requester_id: "oldkey", requester_type: "extension", video_id: "vidA" },
+			{ requester_id: "newkey", requester_type: "extension", video_id: "vidA" },
+		], // requests snapshot
+		{ n: 1 }, // vote collisions
+		{ n: 0 }, // report collisions
+		{ n: 1 }, // request collisions
+	]
+}
+
+describe("runMigration (merge case)", () => {
+	it("returns moved counts and collisionsDropped from the snapshot and collision queries", async () => {
+		const db = makeMockDB(mergeSeed())
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		if ("error" in result) throw new Error(`unexpected error: ${result.error}`)
+		expect(result.moved).toEqual({
+			submissions: 2,
+			votes: 2,
+			reports: 1,
+			fulfillments: 2,
+			collisionsDropped: 2,
+		})
+	})
+
+	it("captures a snapshot of every touched table", async () => {
+		const db = makeMockDB(mergeSeed())
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		if ("error" in result) throw new Error("unexpected error")
+		expect(Object.keys(result.snapshot).sort()).toEqual(
+			[
+				"discord_links",
+				"lyrics",
+				"lyrics_requests",
+				"reports",
+				"request_fulfillments",
+				"users",
+				"votes",
+			].sort()
+		)
+		expect(result.snapshot.users).toHaveLength(2)
+		expect(result.snapshot.votes).toHaveLength(4)
+	})
+
+	it("reports affected lyrics and video ids for cache busting and score recompute", async () => {
+		const db = makeMockDB(mergeSeed())
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		if ("error" in result) throw new Error("unexpected error")
+		expect(result.affectedLyricsIds).toEqual(expect.arrayContaining([10, 11, 12, 20, 21]))
+		expect(result.affectedVideoIds).toEqual(expect.arrayContaining(["vidA", "vidB", "vidC"]))
+	})
+
+	it("dedupes votes/reports before re-pointing, deletes the new user before relabel", async () => {
+		const db = makeMockDB(mergeSeed())
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const calls = db.calls
+		expect(idx(calls, "DELETE FROM votes")).toBeLessThan(idx(calls, "UPDATE votes SET user_id"))
+		expect(idx(calls, "DELETE FROM reports")).toBeLessThan(idx(calls, "UPDATE reports SET user_id"))
+		expect(idx(calls, "DELETE FROM users")).toBeLessThan(idx(calls, "UPDATE users SET key_id"))
+		expect(idx(calls, "UPDATE users SET key_id")).toBeGreaterThanOrEqual(0)
+		expect(idx(calls, "UPDATE discord_links SET key_id")).toBeGreaterThanOrEqual(0)
+		expect(idx(calls, "is_self_vote")).toBeGreaterThan(idx(calls, "UPDATE users SET key_id"))
+		expect(idx(calls, "avg_vote")).toBeGreaterThan(idx(calls, "is_self_vote"))
+	})
+
+	it("regression: lyrics_requests dedup keeps the survivor's (old key) request and drops the new key's dup", async () => {
+		const db = makeMockDB(mergeSeed())
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		const del = db.calls.find(
+			(c) => c.sql.includes("DELETE FROM lyrics_requests") && c.sql.includes("requester_type")
+		)
+		expect(del).toBeDefined()
+		// the delete targets the NEW key's rows (first bound param), keeping the old key's
+		expect(del?.params[0]).toBe("newkey")
+	})
+
+	it("short-circuits with BOTH_KEYS_LINKED and mutates nothing when both keys hold a discord link", async () => {
+		const db = makeMockDB([
+			{ id: 1 }, // old user
+			{ id: 2 }, // new user
+			{ discord_id: "disc-old", key_id: "oldkey" }, // old link
+			{ discord_id: "disc-new", key_id: "newkey" }, // new link
+		])
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		expect(result).toEqual({ error: "BOTH_KEYS_LINKED" })
+		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(false)
+	})
+
+	it("rejects SAME_KEY defensively", async () => {
+		const db = makeMockDB([])
+		const result = await runMigration(makeEnv(db), { oldKey: "samekey", newKey: "samekey" })
+		expect(result).toEqual({ error: "SAME_KEY" })
+	})
+
+	it("reports OLD_KEY_NO_USER when the old key has no user row", async () => {
+		const db = makeMockDB([null])
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
+	})
+})
+
+describe("runMigration (relabel case)", () => {
+	function relabelSeed() {
+		return [
+			{ id: 1 }, // old user
+			null, // new user (none)
+			{ discord_id: "disc-old", key_id: "oldkey" }, // old link
+			null, // new link
+			[{ id: 1, key_id: "oldkey" }], // users snapshot
+			[{ user_id: 1, lyrics_id: 10 }], // votes snapshot
+			[], // reports snapshot
+			[{ id: 10, submitter_id: 1, video_id: "vidA" }], // lyrics snapshot
+			[], // fulfillments snapshot
+			[{ discord_id: "disc-old", key_id: "oldkey" }], // discord snapshot
+			[{ requester_id: "oldkey", requester_type: "extension", video_id: "vidA" }], // requests snapshot
+			{ n: 0 }, // request collisions
+		]
+	}
+
+	it("does not re-point votes or reports (no colliding user row), but relabels requests and the key", async () => {
+		const db = makeMockDB(relabelSeed())
+		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey" })
+		if ("error" in result) throw new Error("unexpected error")
+		expect(result.moved).toEqual({
+			submissions: 0,
+			votes: 0,
+			reports: 0,
+			fulfillments: 0,
+			collisionsDropped: 0,
+		})
+		expect(db.calls.some((c) => c.sql.includes("UPDATE votes SET user_id"))).toBe(false)
+		expect(db.calls.some((c) => c.sql.includes("DELETE FROM users"))).toBe(false)
+		expect(idx(db.calls, "UPDATE lyrics_requests SET requester_id")).toBeGreaterThanOrEqual(0)
+		expect(idx(db.calls, "UPDATE users SET key_id")).toBeGreaterThanOrEqual(0)
 	})
 })

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+import type { Env } from "@/types"
+import { computeMigrationPlan } from "./account-migration"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						getSql: () => sql,
+						getParams: () => args,
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							return (queue.shift() as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							return { results: (queue.shift() as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+							queue.shift()
+						},
+					}
+				},
+			}
+		},
+		async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+			return fn(db)
+		},
+	}
+	return db
+}
+
+function makeEnv(db: ReturnType<typeof makeMockDB>): Env {
+	return { DB: db as unknown as Env["DB"] } as unknown as Env
+}
+
+describe("computeMigrationPlan", () => {
+	it("reports OLD_KEY_NO_USER when the old key has no users row", async () => {
+		const db = makeMockDB([null])
+		const result = await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
+		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
+	})
+
+	it("relabel case: new key has no user, only request collisions can be non-zero", async () => {
+		const db = makeMockDB([
+			{ id: 1 }, // old user
+			null, // new user (none)
+			{ n: 2 }, // request collisions
+		])
+		const result = await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
+		expect(result).toEqual({
+			oldUserId: 1,
+			newUserId: null,
+			counts: { submissions: 0, votes: 0, reports: 0, fulfillments: 0, collisions: 2 },
+		})
+	})
+
+	it("merge case: projects moved counts and total collisions", async () => {
+		const db = makeMockDB([
+			{ id: 1 }, // old user
+			{ id: 2 }, // new user
+			{ n: 5 }, // submissions on new user
+			{ n: 9 }, // votes on new user
+			{ n: 1 }, // reports on new user
+			{ n: 2 }, // fulfillments on new user
+			{ n: 3 }, // vote collisions
+			{ n: 1 }, // report collisions
+			{ n: 4 }, // request collisions
+		])
+		const result = await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
+		expect(result).toEqual({
+			oldUserId: 1,
+			newUserId: 2,
+			counts: { submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisions: 3 + 1 + 4 },
+		})
+	})
+
+	it("scopes request collisions to extension requesters and the collision subquery", async () => {
+		const db = makeMockDB([{ id: 1 }, { id: 2 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }])
+		await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
+		const reqCall = db.calls.find(
+			(c) => c.sql.includes("lyrics_requests") && c.sql.toLowerCase().includes("count")
+		)
+		expect(reqCall?.sql).toContain("requester_type = 'extension'")
+		const voteCollision = db.calls.find(
+			(c) => c.sql.includes("votes") && c.sql.includes("lyrics_id IN (SELECT lyrics_id FROM votes")
+		)
+		expect(voteCollision).toBeDefined()
+	})
+})

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest"
 import type { Env } from "@/types"
-import { computeMigrationPlan, runMigration } from "./account-migration"
+import {
+	computeMigrationPlan,
+	createPreviewAudit,
+	getAudit,
+	markAuditCommitted,
+	markAuditFailed,
+	restoreFromSnapshot,
+	runMigration,
+} from "./account-migration"
 
 function idx(calls: { sql: string }[], needle: string): number {
 	return calls.findIndex((c) => c.sql.includes(needle))
@@ -259,5 +267,132 @@ describe("runMigration (relabel case)", () => {
 		expect(db.calls.some((c) => c.sql.includes("DELETE FROM users"))).toBe(false)
 		expect(idx(db.calls, "UPDATE lyrics_requests SET requester_id")).toBeGreaterThanOrEqual(0)
 		expect(idx(db.calls, "UPDATE users SET key_id")).toBeGreaterThanOrEqual(0)
+	})
+})
+
+describe("migration audit", () => {
+	it("createPreviewAudit inserts a preview row with projected counts and returns its id", async () => {
+		const db = makeMockDB([{ id: 42 }])
+		const id = await createPreviewAudit(makeEnv(db), {
+			sessionId: "sess-1",
+			discordId: "disc-1",
+			oldKey: "oldkey",
+			newKey: "newkey",
+			counts: { submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisions: 3 },
+		})
+		expect(id).toBe(42)
+		const insert = db.calls[0]
+		expect(insert.sql).toContain("INSERT INTO migration_requests")
+		expect(insert.sql).toContain("'preview'")
+		expect(insert.sql).toContain("RETURNING id")
+		expect(insert.params).toEqual(["sess-1", "disc-1", "oldkey", "newkey", 5, 9, 1, 2, 3])
+	})
+
+	it("markAuditCommitted writes committed status, moved counts, and the JSON snapshot", async () => {
+		const db = makeMockDB([])
+		const snapshot = { users: [{ id: 1 }] }
+		await markAuditCommitted(
+			makeEnv(db),
+			42,
+			{ submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisionsDropped: 3 },
+			snapshot as never
+		)
+		const update = db.calls[0]
+		expect(update.sql).toContain("status = 'committed'")
+		expect(update.params).toContain(JSON.stringify(snapshot))
+		expect(update.params[update.params.length - 1]).toBe(42)
+	})
+
+	it("markAuditFailed records the error and failed status", async () => {
+		const db = makeMockDB([])
+		await markAuditFailed(makeEnv(db), 42, "boom")
+		const update = db.calls[0]
+		expect(update.sql).toContain("status = 'failed'")
+		expect(update.params).toEqual(["boom", 42])
+	})
+
+	it("getAudit selects the row by id", async () => {
+		const db = makeMockDB([{ id: 42, status: "committed" }])
+		const row = await getAudit(makeEnv(db), 42)
+		expect(row).toEqual({ id: 42, status: "committed" })
+		expect(db.calls[0].sql).toContain("FROM migration_requests")
+	})
+})
+
+function committedAuditRow() {
+	return {
+		id: 7,
+		status: "committed",
+		old_key: "oldkey",
+		new_key: "newkey",
+		snapshot: {
+			users: [
+				{
+					id: 1,
+					key_id: "oldkey",
+					reputation: 1.2,
+					vote_count: 5,
+					avg_vote: 0.4,
+					created_at: 100,
+					nickname: "old",
+					nickname_updated_at: 90,
+				},
+				{
+					id: 2,
+					key_id: "newkey",
+					reputation: 1.0,
+					vote_count: 2,
+					avg_vote: 0.0,
+					created_at: 200,
+					nickname: null,
+					nickname_updated_at: null,
+				},
+			],
+			votes: [{ id: 11, lyrics_id: 10, user_id: 1, vote: 1, is_self_vote: 0, created_at: 100 }],
+			reports: [],
+			lyrics: [{ id: 10, submitter_id: 1, deleted_by_user_id: null, video_id: "vidA" }],
+			request_fulfillments: [{ id: 5, submitter_id: 1 }],
+			discord_links: [
+				{ discord_id: "disc-old", key_id: "oldkey", discord_username: "u", linked_at: 100 },
+			],
+			lyrics_requests: [
+				{
+					id: 3,
+					video_id: "vidA",
+					requester_id: "oldkey",
+					requester_type: "extension",
+					weight: 1.0,
+					created_at: 100,
+				},
+			],
+		},
+	}
+}
+
+describe("restoreFromSnapshot", () => {
+	it("returns NOT_FOUND when the audit row is missing", async () => {
+		const db = makeMockDB([null])
+		expect(await restoreFromSnapshot(makeEnv(db), 999)).toEqual({ error: "NOT_FOUND" })
+	})
+
+	it("refuses to restore a non-committed migration", async () => {
+		const db = makeMockDB([{ id: 7, status: "preview", old_key: "o", new_key: "n", snapshot: {} }])
+		expect(await restoreFromSnapshot(makeEnv(db), 7)).toEqual({ error: "NOT_COMMITTED" })
+	})
+
+	it("reverses the migration: survivor first, new user re-inserted, leaf tables delete+reinsert, lyrics updated", async () => {
+		const db = makeMockDB([committedAuditRow()])
+		const result = await restoreFromSnapshot(makeEnv(db), 7)
+		expect(result).toEqual({ restored: true })
+
+		const calls = db.calls
+		expect(idx(calls, "UPDATE users SET key_id")).toBeLessThan(idx(calls, "INSERT INTO users"))
+		expect(idx(calls, "DELETE FROM votes")).toBeLessThan(idx(calls, "INSERT INTO votes"))
+		expect(idx(calls, "DELETE FROM discord_links")).toBeLessThan(
+			idx(calls, "INSERT INTO discord_links")
+		)
+		// lyrics restored by targeted UPDATE, never deleted (would cascade its votes/reports)
+		expect(calls.some((c) => c.sql.includes("DELETE FROM lyrics "))).toBe(false)
+		expect(idx(calls, "UPDATE lyrics SET submitter_id")).toBeGreaterThanOrEqual(0)
 	})
 })

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -135,15 +135,11 @@ async function countTx(tx: D1Compat, sql: string, params: unknown[]): Promise<nu
 	return row?.n ?? 0
 }
 
-// Move the OLD identity's whole history onto NEW key in one transaction.
-// The OLD users row survives (it owns the history) and is relabelled to NEW key;
-// if NEW already had its own users row, its activity is folded in first, dropping
-// duplicate votes/reports on the UNIQUE(lyrics_id, user_id) constraint.
 export async function runMigration(
 	env: Env,
-	params: { oldKey: string; newKey: string; keepNickname?: "old" | "new" }
+	params: { oldKey: string; newKey: string; keepNickname?: "old" | "new"; migrationId: number }
 ): Promise<MigrationResult | MigrationRunError> {
-	const { oldKey, newKey, keepNickname } = params
+	const { oldKey, newKey, keepNickname, migrationId } = params
 	if (oldKey === newKey) return { error: "SAME_KEY" }
 
 	return env.DB.transaction(async (tx) => {
@@ -199,7 +195,7 @@ export async function runMigration(
 		const fulfillmentRows = snapshot.request_fulfillments as { submitter_id: number | null }[]
 
 		const moved = {
-			submissions: lyricsRows.filter((r) => r.submitter_id === newId).length,
+			submissions: newId !== null ? lyricsRows.filter((r) => r.submitter_id === newId).length : 0,
 			votes: votesRows.filter((r) => r.user_id === newId).length,
 			reports: reportsRows.filter((r) => r.user_id === newId).length,
 			fulfillments: fulfillmentRows.filter((r) => r.submitter_id === newId).length,
@@ -320,6 +316,26 @@ export async function runMigration(
 
 		moved.collisionsDropped = voteCollisions + reportCollisions + reqCollisions
 
+		await tx
+			.prepare(
+				`UPDATE migration_requests SET
+					status = 'committed',
+					moved_submissions = ?, moved_votes = ?, moved_reports = ?, moved_fulfillments = ?,
+					collisions_dropped = ?, snapshot = ?::jsonb, updated_at = ?
+				 WHERE id = ?`
+			)
+			.bind(
+				moved.submissions,
+				moved.votes,
+				moved.reports,
+				moved.fulfillments,
+				moved.collisionsDropped,
+				JSON.stringify(snapshot),
+				now(),
+				migrationId
+			)
+			.run()
+
 		return { moved, snapshot, affectedLyricsIds, affectedVideoIds }
 	})
 }
@@ -375,36 +391,10 @@ export async function createPreviewAudit(
 	return row!.id
 }
 
-export async function markAuditCommitted(
-	env: Env,
-	id: number,
-	moved: MigrationResult["moved"],
-	snapshot: MigrationSnapshot
-): Promise<void> {
-	await env.DB.prepare(
-		`UPDATE migration_requests SET
-			status = 'committed',
-			moved_submissions = ?, moved_votes = ?, moved_reports = ?, moved_fulfillments = ?,
-			collisions_dropped = ?, snapshot = ?::jsonb, updated_at = ?
-		 WHERE id = ?`
-	)
-		.bind(
-			moved.submissions,
-			moved.votes,
-			moved.reports,
-			moved.fulfillments,
-			moved.collisionsDropped,
-			JSON.stringify(snapshot),
-			now(),
-			id
-		)
-		.run()
-}
-
 export async function markAuditFailed(env: Env, id: number, error: string): Promise<void> {
 	await env.DB.prepare(
 		"UPDATE migration_requests SET status = 'failed', error = ?, updated_at = " +
-			"EXTRACT(EPOCH FROM NOW())::INTEGER WHERE id = ?"
+			"EXTRACT(EPOCH FROM NOW())::INTEGER WHERE id = ? AND status <> 'committed'"
 	)
 		.bind(error, id)
 		.run()
@@ -466,13 +456,11 @@ interface SnapRequest {
 	created_at: number
 }
 
-// Reverse of runMigration, driven entirely by the stored pre-image. Order matters:
-// relabel the survivor back to the old key before re-inserting the new user row (both
-// hold the same key at commit time), and never DELETE lyrics (it would cascade its votes).
+// Restores lyrics by UPDATE, never DELETE: deleting a lyric cascades to its votes/reports.
 export async function restoreFromSnapshot(
 	env: Env,
 	migrationId: number
-): Promise<{ restored: true } | { error: "NOT_FOUND" | "NOT_COMMITTED" }> {
+): Promise<{ restored: true } | { error: "NOT_FOUND" | "NOT_COMMITTED" | "HAS_INTERIM_ACTIVITY" }> {
 	const audit = await getAudit(env, migrationId)
 	if (!audit) return { error: "NOT_FOUND" }
 	if (audit.status !== "committed" || !audit.snapshot) return { error: "NOT_COMMITTED" }
@@ -487,6 +475,25 @@ export async function restoreFromSnapshot(
 	const ids = newSnap ? [oldSnap.id, newSnap.id] : [oldSnap.id]
 
 	return env.DB.transaction(async (tx) => {
+		const snapVoteIds = new Set((snap.votes as SnapVote[]).map((v) => v.id))
+		const snapReportIds = new Set((snap.reports as SnapReport[]).map((r) => r.id))
+		const currentVotes = await all<{ id: number }>(
+			tx,
+			"SELECT id FROM votes WHERE user_id = ANY(?)",
+			[ids]
+		)
+		const currentReports = await all<{ id: number }>(
+			tx,
+			"SELECT id FROM reports WHERE user_id = ANY(?)",
+			[ids]
+		)
+		if (
+			currentVotes.some((v) => !snapVoteIds.has(v.id)) ||
+			currentReports.some((r) => !snapReportIds.has(r.id))
+		) {
+			return { error: "HAS_INTERIM_ACTIVITY" } as const
+		}
+
 		await tx
 			.prepare(
 				"UPDATE users SET key_id = ?, reputation = ?, vote_count = ?, avg_vote = ?, nickname = ?, nickname_updated_at = ? WHERE id = ?"

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -1,0 +1,85 @@
+import type { Env } from "@/types"
+import type { MigrationCounts } from "@/utils/migration-session"
+
+export interface MigrationResolved {
+	oldUserId: number
+	newUserId: number | null
+	counts: MigrationCounts
+}
+
+async function count(env: Env, sql: string, params: unknown[]): Promise<number> {
+	const row = await env.DB.prepare(sql)
+		.bind(...params)
+		.first<{ n: number }>()
+	return row?.n ?? 0
+}
+
+// Reads only: resolve the two identities and project what a commit would move.
+export async function computeMigrationPlan(
+	env: Env,
+	oldKey: string,
+	newKey: string
+): Promise<MigrationResolved | { error: "OLD_KEY_NO_USER" }> {
+	const oldUser = await env.DB.prepare("SELECT id FROM users WHERE key_id = ?")
+		.bind(oldKey)
+		.first<{ id: number }>()
+	if (!oldUser) return { error: "OLD_KEY_NO_USER" }
+	const oldUserId = oldUser.id
+
+	const newUser = await env.DB.prepare("SELECT id FROM users WHERE key_id = ?")
+		.bind(newKey)
+		.first<{ id: number }>()
+	const newUserId = newUser?.id ?? null
+
+	let submissions = 0
+	let votes = 0
+	let reports = 0
+	let fulfillments = 0
+	let voteCollisions = 0
+	let reportCollisions = 0
+
+	if (newUserId !== null) {
+		submissions = await count(env, "SELECT COUNT(*)::int AS n FROM lyrics WHERE submitter_id = ?", [
+			newUserId,
+		])
+		votes = await count(env, "SELECT COUNT(*)::int AS n FROM votes WHERE user_id = ?", [newUserId])
+		reports = await count(env, "SELECT COUNT(*)::int AS n FROM reports WHERE user_id = ?", [
+			newUserId,
+		])
+		fulfillments = await count(
+			env,
+			"SELECT COUNT(*)::int AS n FROM request_fulfillments WHERE submitter_id = ?",
+			[newUserId]
+		)
+		voteCollisions = await count(
+			env,
+			"SELECT COUNT(*)::int AS n FROM votes WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM votes WHERE user_id = ?)",
+			[newUserId, oldUserId]
+		)
+		reportCollisions = await count(
+			env,
+			"SELECT COUNT(*)::int AS n FROM reports WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM reports WHERE user_id = ?)",
+			[newUserId, oldUserId]
+		)
+	}
+
+	const reqCollisions = await count(
+		env,
+		`SELECT COUNT(*)::int AS n FROM lyrics_requests
+		 WHERE requester_id = ? AND requester_type = 'extension'
+		   AND video_id IN (SELECT video_id FROM lyrics_requests WHERE requester_id = ? AND requester_type = 'extension')`,
+		[newKey, oldKey]
+	)
+
+	return {
+		oldUserId,
+		newUserId,
+		counts: {
+			submissions,
+			votes,
+			reports,
+			fulfillments,
+			collisions: voteCollisions + reportCollisions + reqCollisions,
+		},
+	}
+}

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -7,6 +7,8 @@ const now = () => Math.floor(Date.now() / 1000)
 export interface MigrationResolved {
 	oldUserId: number
 	newUserId: number | null
+	oldNickname: string | null
+	newNickname: string | null
 	counts: MigrationCounts
 }
 
@@ -51,15 +53,15 @@ export async function computeMigrationPlan(
 	oldKey: string,
 	newKey: string
 ): Promise<MigrationResolved | { error: "OLD_KEY_NO_USER" }> {
-	const oldUser = await env.DB.prepare("SELECT id FROM users WHERE key_id = ?")
+	const oldUser = await env.DB.prepare("SELECT id, nickname FROM users WHERE key_id = ?")
 		.bind(oldKey)
-		.first<{ id: number }>()
+		.first<{ id: number; nickname: string | null }>()
 	if (!oldUser) return { error: "OLD_KEY_NO_USER" }
 	const oldUserId = oldUser.id
 
-	const newUser = await env.DB.prepare("SELECT id FROM users WHERE key_id = ?")
+	const newUser = await env.DB.prepare("SELECT id, nickname FROM users WHERE key_id = ?")
 		.bind(newKey)
-		.first<{ id: number }>()
+		.first<{ id: number; nickname: string | null }>()
 	const newUserId = newUser?.id ?? null
 
 	let submissions = 0
@@ -105,6 +107,8 @@ export async function computeMigrationPlan(
 	return {
 		oldUserId,
 		newUserId,
+		oldNickname: oldUser.nickname ?? null,
+		newNickname: newUser?.nickname ?? null,
 		counts: {
 			submissions,
 			votes,
@@ -137,9 +141,9 @@ async function countTx(tx: D1Compat, sql: string, params: unknown[]): Promise<nu
 // duplicate votes/reports on the UNIQUE(lyrics_id, user_id) constraint.
 export async function runMigration(
 	env: Env,
-	params: { oldKey: string; newKey: string }
+	params: { oldKey: string; newKey: string; keepNickname?: "old" | "new" }
 ): Promise<MigrationResult | MigrationRunError> {
-	const { oldKey, newKey } = params
+	const { oldKey, newKey, keepNickname } = params
 	if (oldKey === newKey) return { error: "SAME_KEY" }
 
 	return env.DB.transaction(async (tx) => {
@@ -276,6 +280,18 @@ export async function runMigration(
 			await tx.prepare("DELETE FROM users WHERE id = ?").bind(newId).run()
 		}
 		await tx.prepare("UPDATE users SET key_id = ? WHERE id = ?").bind(newKey, oldId).run()
+
+		if (keepNickname === "new" && newId !== null) {
+			const newSnapUser = (snapshot.users as { key_id: string; nickname: string | null }[]).find(
+				(u) => u.key_id === newKey
+			)
+			if (newSnapUser?.nickname) {
+				await tx
+					.prepare("UPDATE users SET nickname = ?, nickname_updated_at = ? WHERE id = ?")
+					.bind(newSnapUser.nickname, now(), oldId)
+					.run()
+			}
+		}
 
 		if (oldLink) {
 			await tx

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -1,3 +1,4 @@
+import type { D1Compat } from "@/infra/database"
 import type { Env } from "@/types"
 import type { MigrationCounts } from "@/utils/migration-session"
 
@@ -6,6 +7,34 @@ export interface MigrationResolved {
 	newUserId: number | null
 	counts: MigrationCounts
 }
+
+export interface MigrationSnapshot {
+	users: unknown[]
+	votes: unknown[]
+	reports: unknown[]
+	lyrics: unknown[]
+	request_fulfillments: unknown[]
+	discord_links: unknown[]
+	lyrics_requests: unknown[]
+}
+
+export interface MigrationResult {
+	moved: {
+		submissions: number
+		votes: number
+		reports: number
+		fulfillments: number
+		collisionsDropped: number
+	}
+	snapshot: MigrationSnapshot
+	affectedLyricsIds: number[]
+	affectedVideoIds: string[]
+}
+
+export type MigrationRunError =
+	| { error: "OLD_KEY_NO_USER" }
+	| { error: "SAME_KEY" }
+	| { error: "BOTH_KEYS_LINKED" }
 
 async function count(env: Env, sql: string, params: unknown[]): Promise<number> {
 	const row = await env.DB.prepare(sql)
@@ -82,4 +111,197 @@ export async function computeMigrationPlan(
 			collisions: voteCollisions + reportCollisions + reqCollisions,
 		},
 	}
+}
+
+async function all<T>(tx: D1Compat, sql: string, params: unknown[]): Promise<T[]> {
+	const { results } = await tx
+		.prepare(sql)
+		.bind(...params)
+		.all<T>()
+	return results
+}
+
+async function countTx(tx: D1Compat, sql: string, params: unknown[]): Promise<number> {
+	const row = await tx
+		.prepare(sql)
+		.bind(...params)
+		.first<{ n: number }>()
+	return row?.n ?? 0
+}
+
+// Move the OLD identity's whole history onto NEW key in one transaction.
+// The OLD users row survives (it owns the history) and is relabelled to NEW key;
+// if NEW already had its own users row, its activity is folded in first, dropping
+// duplicate votes/reports on the UNIQUE(lyrics_id, user_id) constraint.
+export async function runMigration(
+	env: Env,
+	params: { oldKey: string; newKey: string }
+): Promise<MigrationResult | MigrationRunError> {
+	const { oldKey, newKey } = params
+	if (oldKey === newKey) return { error: "SAME_KEY" }
+
+	return env.DB.transaction(async (tx) => {
+		const oldUser = await tx
+			.prepare("SELECT id FROM users WHERE key_id = ?")
+			.bind(oldKey)
+			.first<{ id: number }>()
+		if (!oldUser) return { error: "OLD_KEY_NO_USER" } as const
+		const oldId = oldUser.id
+
+		const newUser = await tx
+			.prepare("SELECT id FROM users WHERE key_id = ?")
+			.bind(newKey)
+			.first<{ id: number }>()
+		const newId = newUser?.id ?? null
+
+		const oldLink = await tx
+			.prepare("SELECT discord_id FROM discord_links WHERE key_id = ?")
+			.bind(oldKey)
+			.first<{ discord_id: string }>()
+		const newLink = await tx
+			.prepare("SELECT discord_id FROM discord_links WHERE key_id = ?")
+			.bind(newKey)
+			.first<{ discord_id: string }>()
+		if (oldLink && newLink) return { error: "BOTH_KEYS_LINKED" } as const
+
+		const ids = newId !== null ? [oldId, newId] : [oldId]
+		const keys = [oldKey, newKey]
+
+		const snapshot: MigrationSnapshot = {
+			users: await all(tx, "SELECT * FROM users WHERE key_id = ANY(?)", [keys]),
+			votes: await all(tx, "SELECT * FROM votes WHERE user_id = ANY(?)", [ids]),
+			reports: await all(tx, "SELECT * FROM reports WHERE user_id = ANY(?)", [ids]),
+			lyrics: await all(
+				tx,
+				"SELECT * FROM lyrics WHERE submitter_id = ANY(?) OR deleted_by_user_id = ANY(?)",
+				[ids, ids]
+			),
+			request_fulfillments: await all(
+				tx,
+				"SELECT * FROM request_fulfillments WHERE submitter_id = ANY(?)",
+				[ids]
+			),
+			discord_links: await all(tx, "SELECT * FROM discord_links WHERE key_id = ANY(?)", [keys]),
+			lyrics_requests: await all(tx, "SELECT * FROM lyrics_requests WHERE requester_id = ANY(?)", [
+				keys,
+			]),
+		}
+
+		const votesRows = snapshot.votes as { user_id: number; lyrics_id: number }[]
+		const lyricsRows = snapshot.lyrics as { id: number; submitter_id: number | null; video_id: string }[]
+		const reportsRows = snapshot.reports as { user_id: number }[]
+		const fulfillmentRows = snapshot.request_fulfillments as { submitter_id: number | null }[]
+
+		const moved = {
+			submissions: lyricsRows.filter((r) => r.submitter_id === newId).length,
+			votes: votesRows.filter((r) => r.user_id === newId).length,
+			reports: reportsRows.filter((r) => r.user_id === newId).length,
+			fulfillments: fulfillmentRows.filter((r) => r.submitter_id === newId).length,
+			collisionsDropped: 0,
+		}
+
+		const affectedLyricsIds = [
+			...new Set<number>([...votesRows.map((r) => r.lyrics_id), ...lyricsRows.map((r) => r.id)]),
+		]
+		const affectedVideoIds = [...new Set<string>(lyricsRows.map((r) => r.video_id))]
+
+		let voteCollisions = 0
+		let reportCollisions = 0
+		if (newId !== null) {
+			voteCollisions = await countTx(
+				tx,
+				"SELECT COUNT(*)::int AS n FROM votes WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM votes WHERE user_id = ?)",
+				[newId, oldId]
+			)
+			await tx
+				.prepare(
+					"DELETE FROM votes WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM votes WHERE user_id = ?)"
+				)
+				.bind(newId, oldId)
+				.run()
+			await tx.prepare("UPDATE votes SET user_id = ? WHERE user_id = ?").bind(oldId, newId).run()
+
+			reportCollisions = await countTx(
+				tx,
+				"SELECT COUNT(*)::int AS n FROM reports WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM reports WHERE user_id = ?)",
+				[newId, oldId]
+			)
+			await tx
+				.prepare(
+					"DELETE FROM reports WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM reports WHERE user_id = ?)"
+				)
+				.bind(newId, oldId)
+				.run()
+			await tx.prepare("UPDATE reports SET user_id = ? WHERE user_id = ?").bind(oldId, newId).run()
+
+			await tx
+				.prepare("UPDATE lyrics SET submitter_id = ? WHERE submitter_id = ?")
+				.bind(oldId, newId)
+				.run()
+			await tx
+				.prepare("UPDATE lyrics SET deleted_by_user_id = ? WHERE deleted_by_user_id = ?")
+				.bind(oldId, newId)
+				.run()
+			await tx
+				.prepare("UPDATE request_fulfillments SET submitter_id = ? WHERE submitter_id = ?")
+				.bind(oldId, newId)
+				.run()
+		}
+
+		const reqCollisions = await countTx(
+			tx,
+			`SELECT COUNT(*)::int AS n FROM lyrics_requests
+			 WHERE requester_id = ? AND requester_type = 'extension'
+			   AND video_id IN (SELECT video_id FROM lyrics_requests WHERE requester_id = ? AND requester_type = 'extension')`,
+			[newKey, oldKey]
+		)
+		await tx
+			.prepare(
+				`DELETE FROM lyrics_requests
+				 WHERE requester_id = ? AND requester_type = 'extension'
+				   AND video_id IN (SELECT video_id FROM lyrics_requests WHERE requester_id = ? AND requester_type = 'extension')`
+			)
+			.bind(newKey, oldKey)
+			.run()
+		await tx
+			.prepare(
+				"UPDATE lyrics_requests SET requester_id = ? WHERE requester_id = ? AND requester_type = 'extension'"
+			)
+			.bind(newKey, oldKey)
+			.run()
+
+		if (newId !== null) {
+			await tx.prepare("DELETE FROM users WHERE id = ?").bind(newId).run()
+		}
+		await tx.prepare("UPDATE users SET key_id = ? WHERE id = ?").bind(newKey, oldId).run()
+
+		if (oldLink) {
+			await tx
+				.prepare("UPDATE discord_links SET key_id = ? WHERE key_id = ?")
+				.bind(newKey, oldKey)
+				.run()
+		}
+
+		await tx
+			.prepare(
+				`UPDATE votes v SET is_self_vote = CASE WHEN l.submitter_id = v.user_id THEN 1 ELSE 0 END
+				 FROM lyrics l WHERE l.id = v.lyrics_id AND (v.user_id = ? OR l.submitter_id = ?)`
+			)
+			.bind(oldId, oldId)
+			.run()
+
+		await tx
+			.prepare(
+				`UPDATE users SET
+					avg_vote = COALESCE((SELECT AVG(vote)::float8 FROM votes WHERE user_id = ?), 0),
+					vote_count = (SELECT COUNT(*)::int FROM votes WHERE user_id = ?)
+				 WHERE id = ?`
+			)
+			.bind(oldId, oldId, oldId)
+			.run()
+
+		moved.collisionsDropped = voteCollisions + reportCollisions + reqCollisions
+
+		return { moved, snapshot, affectedLyricsIds, affectedVideoIds }
+	})
 }

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -2,6 +2,8 @@ import type { D1Compat } from "@/infra/database"
 import type { Env } from "@/types"
 import type { MigrationCounts } from "@/utils/migration-session"
 
+const now = () => Math.floor(Date.now() / 1000)
+
 export interface MigrationResolved {
 	oldUserId: number
 	newUserId: number | null
@@ -303,5 +305,262 @@ export async function runMigration(
 		moved.collisionsDropped = voteCollisions + reportCollisions + reqCollisions
 
 		return { moved, snapshot, affectedLyricsIds, affectedVideoIds }
+	})
+}
+
+export interface MigrationAuditRow {
+	id: number
+	session_id: string | null
+	discord_id: string
+	old_key: string
+	new_key: string
+	status: "preview" | "committed" | "failed"
+	moved_submissions: number
+	moved_votes: number
+	moved_reports: number
+	moved_fulfillments: number
+	collisions_dropped: number
+	snapshot: MigrationSnapshot | null
+	error: string | null
+	created_at: number
+	updated_at: number
+}
+
+export async function createPreviewAudit(
+	env: Env,
+	params: {
+		sessionId: string
+		discordId: string
+		oldKey: string
+		newKey: string
+		counts: MigrationCounts
+	}
+): Promise<number> {
+	const { sessionId, discordId, oldKey, newKey, counts } = params
+	const row = await env.DB.prepare(
+		`INSERT INTO migration_requests
+			(session_id, discord_id, old_key, new_key, status,
+			 moved_submissions, moved_votes, moved_reports, moved_fulfillments, collisions_dropped)
+		 VALUES (?, ?, ?, ?, 'preview', ?, ?, ?, ?, ?)
+		 RETURNING id`
+	)
+		.bind(
+			sessionId,
+			discordId,
+			oldKey,
+			newKey,
+			counts.submissions,
+			counts.votes,
+			counts.reports,
+			counts.fulfillments,
+			counts.collisions
+		)
+		.first<{ id: number }>()
+	return row!.id
+}
+
+export async function markAuditCommitted(
+	env: Env,
+	id: number,
+	moved: MigrationResult["moved"],
+	snapshot: MigrationSnapshot
+): Promise<void> {
+	await env.DB.prepare(
+		`UPDATE migration_requests SET
+			status = 'committed',
+			moved_submissions = ?, moved_votes = ?, moved_reports = ?, moved_fulfillments = ?,
+			collisions_dropped = ?, snapshot = ?::jsonb, updated_at = ?
+		 WHERE id = ?`
+	)
+		.bind(
+			moved.submissions,
+			moved.votes,
+			moved.reports,
+			moved.fulfillments,
+			moved.collisionsDropped,
+			JSON.stringify(snapshot),
+			now(),
+			id
+		)
+		.run()
+}
+
+export async function markAuditFailed(env: Env, id: number, error: string): Promise<void> {
+	await env.DB.prepare(
+		"UPDATE migration_requests SET status = 'failed', error = ?, updated_at = " +
+			"EXTRACT(EPOCH FROM NOW())::INTEGER WHERE id = ?"
+	)
+		.bind(error, id)
+		.run()
+}
+
+export async function getAudit(env: Env, id: number): Promise<MigrationAuditRow | null> {
+	return env.DB.prepare("SELECT * FROM migration_requests WHERE id = ?")
+		.bind(id)
+		.first<MigrationAuditRow>()
+}
+
+interface SnapUser {
+	id: number
+	key_id: string
+	reputation: number
+	vote_count: number
+	avg_vote: number
+	created_at: number
+	nickname: string | null
+	nickname_updated_at: number | null
+}
+interface SnapDiscord {
+	discord_id: string
+	key_id: string
+	discord_username: string | null
+	linked_at: number
+}
+interface SnapVote {
+	id: number
+	lyrics_id: number
+	user_id: number
+	vote: number
+	is_self_vote: number
+	created_at: number
+}
+interface SnapReport {
+	id: number
+	lyrics_id: number
+	user_id: number
+	reason: string
+	details: string | null
+	created_at: number
+}
+interface SnapLyrics {
+	id: number
+	submitter_id: number | null
+	deleted_by_user_id: number | null
+}
+interface SnapFulfillment {
+	id: number
+	submitter_id: number | null
+}
+interface SnapRequest {
+	id: number
+	video_id: string
+	requester_id: string
+	requester_type: string
+	weight: number
+	created_at: number
+}
+
+// Reverse of runMigration, driven entirely by the stored pre-image. Order matters:
+// relabel the survivor back to the old key before re-inserting the new user row (both
+// hold the same key at commit time), and never DELETE lyrics (it would cascade its votes).
+export async function restoreFromSnapshot(
+	env: Env,
+	migrationId: number
+): Promise<{ restored: true } | { error: "NOT_FOUND" | "NOT_COMMITTED" }> {
+	const audit = await getAudit(env, migrationId)
+	if (!audit) return { error: "NOT_FOUND" }
+	if (audit.status !== "committed" || !audit.snapshot) return { error: "NOT_COMMITTED" }
+
+	const snap = audit.snapshot
+	const oldKey = audit.old_key
+	const newKey = audit.new_key
+	const users = snap.users as SnapUser[]
+	const oldSnap = users.find((u) => u.key_id === oldKey)
+	const newSnap = users.find((u) => u.key_id === newKey)
+	if (!oldSnap) return { error: "NOT_COMMITTED" }
+	const ids = newSnap ? [oldSnap.id, newSnap.id] : [oldSnap.id]
+
+	return env.DB.transaction(async (tx) => {
+		await tx
+			.prepare(
+				"UPDATE users SET key_id = ?, reputation = ?, vote_count = ?, avg_vote = ?, nickname = ?, nickname_updated_at = ? WHERE id = ?"
+			)
+			.bind(
+				oldSnap.key_id,
+				oldSnap.reputation,
+				oldSnap.vote_count,
+				oldSnap.avg_vote,
+				oldSnap.nickname,
+				oldSnap.nickname_updated_at,
+				oldSnap.id
+			)
+			.run()
+
+		if (newSnap) {
+			await tx
+				.prepare(
+					"INSERT INTO users (id, key_id, reputation, vote_count, avg_vote, created_at, nickname, nickname_updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+				)
+				.bind(
+					newSnap.id,
+					newSnap.key_id,
+					newSnap.reputation,
+					newSnap.vote_count,
+					newSnap.avg_vote,
+					newSnap.created_at,
+					newSnap.nickname,
+					newSnap.nickname_updated_at
+				)
+				.run()
+		}
+
+		await tx.prepare("DELETE FROM discord_links WHERE key_id = ANY(?)").bind([oldKey, newKey]).run()
+		for (const d of snap.discord_links as SnapDiscord[]) {
+			await tx
+				.prepare(
+					"INSERT INTO discord_links (discord_id, key_id, discord_username, linked_at) VALUES (?, ?, ?, ?)"
+				)
+				.bind(d.discord_id, d.key_id, d.discord_username, d.linked_at)
+				.run()
+		}
+
+		await tx.prepare("DELETE FROM votes WHERE user_id = ANY(?)").bind(ids).run()
+		for (const v of snap.votes as SnapVote[]) {
+			await tx
+				.prepare(
+					"INSERT INTO votes (id, lyrics_id, user_id, vote, is_self_vote, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+				)
+				.bind(v.id, v.lyrics_id, v.user_id, v.vote, v.is_self_vote, v.created_at)
+				.run()
+		}
+
+		await tx.prepare("DELETE FROM reports WHERE user_id = ANY(?)").bind(ids).run()
+		for (const r of snap.reports as SnapReport[]) {
+			await tx
+				.prepare(
+					"INSERT INTO reports (id, lyrics_id, user_id, reason, details, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+				)
+				.bind(r.id, r.lyrics_id, r.user_id, r.reason, r.details, r.created_at)
+				.run()
+		}
+
+		for (const l of snap.lyrics as SnapLyrics[]) {
+			await tx
+				.prepare("UPDATE lyrics SET submitter_id = ?, deleted_by_user_id = ? WHERE id = ?")
+				.bind(l.submitter_id, l.deleted_by_user_id, l.id)
+				.run()
+		}
+
+		for (const f of snap.request_fulfillments as SnapFulfillment[]) {
+			await tx
+				.prepare("UPDATE request_fulfillments SET submitter_id = ? WHERE id = ?")
+				.bind(f.submitter_id, f.id)
+				.run()
+		}
+
+		await tx
+			.prepare("DELETE FROM lyrics_requests WHERE requester_id = ANY(?)")
+			.bind([oldKey, newKey])
+			.run()
+		for (const rq of snap.lyrics_requests as SnapRequest[]) {
+			await tx
+				.prepare(
+					"INSERT INTO lyrics_requests (id, video_id, requester_id, requester_type, weight, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+				)
+				.bind(rq.id, rq.video_id, rq.requester_id, rq.requester_type, rq.weight, rq.created_at)
+				.run()
+		}
+
+		return { restored: true } as const
 	})
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { feedRoutes } from "@/routes/feed"
 import { leaderboardRoutes } from "@/routes/leaderboard"
 import { linkRoutes, linkStartRoutes } from "@/routes/links"
 import { lyricsRoutes } from "@/routes/lyrics"
+import { migrationRoutes } from "@/routes/migrations"
 import { requestRoutes } from "@/routes/requests"
 import { translateRoutes } from "@/routes/translate"
 import { userRoutes } from "@/routes/users"
@@ -202,6 +203,7 @@ const app = new Elysia({ adapter: node() })
 	.use(authRoutes(env))
 	.use(linkStartRoutes(env))
 	.use(linkRoutes(env))
+	.use(migrationRoutes(env))
 	.get("/*", ({ request }) => {
 		const { pathname } = new URL(request.url)
 

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -305,7 +305,8 @@ describe("GET /links/discord/callback - migration attach", () => {
 			oldKey,
 			newKey: null,
 			status: "awaiting_new_key",
-			nicknameKept: true,
+			oldNickname: null,
+			newNickname: null,
 			counts: null,
 			migrationId: null,
 			createdAt: 1,
@@ -317,8 +318,8 @@ describe("GET /links/discord/callback - migration attach", () => {
 	it("treats a link from a discord with an active migration session as the proof, and does NOT relink", async () => {
 		const cache = makeMockCache({ "link_state:st-m": newKey })
 		seedActiveSession(cache)
-		// computeMigrationPlan (relabel: old user, no new user, req collisions) + createPreviewAudit
-		const db = makeMockDB([{ id: 1 }, null, { n: 0 }, { id: 99 }])
+		// computeMigrationPlan (relabel: old user with nickname, no new user, req collisions) + createPreviewAudit
+		const db = makeMockDB([{ id: 1, nickname: "Caplump" }, null, { n: 0 }, { id: 99 }])
 		const app = linkRoutes(
 			makeEnv(db, cache),
 			discordFetch({ id: "d-1", username: "alice", global_name: "Alice" })
@@ -336,6 +337,8 @@ describe("GET /links/discord/callback - migration attach", () => {
 		expect(updated.status).toBe("ready")
 		expect(updated.newKey).toBe(newKey)
 		expect(updated.migrationId).toBe(99)
+		expect(updated.oldNickname).toBe("Caplump")
+		expect(updated.newNickname).toBeNull()
 		expect(updated.counts).toEqual({
 			submissions: 0,
 			votes: 0,

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -192,6 +192,46 @@ describe("POST /links/discord/start", () => {
 		expect(res.status).toBe(403)
 	})
 
+	it("stores a migration-tagged state when the signed payload carries a migrationSessionId", async () => {
+		const kp = await generateKeyPair()
+		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
+		const keyId = await hashPublicKey(publicJwk)
+		const db = makeMockDB([
+			{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 },
+			{ id: 7, key_id: keyId },
+		])
+		const cache = makeMockCache()
+		const app = linkStartRoutes(makeEnv(db, cache))
+
+		const payload = {
+			timestamp: Date.now(),
+			nonce: "n".repeat(32),
+			keyId,
+			migrationSessionId: "sess-xyz",
+		}
+		const buf = new TextEncoder().encode(canonicalJson(payload))
+		const sig = await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, kp.privateKey, buf)
+		const bytes = new Uint8Array(sig)
+		let bin = ""
+		for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+		const body = { payload, signature: btoa(bin), publicKey: publicJwk }
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/start", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			})
+		)
+		expect(res.status).toBe(200)
+		const json = (await res.json()) as { data: { authorizeUrl: string } }
+		const state = new URL(json.data.authorizeUrl).searchParams.get("state")
+		expect(JSON.parse(cache.store.get(`link_state:${state}`) ?? "{}")).toEqual({
+			keyId,
+			migrationSessionId: "sess-xyz",
+		})
+	})
+
 	it("reports 503 when Discord OAuth is not configured", async () => {
 		const kp = await generateKeyPair()
 		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
@@ -291,6 +331,97 @@ describe("GET /links/discord/callback", () => {
 		)
 		expect(res.status).toBe(302)
 		expect(res.headers.get("location")).toContain("status=error")
+	})
+})
+
+describe("GET /links/discord/callback - migration attach", () => {
+	const oldKey = "a".repeat(64)
+	const newKey = "b".repeat(64)
+
+	function awaitingSession(overrides: Record<string, unknown> = {}) {
+		return JSON.stringify({
+			sessionId: "msess",
+			discordId: "d-1",
+			oldKey,
+			newKey: null,
+			status: "awaiting_new_key",
+			nicknameKept: true,
+			counts: null,
+			migrationId: null,
+			createdAt: 1,
+			...overrides,
+		})
+	}
+
+	it("attaches the proven new key to the session and does NOT relink discord", async () => {
+		const cache = makeMockCache({
+			"link_state:st-m": JSON.stringify({ keyId: newKey, migrationSessionId: "msess" }),
+			"migration:msess": awaitingSession(),
+		})
+		// computeMigrationPlan (relabel: old user, no new user, req collisions) + createPreviewAudit
+		const db = makeMockDB([{ id: 1 }, null, { n: 0 }, { id: 99 }])
+		const app = linkRoutes(
+			makeEnv(db, cache),
+			discordFetch({ id: "d-1", username: "alice", global_name: "Alice" })
+		)
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=c&state=st-m", { redirect: "manual" })
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("/migrate?status=ready")
+		expect(db.calls.some((c) => c.sql.includes("INSERT INTO discord_links"))).toBe(false)
+		expect(db.calls.some((c) => c.sql.includes("INSERT INTO migration_requests"))).toBe(true)
+
+		const updated = JSON.parse(cache.store.get("migration:msess") ?? "{}")
+		expect(updated.status).toBe("ready")
+		expect(updated.newKey).toBe(newKey)
+		expect(updated.migrationId).toBe(99)
+		expect(updated.counts).toEqual({
+			submissions: 0,
+			votes: 0,
+			reports: 0,
+			fulfillments: 0,
+			collisions: 0,
+		})
+	})
+
+	it("fails the session with same_key when the proven key equals the old key", async () => {
+		const cache = makeMockCache({
+			"link_state:st-s": JSON.stringify({ keyId: oldKey, migrationSessionId: "msess" }),
+			"migration:msess": awaitingSession(),
+		})
+		const db = makeMockDB([])
+		const app = linkRoutes(makeEnv(db, cache), discordFetch({ id: "d-1", username: "a" }))
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=c&state=st-s", { redirect: "manual" })
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("/migrate?status=same_key")
+		const updated = JSON.parse(cache.store.get("migration:msess") ?? "{}")
+		expect(updated.status).toBe("failed")
+		expect(updated.failureReason).toBe("same_key")
+		expect(db.calls.some((c) => c.sql.includes("INSERT INTO discord_links"))).toBe(false)
+		expect(db.calls.some((c) => c.sql.includes("INSERT INTO migration_requests"))).toBe(false)
+	})
+
+	it("refuses to attach when a different discord completes the OAuth", async () => {
+		const cache = makeMockCache({
+			"link_state:st-w": JSON.stringify({ keyId: newKey, migrationSessionId: "msess" }),
+			"migration:msess": awaitingSession(),
+		})
+		const db = makeMockDB([])
+		const app = linkRoutes(makeEnv(db, cache), discordFetch({ id: "attacker", username: "x" }))
+
+		const res = await app.handle(
+			new Request("http://localhost/links/discord/callback?code=c&state=st-w", { redirect: "manual" })
+		)
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("/migrate?status=wrong_account")
+		const updated = JSON.parse(cache.store.get("migration:msess") ?? "{}")
+		expect(updated.status).toBe("awaiting_new_key") // untouched, real owner can retry
+		expect(db.calls.some((c) => c.sql.includes("INSERT INTO migration_requests"))).toBe(false)
 	})
 })
 

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -192,46 +192,6 @@ describe("POST /links/discord/start", () => {
 		expect(res.status).toBe(403)
 	})
 
-	it("stores a migration-tagged state when the signed payload carries a migrationSessionId", async () => {
-		const kp = await generateKeyPair()
-		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
-		const keyId = await hashPublicKey(publicJwk)
-		const db = makeMockDB([
-			{ key_id: keyId, public_key: JSON.stringify(publicJwk), created_at: 0 },
-			{ id: 7, key_id: keyId },
-		])
-		const cache = makeMockCache()
-		const app = linkStartRoutes(makeEnv(db, cache))
-
-		const payload = {
-			timestamp: Date.now(),
-			nonce: "n".repeat(32),
-			keyId,
-			migrationSessionId: "sess-xyz",
-		}
-		const buf = new TextEncoder().encode(canonicalJson(payload))
-		const sig = await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, kp.privateKey, buf)
-		const bytes = new Uint8Array(sig)
-		let bin = ""
-		for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
-		const body = { payload, signature: btoa(bin), publicKey: publicJwk }
-
-		const res = await app.handle(
-			new Request("http://localhost/links/discord/start", {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify(body),
-			})
-		)
-		expect(res.status).toBe(200)
-		const json = (await res.json()) as { data: { authorizeUrl: string } }
-		const state = new URL(json.data.authorizeUrl).searchParams.get("state")
-		expect(JSON.parse(cache.store.get(`link_state:${state}`) ?? "{}")).toEqual({
-			keyId,
-			migrationSessionId: "sess-xyz",
-		})
-	})
-
 	it("reports 503 when Discord OAuth is not configured", async () => {
 		const kp = await generateKeyPair()
 		const publicJwk = (await crypto.subtle.exportKey("jwk", kp.publicKey)) as JsonWebKey
@@ -338,8 +298,8 @@ describe("GET /links/discord/callback - migration attach", () => {
 	const oldKey = "a".repeat(64)
 	const newKey = "b".repeat(64)
 
-	function awaitingSession(overrides: Record<string, unknown> = {}) {
-		return JSON.stringify({
+	function seedActiveSession(cache: ReturnType<typeof makeMockCache>) {
+		const session = {
 			sessionId: "msess",
 			discordId: "d-1",
 			oldKey,
@@ -349,15 +309,14 @@ describe("GET /links/discord/callback - migration attach", () => {
 			counts: null,
 			migrationId: null,
 			createdAt: 1,
-			...overrides,
-		})
+		}
+		cache.store.set("migration:msess", JSON.stringify(session))
+		cache.store.set("migration:by-discord:d-1", "msess")
 	}
 
-	it("attaches the proven new key to the session and does NOT relink discord", async () => {
-		const cache = makeMockCache({
-			"link_state:st-m": JSON.stringify({ keyId: newKey, migrationSessionId: "msess" }),
-			"migration:msess": awaitingSession(),
-		})
+	it("treats a link from a discord with an active migration session as the proof, and does NOT relink", async () => {
+		const cache = makeMockCache({ "link_state:st-m": newKey })
+		seedActiveSession(cache)
 		// computeMigrationPlan (relabel: old user, no new user, req collisions) + createPreviewAudit
 		const db = makeMockDB([{ id: 1 }, null, { n: 0 }, { id: 99 }])
 		const app = linkRoutes(
@@ -387,10 +346,8 @@ describe("GET /links/discord/callback - migration attach", () => {
 	})
 
 	it("fails the session with same_key when the proven key equals the old key", async () => {
-		const cache = makeMockCache({
-			"link_state:st-s": JSON.stringify({ keyId: oldKey, migrationSessionId: "msess" }),
-			"migration:msess": awaitingSession(),
-		})
+		const cache = makeMockCache({ "link_state:st-s": oldKey })
+		seedActiveSession(cache)
 		const db = makeMockDB([])
 		const app = linkRoutes(makeEnv(db, cache), discordFetch({ id: "d-1", username: "a" }))
 
@@ -406,21 +363,20 @@ describe("GET /links/discord/callback - migration attach", () => {
 		expect(db.calls.some((c) => c.sql.includes("INSERT INTO migration_requests"))).toBe(false)
 	})
 
-	it("refuses to attach when a different discord completes the OAuth", async () => {
-		const cache = makeMockCache({
-			"link_state:st-w": JSON.stringify({ keyId: newKey, migrationSessionId: "msess" }),
-			"migration:msess": awaitingSession(),
-		})
-		const db = makeMockDB([])
-		const app = linkRoutes(makeEnv(db, cache), discordFetch({ id: "attacker", username: "x" }))
+	it("performs a normal relink when the discord has no active migration session", async () => {
+		const cache = makeMockCache({ "link_state:st-n": newKey })
+		const db = makeMockDB([null, null]) // linkDiscord: delete, insert
+		const app = linkRoutes(
+			makeEnv(db, cache),
+			discordFetch({ id: "d-2", username: "bob", global_name: "Bob" })
+		)
 
 		const res = await app.handle(
-			new Request("http://localhost/links/discord/callback?code=c&state=st-w", { redirect: "manual" })
+			new Request("http://localhost/links/discord/callback?code=c&state=st-n", { redirect: "manual" })
 		)
 		expect(res.status).toBe(302)
-		expect(res.headers.get("location")).toContain("/migrate?status=wrong_account")
-		const updated = JSON.parse(cache.store.get("migration:msess") ?? "{}")
-		expect(updated.status).toBe("awaiting_new_key") // untouched, real owner can retry
+		expect(res.headers.get("location")).toContain("/link?status=linked")
+		expect(db.calls.some((c) => c.sql.includes("INSERT INTO discord_links"))).toBe(true)
 		expect(db.calls.some((c) => c.sql.includes("INSERT INTO migration_requests"))).toBe(false)
 	})
 })

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -33,10 +33,6 @@ const redirectToLinkPage = (status: string, name?: string) => redirectPage(LINK_
 const redirectToMigratePage = (status: string, name?: string) =>
 	redirectPage(MIGRATE_PAGE, status, name)
 
-// Proof-of-new-key branch of the Discord link flow. When the Discord that just
-// completed OAuth has an active migration session, this link IS the proof: attach
-// the proven key to the session instead of relinking Discord, so the old link
-// survives for commit-time re-verification.
 async function attachMigrationProof(
 	env: Env,
 	session: MigrationSession,

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia"
 import { config } from "@/config"
+import { computeMigrationPlan, createPreviewAudit } from "@/db/account-migration"
 import { getByKeyId, linkDiscord, listLinks, unlinkByKeyId } from "@/db/discordLinks"
 import { Logger } from "@/infra/logger"
 import type { Env } from "@/types"
@@ -7,29 +8,102 @@ import { eitherAuth } from "@/utils/either-auth"
 import { signedRequest } from "@/utils/auth"
 import { isLinkBlacklisted } from "@/utils/blacklist"
 import { isAuthorizedBot } from "@/utils/bot-auth"
+import type { DiscordIdentity } from "@/utils/discord-oauth"
 import { buildAuthorizeUrl, exchangeCodeForUser } from "@/utils/discord-oauth"
 import { ErrorCode, buildError } from "@/utils/errors"
+import { getSession, saveSession } from "@/utils/migration-session"
 import { generateSessionToken } from "@/utils/session"
 
 const log = new Logger("links")
 
 const LINK_STATE_PREFIX = "link_state:"
 const LINK_PAGE = "/link"
+const MIGRATE_PAGE = "/migrate"
 
-function redirectToLinkPage(status: string, name?: string): Response {
+function redirectPage(page: string, status: string, name?: string): Response {
 	const params = new URLSearchParams({ status })
 	if (name) params.set("name", name)
 	return new Response(null, {
 		status: 302,
-		headers: { location: `${LINK_PAGE}?${params.toString()}` },
+		headers: { location: `${page}?${params.toString()}` },
 	})
+}
+
+const redirectToLinkPage = (status: string, name?: string) => redirectPage(LINK_PAGE, status, name)
+const redirectToMigratePage = (status: string, name?: string) =>
+	redirectPage(MIGRATE_PAGE, status, name)
+
+interface LinkState {
+	keyId: string
+	migrationSessionId?: string
+}
+
+function parseLinkState(raw: string): LinkState {
+	try {
+		const parsed = JSON.parse(raw) as Record<string, unknown>
+		if (parsed && typeof parsed === "object" && typeof parsed.keyId === "string") {
+			return {
+				keyId: parsed.keyId,
+				migrationSessionId:
+					typeof parsed.migrationSessionId === "string" ? parsed.migrationSessionId : undefined,
+			}
+		}
+	} catch {
+		// legacy/plain state: the value is the bare keyId
+	}
+	return { keyId: raw }
+}
+
+// Proof-of-new-key branch of the Discord link flow: attach the proven new key to
+// an open migration session instead of relinking Discord (the old link must survive
+// for commit-time re-verification).
+async function attachMigrationProof(
+	env: Env,
+	migrationSessionId: string,
+	provenKeyId: string,
+	identity: DiscordIdentity
+): Promise<Response> {
+	const session = await getSession(env, migrationSessionId)
+	if (!session || session.status === "committed" || session.status === "failed") {
+		return redirectToMigratePage("expired")
+	}
+	if (session.status === "ready") return redirectToMigratePage("ready")
+	if (identity.id !== session.discordId) return redirectToMigratePage("wrong_account")
+
+	if (provenKeyId === session.oldKey) {
+		await saveSession(env, { ...session, status: "failed", failureReason: "same_key" })
+		return redirectToMigratePage("same_key")
+	}
+
+	const plan = await computeMigrationPlan(env, session.oldKey, provenKeyId)
+	if ("error" in plan) {
+		await saveSession(env, { ...session, status: "failed", failureReason: plan.error })
+		return redirectToMigratePage("error")
+	}
+
+	const migrationId = await createPreviewAudit(env, {
+		sessionId: session.sessionId,
+		discordId: session.discordId,
+		oldKey: session.oldKey,
+		newKey: provenKeyId,
+		counts: plan.counts,
+	})
+	await saveSession(env, {
+		...session,
+		newKey: provenKeyId,
+		counts: plan.counts,
+		status: "ready",
+		migrationId,
+	})
+	log.info("migration new key proven", { migrationSessionId, migrationId })
+	return redirectToMigratePage("ready", identity.displayName)
 }
 
 export const linkStartRoutes = (env: Env) =>
 	new Elysia({ prefix: "/links" })
 		.decorate("env", env)
 		.use(signedRequest)
-		.post("/discord/start", async ({ env, keyId, status }) => {
+		.post("/discord/start", async ({ env, keyId, signedPayload, status }) => {
 			const oauth = env.DISCORD_OAUTH
 			if (!oauth) {
 				return status(503, buildError(ErrorCode.LINKING_DISABLED))
@@ -39,8 +113,16 @@ export const linkStartRoutes = (env: Env) =>
 				return status(403, buildError(ErrorCode.LINK_BLACKLISTED))
 			}
 
+			const migrationSessionId =
+				typeof signedPayload.migrationSessionId === "string" && signedPayload.migrationSessionId
+					? signedPayload.migrationSessionId
+					: undefined
+			const stateValue = migrationSessionId
+				? JSON.stringify({ keyId, migrationSessionId })
+				: keyId
+
 			const state = generateSessionToken()
-			await env.CACHE.put(`${LINK_STATE_PREFIX}${state}`, keyId, {
+			await env.CACHE.put(`${LINK_STATE_PREFIX}${state}`, stateValue, {
 				expirationTtl: config.linking.stateTtlSeconds,
 			})
 			const authorizeUrl = buildAuthorizeUrl(oauth, state, config.linking.discordScope)
@@ -56,22 +138,28 @@ export const linkRoutes = (env: Env, fetchImpl: typeof fetch = fetch) =>
 				const { code, state } = query
 				if (!code || !state) return redirectToLinkPage("error")
 
-				const keyId = await env.CACHE.getDel(`${LINK_STATE_PREFIX}${state}`)
-				if (!keyId) return redirectToLinkPage("expired")
+				const raw = await env.CACHE.getDel(`${LINK_STATE_PREFIX}${state}`)
+				if (!raw) return redirectToLinkPage("expired")
+				const { keyId, migrationSessionId } = parseLinkState(raw)
+				const redirectError = migrationSessionId ? redirectToMigratePage : redirectToLinkPage
 				if (isLinkBlacklisted(keyId)) {
 					log.warn("blacklisted key reached link callback", { keyId })
-					return redirectToLinkPage("blocked")
+					return redirectError("blocked")
 				}
 
 				const oauth = env.DISCORD_OAUTH
-				if (!oauth) return redirectToLinkPage("error")
+				if (!oauth) return redirectError("error")
 
 				let identity: Awaited<ReturnType<typeof exchangeCodeForUser>>
 				try {
 					identity = await exchangeCodeForUser(oauth, code, fetchImpl)
 				} catch (err) {
 					log.warn("discord oauth exchange failed", { error: (err as Error).message })
-					return redirectToLinkPage("error")
+					return redirectError("error")
+				}
+
+				if (migrationSessionId) {
+					return attachMigrationProof(env, migrationSessionId, keyId, identity)
 				}
 
 				await linkDiscord(env, {

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -67,6 +67,8 @@ async function attachMigrationProof(
 		...session,
 		newKey: provenKeyId,
 		counts: plan.counts,
+		oldNickname: plan.oldNickname,
+		newNickname: plan.newNickname,
 		status: "ready",
 		migrationId,
 	})

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -11,7 +11,7 @@ import { isAuthorizedBot } from "@/utils/bot-auth"
 import type { DiscordIdentity } from "@/utils/discord-oauth"
 import { buildAuthorizeUrl, exchangeCodeForUser } from "@/utils/discord-oauth"
 import { ErrorCode, buildError } from "@/utils/errors"
-import { getSession, saveSession } from "@/utils/migration-session"
+import { getActiveSessionForDiscord, type MigrationSession, saveSession } from "@/utils/migration-session"
 import { generateSessionToken } from "@/utils/session"
 
 const log = new Logger("links")
@@ -33,42 +33,17 @@ const redirectToLinkPage = (status: string, name?: string) => redirectPage(LINK_
 const redirectToMigratePage = (status: string, name?: string) =>
 	redirectPage(MIGRATE_PAGE, status, name)
 
-interface LinkState {
-	keyId: string
-	migrationSessionId?: string
-}
-
-function parseLinkState(raw: string): LinkState {
-	try {
-		const parsed = JSON.parse(raw) as Record<string, unknown>
-		if (parsed && typeof parsed === "object" && typeof parsed.keyId === "string") {
-			return {
-				keyId: parsed.keyId,
-				migrationSessionId:
-					typeof parsed.migrationSessionId === "string" ? parsed.migrationSessionId : undefined,
-			}
-		}
-	} catch {
-		// legacy/plain state: the value is the bare keyId
-	}
-	return { keyId: raw }
-}
-
-// Proof-of-new-key branch of the Discord link flow: attach the proven new key to
-// an open migration session instead of relinking Discord (the old link must survive
-// for commit-time re-verification).
+// Proof-of-new-key branch of the Discord link flow. When the Discord that just
+// completed OAuth has an active migration session, this link IS the proof: attach
+// the proven key to the session instead of relinking Discord, so the old link
+// survives for commit-time re-verification.
 async function attachMigrationProof(
 	env: Env,
-	migrationSessionId: string,
+	session: MigrationSession,
 	provenKeyId: string,
 	identity: DiscordIdentity
 ): Promise<Response> {
-	const session = await getSession(env, migrationSessionId)
-	if (!session || session.status === "committed" || session.status === "failed") {
-		return redirectToMigratePage("expired")
-	}
 	if (session.status === "ready") return redirectToMigratePage("ready")
-	if (identity.id !== session.discordId) return redirectToMigratePage("wrong_account")
 
 	if (provenKeyId === session.oldKey) {
 		await saveSession(env, { ...session, status: "failed", failureReason: "same_key" })
@@ -95,7 +70,7 @@ async function attachMigrationProof(
 		status: "ready",
 		migrationId,
 	})
-	log.info("migration new key proven", { migrationSessionId, migrationId })
+	log.info("migration new key proven", { sessionId: session.sessionId, migrationId })
 	return redirectToMigratePage("ready", identity.displayName)
 }
 
@@ -103,7 +78,7 @@ export const linkStartRoutes = (env: Env) =>
 	new Elysia({ prefix: "/links" })
 		.decorate("env", env)
 		.use(signedRequest)
-		.post("/discord/start", async ({ env, keyId, signedPayload, status }) => {
+		.post("/discord/start", async ({ env, keyId, status }) => {
 			const oauth = env.DISCORD_OAUTH
 			if (!oauth) {
 				return status(503, buildError(ErrorCode.LINKING_DISABLED))
@@ -113,16 +88,8 @@ export const linkStartRoutes = (env: Env) =>
 				return status(403, buildError(ErrorCode.LINK_BLACKLISTED))
 			}
 
-			const migrationSessionId =
-				typeof signedPayload.migrationSessionId === "string" && signedPayload.migrationSessionId
-					? signedPayload.migrationSessionId
-					: undefined
-			const stateValue = migrationSessionId
-				? JSON.stringify({ keyId, migrationSessionId })
-				: keyId
-
 			const state = generateSessionToken()
-			await env.CACHE.put(`${LINK_STATE_PREFIX}${state}`, stateValue, {
+			await env.CACHE.put(`${LINK_STATE_PREFIX}${state}`, keyId, {
 				expirationTtl: config.linking.stateTtlSeconds,
 			})
 			const authorizeUrl = buildAuthorizeUrl(oauth, state, config.linking.discordScope)
@@ -138,28 +105,27 @@ export const linkRoutes = (env: Env, fetchImpl: typeof fetch = fetch) =>
 				const { code, state } = query
 				if (!code || !state) return redirectToLinkPage("error")
 
-				const raw = await env.CACHE.getDel(`${LINK_STATE_PREFIX}${state}`)
-				if (!raw) return redirectToLinkPage("expired")
-				const { keyId, migrationSessionId } = parseLinkState(raw)
-				const redirectError = migrationSessionId ? redirectToMigratePage : redirectToLinkPage
+				const keyId = await env.CACHE.getDel(`${LINK_STATE_PREFIX}${state}`)
+				if (!keyId) return redirectToLinkPage("expired")
 				if (isLinkBlacklisted(keyId)) {
 					log.warn("blacklisted key reached link callback", { keyId })
-					return redirectError("blocked")
+					return redirectToLinkPage("blocked")
 				}
 
 				const oauth = env.DISCORD_OAUTH
-				if (!oauth) return redirectError("error")
+				if (!oauth) return redirectToLinkPage("error")
 
 				let identity: Awaited<ReturnType<typeof exchangeCodeForUser>>
 				try {
 					identity = await exchangeCodeForUser(oauth, code, fetchImpl)
 				} catch (err) {
 					log.warn("discord oauth exchange failed", { error: (err as Error).message })
-					return redirectError("error")
+					return redirectToLinkPage("error")
 				}
 
-				if (migrationSessionId) {
-					return attachMigrationProof(env, migrationSessionId, keyId, identity)
+				const migration = await getActiveSessionForDiscord(env, identity.id)
+				if (migration) {
+					return attachMigrationProof(env, migration, keyId, identity)
 				}
 
 				await linkDiscord(env, {

--- a/src/routes/migrations.test.ts
+++ b/src/routes/migrations.test.ts
@@ -120,7 +120,8 @@ function baseSession(overrides: Partial<MigrationSession> = {}): MigrationSessio
 		oldKey: `${"a".repeat(58)}oldkey`,
 		newKey: null,
 		status: "awaiting_new_key",
-		nicknameKept: true,
+		oldNickname: null,
+		newNickname: null,
 		counts: null,
 		migrationId: null,
 		createdAt: 100,
@@ -187,9 +188,11 @@ describe("GET /migrations/bot/:sessionId", () => {
 		expect(data.status).toBe("expired")
 		expect(data.counts).toBeNull()
 		expect(data.newKeyId).toBeNull()
+		expect(data.oldNickname).toBeNull()
+		expect(data.newNickname).toBeNull()
 	})
 
-	it("reports awaiting_new_key with null new key and counts", async () => {
+	it("reports awaiting_new_key with null new key, counts, and nicknames", async () => {
 		const cache = makeMockCache()
 		seedSession(cache, baseSession())
 		const app = migrationRoutes(makeEnv(makeMockDB(), cache))
@@ -198,10 +201,11 @@ describe("GET /migrations/bot/:sessionId", () => {
 		expect(data.status).toBe("awaiting_new_key")
 		expect(data.newKeyId).toBeNull()
 		expect(data.counts).toBeNull()
-		expect(data.nicknameKept).toBe(true)
+		expect(data.oldNickname).toBeNull()
+		expect(data.newNickname).toBeNull()
 	})
 
-	it("reports ready with short new key id and dry-run counts", async () => {
+	it("reports ready with short new key id, dry-run counts, and both nicknames", async () => {
 		const cache = makeMockCache()
 		seedSession(
 			cache,
@@ -209,6 +213,8 @@ describe("GET /migrations/bot/:sessionId", () => {
 				status: "ready",
 				newKey: `${"b".repeat(58)}newkey`,
 				migrationId: 7,
+				oldNickname: "Caplump",
+				newNickname: "tropicawhale",
 				counts: { submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 },
 			})
 		)
@@ -217,6 +223,8 @@ describe("GET /migrations/bot/:sessionId", () => {
 			{}) as Record<string, unknown>
 		expect(data.status).toBe("ready")
 		expect(data.newKeyId).toBe("newkey")
+		expect(data.oldNickname).toBe("Caplump")
+		expect(data.newNickname).toBe("tropicawhale")
 		expect(data.counts).toEqual({ submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 })
 	})
 })
@@ -304,6 +312,40 @@ describe("POST /migrations/bot/:sessionId/commit", () => {
 		expect(committed.status).toBe("committed")
 		// discord index cleared
 		expect(cache.store.has("migration:by-discord:disc-1")).toBe(false)
+	})
+
+	it("forwards keepNickname:new so the survivor takes the new key's nickname", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, readySession())
+		// re-verify link, then a merge-case runMigration where the new user has a nickname
+		const db = makeMockDB([
+			{ discord_id: "disc-1", key_id: oldKey }, // re-verify
+			{ id: 1 }, // old user
+			{ id: 2 }, // new user (merge case)
+			{ discord_id: "disc-1", key_id: oldKey }, // old link
+			null, // new link
+			[
+				{ id: 1, key_id: oldKey, nickname: "Caplump" },
+				{ id: 2, key_id: newKey, nickname: "tropicawhale" },
+			], // users snapshot
+			[], // votes
+			[], // reports
+			[], // lyrics
+			[], // fulfillments
+			[{ discord_id: "disc-1", key_id: oldKey }], // discord snapshot
+			[], // requests
+			{ n: 0 }, // vote collisions
+			{ n: 0 }, // report collisions
+			{ n: 0 }, // request collisions
+		])
+		const app = migrationRoutes(makeEnv(db, cache))
+		const res = await app.handle(
+			post("/migrations/bot/sess-1/commit", { discordId: "disc-1", keepNickname: "new" })
+		)
+		expect(res.status).toBe(200)
+		const nick = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
+		expect(nick).toBeDefined()
+		expect(nick?.params[0]).toBe("tropicawhale")
 	})
 
 	it("returns already_committed for a committed session", async () => {

--- a/src/routes/migrations.test.ts
+++ b/src/routes/migrations.test.ts
@@ -272,6 +272,18 @@ describe("POST /migrations/bot/:sessionId/commit", () => {
 		expect((await json(res)).code).toBe("MIGRATION_NOT_OWNER")
 	})
 
+	it("returns in_progress when a commit for the session is already running", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, readySession())
+		cache.setNX = async () => false
+		const db = makeMockDB([{ discord_id: "disc-1", key_id: oldKey }]) // re-verify link
+		const app = migrationRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_IN_PROGRESS")
+		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(false)
+	})
+
 	it("commits: runs the migration, marks audit, busts caches, returns moved", async () => {
 		const cache = makeMockCache()
 		seedSession(cache, readySession())
@@ -290,7 +302,7 @@ describe("POST /migrations/bot/:sessionId/commit", () => {
 			[{ discord_id: "disc-1", key_id: oldKey }], // discord snapshot
 			[], // requests snapshot
 			{ n: 0 }, // request collisions
-			// markAuditCommitted UPDATE (run, no return)
+			// in-transaction committed audit UPDATE (run, no return)
 		])
 		const app = migrationRoutes(makeEnv(db, cache))
 		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))

--- a/src/routes/migrations.test.ts
+++ b/src/routes/migrations.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest"
+import type { Env } from "@/types"
+import type { MigrationSession } from "@/utils/migration-session"
+import { migrationRoutes } from "./migrations"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						getSql: () => sql,
+						getParams: () => args,
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							return (queue.shift() as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							return { results: (queue.shift() as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+						},
+					}
+				},
+			}
+		},
+		async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+			return fn(db)
+		},
+	}
+	return db
+}
+
+function makeMockCache(seed: Record<string, string> = {}) {
+	const store = new Map(Object.entries(seed))
+	const deletes: string[] = []
+	return {
+		store,
+		deletes,
+		async get(k: string) {
+			return store.get(k) ?? null
+		},
+		async put(k: string, v: string) {
+			store.set(k, v)
+		},
+		async delete(k: string) {
+			deletes.push(k)
+			store.delete(k)
+		},
+		async getDel(k: string) {
+			const v = store.get(k) ?? null
+			store.delete(k)
+			return v
+		},
+		async setNX() {
+			return true
+		},
+		async keys() {
+			return []
+		},
+	}
+}
+
+const OAUTH = {
+	clientId: "c",
+	clientSecret: "s",
+	redirectUri: "https://unison.boidu.dev/links/discord/callback",
+}
+
+function makeEnv(
+	db: ReturnType<typeof makeMockDB>,
+	cache: ReturnType<typeof makeMockCache>,
+	overrides: Partial<Env> = {}
+): Env {
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		BUTLER_BOT_SECRET: "bot-secret",
+		DISCORD_OAUTH: OAUTH,
+		...overrides,
+	} as unknown as Env
+}
+
+const BOT = { authorization: "Bearer bot-secret" }
+
+function post(path: string, body: unknown, headers: Record<string, string> = BOT) {
+	return new Request(`http://localhost${path}`, {
+		method: "POST",
+		headers: { "content-type": "application/json", ...headers },
+		body: JSON.stringify(body),
+	})
+}
+
+function get(path: string, headers: Record<string, string> = BOT) {
+	return new Request(`http://localhost${path}`, { method: "GET", headers })
+}
+
+async function json(res: Response) {
+	return (await res.json()) as { success: boolean; data?: Record<string, unknown>; code?: string }
+}
+
+function seedSession(cache: ReturnType<typeof makeMockCache>, session: MigrationSession) {
+	cache.store.set(`migration:${session.sessionId}`, JSON.stringify(session))
+	cache.store.set(`migration:by-discord:${session.discordId}`, session.sessionId)
+}
+
+function baseSession(overrides: Partial<MigrationSession> = {}): MigrationSession {
+	return {
+		sessionId: "sess-1",
+		discordId: "disc-1",
+		oldKey: `${"a".repeat(58)}oldkey`,
+		newKey: null,
+		status: "awaiting_new_key",
+		nicknameKept: true,
+		counts: null,
+		migrationId: null,
+		createdAt: 100,
+		...overrides,
+	}
+}
+
+describe("migration bot endpoints - auth", () => {
+	it("rejects all three without a valid bearer token", async () => {
+		const app = migrationRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const noauth = { authorization: "Bearer wrong" }
+		expect((await app.handle(post("/migrations/bot/start", { discordId: "d" }, noauth))).status).toBe(401)
+		expect((await app.handle(get("/migrations/bot/sess-1", noauth))).status).toBe(401)
+		expect(
+			(await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "d" }, noauth))).status
+		).toBe(401)
+	})
+})
+
+describe("POST /migrations/bot/start", () => {
+	it("returns not_linked when the discord has no link", async () => {
+		const db = makeMockDB([null]) // getByDiscordId -> none
+		const app = migrationRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/migrations/bot/start", { discordId: "disc-1" }))
+		expect(res.status).toBe(400)
+		expect((await json(res)).code).toBe("NOT_LINKED")
+	})
+
+	it("opens a session and returns signUrl + short old key id", async () => {
+		const oldKey = `${"a".repeat(58)}oldkey`
+		const db = makeMockDB([{ discord_id: "disc-1", key_id: oldKey }])
+		const cache = makeMockCache()
+		const app = migrationRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/migrations/bot/start", { discordId: "disc-1" }))
+		expect(res.status).toBe(200)
+		const data = (await json(res)).data as Record<string, unknown>
+		expect(data.status).toBe("awaiting_new_key")
+		expect(data.oldKeyId).toBe("oldkey")
+		expect(typeof data.sessionId).toBe("string")
+		expect(data.signUrl).toContain("https://unison.boidu.dev/migrate?session=")
+		expect(cache.store.get(`migration:by-discord:disc-1`)).toBe(data.sessionId)
+	})
+
+	it("returns already_active when a session already exists", async () => {
+		const oldKey = `${"a".repeat(58)}oldkey`
+		const db = makeMockDB([
+			{ discord_id: "disc-1", key_id: oldKey }, // first start link lookup
+			{ discord_id: "disc-1", key_id: oldKey }, // second start link lookup
+		])
+		const cache = makeMockCache()
+		const app = migrationRoutes(makeEnv(db, cache))
+		await app.handle(post("/migrations/bot/start", { discordId: "disc-1" }))
+		const res = await app.handle(post("/migrations/bot/start", { discordId: "disc-1" }))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_ALREADY_ACTIVE")
+	})
+})
+
+describe("GET /migrations/bot/:sessionId", () => {
+	it("returns expired for an unknown session", async () => {
+		const app = migrationRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(get("/migrations/bot/nope"))
+		const data = (await json(res)).data as Record<string, unknown>
+		expect(data.status).toBe("expired")
+		expect(data.counts).toBeNull()
+		expect(data.newKeyId).toBeNull()
+	})
+
+	it("reports awaiting_new_key with null new key and counts", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, baseSession())
+		const app = migrationRoutes(makeEnv(makeMockDB(), cache))
+		const data = ((await json(await app.handle(get("/migrations/bot/sess-1")))).data ??
+			{}) as Record<string, unknown>
+		expect(data.status).toBe("awaiting_new_key")
+		expect(data.newKeyId).toBeNull()
+		expect(data.counts).toBeNull()
+		expect(data.nicknameKept).toBe(true)
+	})
+
+	it("reports ready with short new key id and dry-run counts", async () => {
+		const cache = makeMockCache()
+		seedSession(
+			cache,
+			baseSession({
+				status: "ready",
+				newKey: `${"b".repeat(58)}newkey`,
+				migrationId: 7,
+				counts: { submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 },
+			})
+		)
+		const app = migrationRoutes(makeEnv(makeMockDB(), cache))
+		const data = ((await json(await app.handle(get("/migrations/bot/sess-1")))).data ??
+			{}) as Record<string, unknown>
+		expect(data.status).toBe("ready")
+		expect(data.newKeyId).toBe("newkey")
+		expect(data.counts).toEqual({ submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 })
+	})
+})
+
+describe("POST /migrations/bot/:sessionId/commit", () => {
+	const oldKey = `${"a".repeat(58)}oldkey`
+	const newKey = `${"b".repeat(58)}newkey`
+
+	function readySession(): MigrationSession {
+		return baseSession({ status: "ready", newKey, migrationId: 7 })
+	}
+
+	it("returns expired for unknown session", async () => {
+		const app = migrationRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(post("/migrations/bot/nope/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(410)
+		expect((await json(res)).code).toBe("MIGRATION_EXPIRED")
+	})
+
+	it("returns not_ready when the session has not been proven", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, baseSession()) // awaiting_new_key
+		const app = migrationRoutes(makeEnv(makeMockDB(), cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_READY")
+	})
+
+	it("returns not_owner when the discord no longer owns the old key", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, readySession())
+		const db = makeMockDB([{ discord_id: "disc-1", key_id: "some-other-key" }]) // re-verify lookup
+		const app = migrationRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(403)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_OWNER")
+	})
+
+	it("returns not_owner when a different discord tries to commit", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, readySession())
+		const app = migrationRoutes(makeEnv(makeMockDB(), cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "attacker" }))
+		expect(res.status).toBe(403)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_OWNER")
+	})
+
+	it("commits: runs the migration, marks audit, busts caches, returns moved", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, readySession())
+		// queue: re-verify link, then runMigration's internal reads (relabel case)
+		const db = makeMockDB([
+			{ discord_id: "disc-1", key_id: oldKey }, // re-verify getByDiscordId
+			{ id: 1 }, // runMigration old user
+			null, // runMigration new user (relabel case)
+			{ discord_id: "disc-1", key_id: oldKey }, // old link
+			null, // new link
+			[{ id: 1, key_id: oldKey }], // users snapshot
+			[], // votes snapshot
+			[], // reports snapshot
+			[], // lyrics snapshot
+			[], // fulfillments snapshot
+			[{ discord_id: "disc-1", key_id: oldKey }], // discord snapshot
+			[], // requests snapshot
+			{ n: 0 }, // request collisions
+			// markAuditCommitted UPDATE (run, no return)
+		])
+		const app = migrationRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(200)
+		const data = ((await json(res)).data ?? {}) as Record<string, unknown>
+		expect(data.migrationId).toBe(7)
+		expect(data.moved).toEqual({
+			submissions: 0,
+			votes: 0,
+			reports: 0,
+			fulfillments: 0,
+			collisionsDropped: 0,
+		})
+		// leaderboard + submitter cache busts happened
+		expect(cache.deletes).toContain("leaderboard:users")
+		// audit committed + session committed
+		expect(db.calls.some((c) => c.sql.includes("status = 'committed'"))).toBe(true)
+		const committed = JSON.parse(cache.store.get("migration:sess-1") ?? "{}") as MigrationSession
+		expect(committed.status).toBe("committed")
+		// discord index cleared
+		expect(cache.store.has("migration:by-discord:disc-1")).toBe(false)
+	})
+
+	it("returns already_committed for a committed session", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, baseSession({ status: "committed", newKey, migrationId: 7 }))
+		const app = migrationRoutes(makeEnv(makeMockDB(), cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_ALREADY_COMMITTED")
+	})
+})

--- a/src/routes/migrations.test.ts
+++ b/src/routes/migrations.test.ts
@@ -161,7 +161,7 @@ describe("POST /migrations/bot/start", () => {
 		expect(data.oldKeyId).toBe("oldkey")
 		expect(typeof data.sessionId).toBe("string")
 		expect(data.signUrl).toContain("https://unison.boidu.dev/migrate?session=")
-		expect(cache.store.get(`migration:by-discord:disc-1`)).toBe(data.sessionId)
+		expect(cache.store.get("migration:by-discord:disc-1")).toBe(data.sessionId)
 	})
 
 	it("returns already_active when a session already exists", async () => {

--- a/src/routes/migrations.ts
+++ b/src/routes/migrations.ts
@@ -1,0 +1,153 @@
+import { Elysia, t } from "elysia"
+import {
+	markAuditCommitted,
+	markAuditFailed,
+	runMigration,
+} from "@/db/account-migration"
+import { getByDiscordId } from "@/db/discordLinks"
+import { invalidateCuratorLeaderboardCache } from "@/db/leaderboard"
+import { invalidateCacheForSubmitter } from "@/db/lyrics"
+import { Logger } from "@/infra/logger"
+import { recalculateScore } from "@/jobs/score-updater"
+import type { Env } from "@/types"
+import { isLinkBlacklisted } from "@/utils/blacklist"
+import { isAuthorizedBot } from "@/utils/bot-auth"
+import { ErrorCode, buildError } from "@/utils/errors"
+import {
+	clearDiscordIndex,
+	createSession,
+	getActiveSessionForDiscord,
+	getSession,
+	saveSession,
+} from "@/utils/migration-session"
+import { shortKeyId } from "@/utils/short-key-id"
+
+const log = new Logger("migrations")
+
+const bodyDiscordId = t.Object({ discordId: t.String() })
+
+export const migrationRoutes = (env: Env) =>
+	new Elysia({ prefix: "/migrations" })
+		.decorate("env", env)
+		.post(
+			"/bot/start",
+			async ({ env, headers, body, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const { discordId } = body
+
+				const link = await getByDiscordId(env, discordId)
+				if (!link) return status(400, buildError(ErrorCode.NOT_LINKED))
+				const oldKey = link.key_id
+				if (isLinkBlacklisted(oldKey)) {
+					return status(403, buildError(ErrorCode.LINK_BLACKLISTED))
+				}
+
+				const active = await getActiveSessionForDiscord(env, discordId)
+				if (active) return status(409, buildError(ErrorCode.MIGRATION_ALREADY_ACTIVE))
+
+				const oauth = env.DISCORD_OAUTH
+				if (!oauth) return status(503, buildError(ErrorCode.LINKING_DISABLED))
+
+				const session = await createSession(env, { discordId, oldKey })
+				const signUrl = `${new URL(oauth.redirectUri).origin}/migrate?session=${session.sessionId}`
+
+				log.info("migration started", { discordId, sessionId: session.sessionId })
+				return status(200, {
+					success: true,
+					data: {
+						sessionId: session.sessionId,
+						signUrl,
+						oldKeyId: shortKeyId(oldKey),
+						status: "awaiting_new_key",
+					},
+				})
+			},
+			{ body: bodyDiscordId }
+		)
+		.get("/bot/:sessionId", async ({ env, headers, params, status }) => {
+			if (!isAuthorizedBot(headers.authorization, env)) {
+				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+			}
+			const session = await getSession(env, params.sessionId)
+			if (!session) {
+				return status(200, {
+					success: true,
+					data: {
+						status: "expired",
+						oldKeyId: null,
+						newKeyId: null,
+						nicknameKept: true,
+						counts: null,
+					},
+				})
+			}
+			return status(200, {
+				success: true,
+				data: {
+					status: session.status,
+					oldKeyId: shortKeyId(session.oldKey),
+					newKeyId: session.newKey ? shortKeyId(session.newKey) : null,
+					nicknameKept: session.nicknameKept,
+					counts: session.counts,
+				},
+			})
+		})
+		.post(
+			"/bot/:sessionId/commit",
+			async ({ env, headers, params, body, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const { discordId } = body
+
+				const session = await getSession(env, params.sessionId)
+				if (!session) return status(410, buildError(ErrorCode.MIGRATION_EXPIRED))
+				if (session.status === "committed") {
+					return status(409, buildError(ErrorCode.MIGRATION_ALREADY_COMMITTED))
+				}
+				if (session.status !== "ready" || session.newKey === null || session.migrationId === null) {
+					return status(409, buildError(ErrorCode.MIGRATION_NOT_READY))
+				}
+
+				if (discordId !== session.discordId) {
+					return status(403, buildError(ErrorCode.MIGRATION_NOT_OWNER))
+				}
+				const link = await getByDiscordId(env, discordId)
+				if (!link || link.key_id !== session.oldKey) {
+					return status(403, buildError(ErrorCode.MIGRATION_NOT_OWNER))
+				}
+
+				const result = await runMigration(env, { oldKey: session.oldKey, newKey: session.newKey })
+				if ("error" in result) {
+					await markAuditFailed(env, session.migrationId, result.error)
+					await saveSession(env, { ...session, status: "failed", failureReason: result.error })
+					log.error("migration commit failed", { sessionId: session.sessionId, error: result.error })
+					return status(500, buildError(ErrorCode.MIGRATION_FAILED))
+				}
+
+				await markAuditCommitted(env, session.migrationId, result.moved, result.snapshot)
+				await saveSession(env, { ...session, status: "committed" })
+				await clearDiscordIndex(env, discordId)
+
+				await invalidateCuratorLeaderboardCache(env)
+				await invalidateCacheForSubmitter(env, session.newKey)
+				for (const lyricsId of result.affectedLyricsIds) {
+					recalculateScore(env, lyricsId).catch((err) =>
+						log.error("post-migration recalc failed", { lyricsId, error: String(err) })
+					)
+				}
+
+				log.info("migration committed", {
+					sessionId: session.sessionId,
+					migrationId: session.migrationId,
+					moved: result.moved,
+				})
+				return status(200, {
+					success: true,
+					data: { migrationId: session.migrationId, moved: result.moved },
+				})
+			},
+			{ body: bodyDiscordId }
+		)

--- a/src/routes/migrations.ts
+++ b/src/routes/migrations.ts
@@ -1,9 +1,6 @@
 import { Elysia, t } from "elysia"
-import {
-	markAuditCommitted,
-	markAuditFailed,
-	runMigration,
-} from "@/db/account-migration"
+import { config } from "@/config"
+import { markAuditFailed, runMigration } from "@/db/account-migration"
 import { getByDiscordId } from "@/db/discordLinks"
 import { invalidateCuratorLeaderboardCache } from "@/db/leaderboard"
 import { invalidateCacheForSubmitter } from "@/db/lyrics"
@@ -15,6 +12,7 @@ import { isAuthorizedBot } from "@/utils/bot-auth"
 import { ErrorCode, buildError } from "@/utils/errors"
 import {
 	clearDiscordIndex,
+	commitLockKey,
 	createSession,
 	getActiveSessionForDiscord,
 	getSession,
@@ -29,6 +27,7 @@ const bodyCommit = t.Object({
 	discordId: t.String(),
 	keepNickname: t.Optional(t.Union([t.Literal("old"), t.Literal("new")])),
 })
+const paramsSession = t.Object({ sessionId: t.String() })
 
 export const migrationRoutes = (env: Env) =>
 	new Elysia({ prefix: "/migrations" })
@@ -70,36 +69,40 @@ export const migrationRoutes = (env: Env) =>
 			},
 			{ body: bodyDiscordId }
 		)
-		.get("/bot/:sessionId", async ({ env, headers, params, status }) => {
-			if (!isAuthorizedBot(headers.authorization, env)) {
-				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
-			}
-			const session = await getSession(env, params.sessionId)
-			if (!session) {
+		.get(
+			"/bot/:sessionId",
+			async ({ env, headers, params, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const session = await getSession(env, params.sessionId)
+				if (!session) {
+					return status(200, {
+						success: true,
+						data: {
+							status: "expired",
+							oldKeyId: null,
+							newKeyId: null,
+							oldNickname: null,
+							newNickname: null,
+							counts: null,
+						},
+					})
+				}
 				return status(200, {
 					success: true,
 					data: {
-						status: "expired",
-						oldKeyId: null,
-						newKeyId: null,
-						oldNickname: null,
-						newNickname: null,
-						counts: null,
+						status: session.status,
+						oldKeyId: shortKeyId(session.oldKey),
+						newKeyId: session.newKey ? shortKeyId(session.newKey) : null,
+						oldNickname: session.oldNickname,
+						newNickname: session.newNickname,
+						counts: session.counts,
 					},
 				})
-			}
-			return status(200, {
-				success: true,
-				data: {
-					status: session.status,
-					oldKeyId: shortKeyId(session.oldKey),
-					newKeyId: session.newKey ? shortKeyId(session.newKey) : null,
-					oldNickname: session.oldNickname,
-					newNickname: session.newNickname,
-					counts: session.counts,
-				},
-			})
-		})
+			},
+			{ params: paramsSession }
+		)
 		.post(
 			"/bot/:sessionId/commit",
 			async ({ env, headers, params, body, status }) => {
@@ -125,19 +128,24 @@ export const migrationRoutes = (env: Env) =>
 					return status(403, buildError(ErrorCode.MIGRATION_NOT_OWNER))
 				}
 
+				const lockKey = commitLockKey(session.sessionId)
+				const locked = await env.CACHE.setNX(lockKey, "1", config.migration.commitLockSeconds)
+				if (!locked) return status(409, buildError(ErrorCode.MIGRATION_IN_PROGRESS))
+
 				const result = await runMigration(env, {
 					oldKey: session.oldKey,
 					newKey: session.newKey,
 					keepNickname: keepNickname ?? "old",
+					migrationId: session.migrationId,
 				})
 				if ("error" in result) {
+					await env.CACHE.delete(lockKey)
 					await markAuditFailed(env, session.migrationId, result.error)
 					await saveSession(env, { ...session, status: "failed", failureReason: result.error })
 					log.error("migration commit failed", { sessionId: session.sessionId, error: result.error })
 					return status(500, buildError(ErrorCode.MIGRATION_FAILED))
 				}
 
-				await markAuditCommitted(env, session.migrationId, result.moved, result.snapshot)
 				await saveSession(env, { ...session, status: "committed" })
 				await clearDiscordIndex(env, discordId)
 
@@ -159,5 +167,5 @@ export const migrationRoutes = (env: Env) =>
 					data: { migrationId: session.migrationId, moved: result.moved },
 				})
 			},
-			{ body: bodyCommit }
+			{ params: paramsSession, body: bodyCommit }
 		)

--- a/src/routes/migrations.ts
+++ b/src/routes/migrations.ts
@@ -25,6 +25,10 @@ import { shortKeyId } from "@/utils/short-key-id"
 const log = new Logger("migrations")
 
 const bodyDiscordId = t.Object({ discordId: t.String() })
+const bodyCommit = t.Object({
+	discordId: t.String(),
+	keepNickname: t.Optional(t.Union([t.Literal("old"), t.Literal("new")])),
+})
 
 export const migrationRoutes = (env: Env) =>
 	new Elysia({ prefix: "/migrations" })
@@ -78,7 +82,8 @@ export const migrationRoutes = (env: Env) =>
 						status: "expired",
 						oldKeyId: null,
 						newKeyId: null,
-						nicknameKept: true,
+						oldNickname: null,
+						newNickname: null,
 						counts: null,
 					},
 				})
@@ -89,7 +94,8 @@ export const migrationRoutes = (env: Env) =>
 					status: session.status,
 					oldKeyId: shortKeyId(session.oldKey),
 					newKeyId: session.newKey ? shortKeyId(session.newKey) : null,
-					nicknameKept: session.nicknameKept,
+					oldNickname: session.oldNickname,
+					newNickname: session.newNickname,
 					counts: session.counts,
 				},
 			})
@@ -100,7 +106,7 @@ export const migrationRoutes = (env: Env) =>
 				if (!isAuthorizedBot(headers.authorization, env)) {
 					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
 				}
-				const { discordId } = body
+				const { discordId, keepNickname } = body
 
 				const session = await getSession(env, params.sessionId)
 				if (!session) return status(410, buildError(ErrorCode.MIGRATION_EXPIRED))
@@ -119,7 +125,11 @@ export const migrationRoutes = (env: Env) =>
 					return status(403, buildError(ErrorCode.MIGRATION_NOT_OWNER))
 				}
 
-				const result = await runMigration(env, { oldKey: session.oldKey, newKey: session.newKey })
+				const result = await runMigration(env, {
+					oldKey: session.oldKey,
+					newKey: session.newKey,
+					keepNickname: keepNickname ?? "old",
+				})
 				if ("error" in result) {
 					await markAuditFailed(env, session.migrationId, result.error)
 					await saveSession(env, { ...session, status: "failed", failureReason: result.error })
@@ -149,5 +159,5 @@ export const migrationRoutes = (env: Env) =>
 					data: { migrationId: session.migrationId, moved: result.moved },
 				})
 			},
-			{ body: bodyDiscordId }
+			{ body: bodyCommit }
 		)

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -53,4 +53,24 @@ describe("buildError", () => {
 		expect(result.code).toBe("REPORT_DETAILS_TOO_LONG")
 		expect(result.hint).toMatch(/1000 characters/i)
 	})
+
+	it("defines the account-migration error codes", () => {
+		const codes: ErrorCode[] = [
+			ErrorCode.NOT_LINKED,
+			ErrorCode.MIGRATION_ALREADY_ACTIVE,
+			ErrorCode.MIGRATION_SAME_KEY,
+			ErrorCode.MIGRATION_NOT_READY,
+			ErrorCode.MIGRATION_NOT_OWNER,
+			ErrorCode.MIGRATION_ALREADY_COMMITTED,
+			ErrorCode.MIGRATION_EXPIRED,
+			ErrorCode.MIGRATION_FAILED,
+		]
+		for (const code of codes) {
+			const result = buildError(code)
+			expect(result.success).toBe(false)
+			expect(result.code).toBe(code)
+			expect(result.error.length).toBeGreaterThan(0)
+			expect(result.hint.length).toBeGreaterThan(0)
+		}
+	})
 })

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -30,6 +30,14 @@ export const ErrorCode = {
 	INVALID_CURSOR: "INVALID_CURSOR",
 	LINK_BLACKLISTED: "LINK_BLACKLISTED",
 	LINKING_DISABLED: "LINKING_DISABLED",
+	NOT_LINKED: "NOT_LINKED",
+	MIGRATION_ALREADY_ACTIVE: "MIGRATION_ALREADY_ACTIVE",
+	MIGRATION_SAME_KEY: "MIGRATION_SAME_KEY",
+	MIGRATION_NOT_READY: "MIGRATION_NOT_READY",
+	MIGRATION_NOT_OWNER: "MIGRATION_NOT_OWNER",
+	MIGRATION_ALREADY_COMMITTED: "MIGRATION_ALREADY_COMMITTED",
+	MIGRATION_EXPIRED: "MIGRATION_EXPIRED",
+	MIGRATION_FAILED: "MIGRATION_FAILED",
 } as const
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
@@ -144,6 +152,38 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	LINKING_DISABLED: {
 		error: "Linking unavailable",
 		hint: "Account linking is temporarily unavailable. Please try again later.",
+	},
+	NOT_LINKED: {
+		error: "No linked account",
+		hint: "This Discord isn't linked to a Better Lyrics key yet. Link it first, then start a migration.",
+	},
+	MIGRATION_ALREADY_ACTIVE: {
+		error: "Migration already in progress",
+		hint: "You already have a migration underway. Finish it, or wait for it to expire, before starting another.",
+	},
+	MIGRATION_SAME_KEY: {
+		error: "Same key",
+		hint: "The new install proved the same key as the old one, so there's nothing to migrate.",
+	},
+	MIGRATION_NOT_READY: {
+		error: "Migration not ready",
+		hint: "Prove control of the new key first by opening the sign-in link in the new extension.",
+	},
+	MIGRATION_NOT_OWNER: {
+		error: "Not your account",
+		hint: "This Discord no longer owns the account being migrated, so it can't be completed.",
+	},
+	MIGRATION_ALREADY_COMMITTED: {
+		error: "Already migrated",
+		hint: "This migration was already completed. There's nothing left to do.",
+	},
+	MIGRATION_EXPIRED: {
+		error: "Migration expired",
+		hint: "This migration session timed out. Start a new one to try again.",
+	},
+	MIGRATION_FAILED: {
+		error: "Migration failed",
+		hint: "Something went wrong applying the migration. Nothing was changed. Try again in a moment.",
 	},
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,6 +36,7 @@ export const ErrorCode = {
 	MIGRATION_NOT_READY: "MIGRATION_NOT_READY",
 	MIGRATION_NOT_OWNER: "MIGRATION_NOT_OWNER",
 	MIGRATION_ALREADY_COMMITTED: "MIGRATION_ALREADY_COMMITTED",
+	MIGRATION_IN_PROGRESS: "MIGRATION_IN_PROGRESS",
 	MIGRATION_EXPIRED: "MIGRATION_EXPIRED",
 	MIGRATION_FAILED: "MIGRATION_FAILED",
 } as const
@@ -176,6 +177,10 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	MIGRATION_ALREADY_COMMITTED: {
 		error: "Already migrated",
 		hint: "This migration was already completed. There's nothing left to do.",
+	},
+	MIGRATION_IN_PROGRESS: {
+		error: "Migration in progress",
+		hint: "This migration is already being finalized. Give it a moment, then check the status.",
 	},
 	MIGRATION_EXPIRED: {
 		error: "Migration expired",

--- a/src/utils/migration-session.test.ts
+++ b/src/utils/migration-session.test.ts
@@ -52,7 +52,8 @@ describe("migration-session", () => {
 		expect(session.oldKey).toBe("oldkey")
 		expect(session.newKey).toBeNull()
 		expect(session.counts).toBeNull()
-		expect(session.nicknameKept).toBe(true)
+		expect(session.oldNickname).toBeNull()
+		expect(session.newNickname).toBeNull()
 
 		const fetched = await getSession(env, session.sessionId)
 		expect(fetched).toEqual(session)

--- a/src/utils/migration-session.test.ts
+++ b/src/utils/migration-session.test.ts
@@ -95,6 +95,18 @@ describe("migration-session", () => {
 		expect(await getActiveSessionForDiscord(env, "disc-1")).toBeNull()
 	})
 
+	it("refreshes the by-discord index on save so the active-session guard cannot lapse", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+
+		await cache.delete("migration:by-discord:disc-1")
+		expect(await getActiveSessionForDiscord(env, "disc-1")).toBeNull()
+
+		await saveSession(env, { ...session, status: "ready" })
+		expect((await getActiveSessionForDiscord(env, "disc-1"))?.sessionId).toBe(session.sessionId)
+	})
+
 	it("returns null active session when the index dangles past the session", async () => {
 		const cache = makeMockCache()
 		const env = makeEnv(cache)

--- a/src/utils/migration-session.test.ts
+++ b/src/utils/migration-session.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import type { Env } from "@/types"
+import {
+	clearDiscordIndex,
+	createSession,
+	getActiveSessionForDiscord,
+	getSession,
+	type MigrationSession,
+	saveSession,
+} from "./migration-session"
+
+function makeMockCache(seed: Record<string, string> = {}) {
+	const store = new Map(Object.entries(seed))
+	return {
+		store,
+		async get(k: string) {
+			return store.get(k) ?? null
+		},
+		async put(k: string, v: string) {
+			store.set(k, v)
+		},
+		async delete(k: string) {
+			store.delete(k)
+		},
+		async getDel(k: string) {
+			const v = store.get(k) ?? null
+			store.delete(k)
+			return v
+		},
+		async setNX() {
+			return true
+		},
+		async keys() {
+			return []
+		},
+	}
+}
+
+function makeEnv(cache: ReturnType<typeof makeMockCache>): Env {
+	return { CACHE: cache as unknown as Env["CACHE"] } as unknown as Env
+}
+
+describe("migration-session", () => {
+	it("creates a session, stores it, and round-trips by id", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+
+		expect(session.sessionId).toBeTruthy()
+		expect(session.status).toBe("awaiting_new_key")
+		expect(session.oldKey).toBe("oldkey")
+		expect(session.newKey).toBeNull()
+		expect(session.counts).toBeNull()
+		expect(session.nicknameKept).toBe(true)
+
+		const fetched = await getSession(env, session.sessionId)
+		expect(fetched).toEqual(session)
+	})
+
+	it("indexes the session by discord id for active-session lookup", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+		const active = await getActiveSessionForDiscord(env, "disc-1")
+
+		expect(active?.sessionId).toBe(session.sessionId)
+	})
+
+	it("returns null active session when the discord has none", async () => {
+		const env = makeEnv(makeMockCache())
+		expect(await getActiveSessionForDiscord(env, "nobody")).toBeNull()
+	})
+
+	it("does not treat committed sessions as active", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+
+		const committed: MigrationSession = { ...session, status: "committed" }
+		await saveSession(env, committed)
+
+		expect(await getActiveSessionForDiscord(env, "disc-1")).toBeNull()
+	})
+
+	it("does not treat failed sessions as active", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+
+		await saveSession(env, { ...session, status: "failed", failureReason: "same_key" })
+
+		expect(await getActiveSessionForDiscord(env, "disc-1")).toBeNull()
+	})
+
+	it("returns null active session when the index dangles past the session", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+
+		await cache.delete(`migration:${session.sessionId}`)
+
+		expect(await getActiveSessionForDiscord(env, "disc-1")).toBeNull()
+	})
+
+	it("clears the discord index", async () => {
+		const cache = makeMockCache()
+		const env = makeEnv(cache)
+		const session = await createSession(env, { discordId: "disc-1", oldKey: "oldkey" })
+
+		await clearDiscordIndex(env, "disc-1")
+
+		expect(await getActiveSessionForDiscord(env, "disc-1")).toBeNull()
+		expect(await getSession(env, session.sessionId)).not.toBeNull()
+	})
+
+	it("returns null for a missing session id", async () => {
+		const env = makeEnv(makeMockCache())
+		expect(await getSession(env, "nope")).toBeNull()
+	})
+
+	it("tolerates a corrupt session payload", async () => {
+		const cache = makeMockCache({ "migration:bad": "{not json" })
+		const env = makeEnv(cache)
+		expect(await getSession(env, "bad")).toBeNull()
+	})
+})

--- a/src/utils/migration-session.ts
+++ b/src/utils/migration-session.ts
@@ -1,0 +1,86 @@
+import { config } from "@/config"
+import type { Env } from "@/types"
+import { generateSessionToken } from "./session"
+
+export type MigrationStatus = "awaiting_new_key" | "ready" | "committed" | "failed"
+
+export interface MigrationCounts {
+	submissions: number
+	votes: number
+	reports: number
+	fulfillments: number
+	collisions: number
+}
+
+export interface MigrationSession {
+	sessionId: string
+	discordId: string
+	oldKey: string
+	newKey: string | null
+	status: MigrationStatus
+	failureReason?: string
+	nicknameKept: true
+	counts: MigrationCounts | null
+	migrationId: number | null
+	createdAt: number
+}
+
+const SESSION_PREFIX = "migration:"
+const DISCORD_INDEX_PREFIX = "migration:by-discord:"
+
+const sessionKey = (sessionId: string) => `${SESSION_PREFIX}${sessionId}`
+const indexKey = (discordId: string) => `${DISCORD_INDEX_PREFIX}${discordId}`
+
+export async function createSession(
+	env: Env,
+	params: { discordId: string; oldKey: string }
+): Promise<MigrationSession> {
+	const session: MigrationSession = {
+		sessionId: generateSessionToken(),
+		discordId: params.discordId,
+		oldKey: params.oldKey,
+		newKey: null,
+		status: "awaiting_new_key",
+		nicknameKept: true,
+		counts: null,
+		migrationId: null,
+		createdAt: Math.floor(Date.now() / 1000),
+	}
+	await saveSession(env, session)
+	await env.CACHE.put(indexKey(params.discordId), session.sessionId, {
+		expirationTtl: config.migration.sessionTtlSeconds,
+	})
+	return session
+}
+
+export async function saveSession(env: Env, session: MigrationSession): Promise<void> {
+	await env.CACHE.put(sessionKey(session.sessionId), JSON.stringify(session), {
+		expirationTtl: config.migration.sessionTtlSeconds,
+	})
+}
+
+export async function getSession(env: Env, sessionId: string): Promise<MigrationSession | null> {
+	const raw = await env.CACHE.get(sessionKey(sessionId))
+	if (!raw) return null
+	try {
+		return JSON.parse(raw) as MigrationSession
+	} catch {
+		return null
+	}
+}
+
+export async function getActiveSessionForDiscord(
+	env: Env,
+	discordId: string
+): Promise<MigrationSession | null> {
+	const sessionId = await env.CACHE.get(indexKey(discordId))
+	if (!sessionId) return null
+	const session = await getSession(env, sessionId)
+	if (!session) return null
+	if (session.status === "committed" || session.status === "failed") return null
+	return session
+}
+
+export async function clearDiscordIndex(env: Env, discordId: string): Promise<void> {
+	await env.CACHE.delete(indexKey(discordId))
+}

--- a/src/utils/migration-session.ts
+++ b/src/utils/migration-session.ts
@@ -29,8 +29,11 @@ export interface MigrationSession {
 const SESSION_PREFIX = "migration:"
 const DISCORD_INDEX_PREFIX = "migration:by-discord:"
 
+const COMMIT_LOCK_PREFIX = "migration:commit-lock:"
+
 const sessionKey = (sessionId: string) => `${SESSION_PREFIX}${sessionId}`
 const indexKey = (discordId: string) => `${DISCORD_INDEX_PREFIX}${discordId}`
+export const commitLockKey = (sessionId: string) => `${COMMIT_LOCK_PREFIX}${sessionId}`
 
 export async function createSession(
 	env: Env,
@@ -49,14 +52,14 @@ export async function createSession(
 		createdAt: Math.floor(Date.now() / 1000),
 	}
 	await saveSession(env, session)
-	await env.CACHE.put(indexKey(params.discordId), session.sessionId, {
-		expirationTtl: config.migration.sessionTtlSeconds,
-	})
 	return session
 }
 
 export async function saveSession(env: Env, session: MigrationSession): Promise<void> {
 	await env.CACHE.put(sessionKey(session.sessionId), JSON.stringify(session), {
+		expirationTtl: config.migration.sessionTtlSeconds,
+	})
+	await env.CACHE.put(indexKey(session.discordId), session.sessionId, {
 		expirationTtl: config.migration.sessionTtlSeconds,
 	})
 }

--- a/src/utils/migration-session.ts
+++ b/src/utils/migration-session.ts
@@ -19,7 +19,8 @@ export interface MigrationSession {
 	newKey: string | null
 	status: MigrationStatus
 	failureReason?: string
-	nicknameKept: true
+	oldNickname: string | null
+	newNickname: string | null
 	counts: MigrationCounts | null
 	migrationId: number | null
 	createdAt: number
@@ -41,7 +42,8 @@ export async function createSession(
 		oldKey: params.oldKey,
 		newKey: null,
 		status: "awaiting_new_key",
-		nicknameKept: true,
+		oldNickname: null,
+		newNickname: null,
 		counts: null,
 		migrationId: null,
 		createdAt: Math.floor(Date.now() / 1000),

--- a/src/utils/short-key-id.test.ts
+++ b/src/utils/short-key-id.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { shortKeyId } from "./short-key-id"
+
+describe("shortKeyId", () => {
+	it("returns the last 6 chars of a 64-hex key", () => {
+		const key = `${"a".repeat(58)}abc123`
+		expect(shortKeyId(key)).toBe("abc123")
+	})
+
+	it("returns the whole string when shorter than 6", () => {
+		expect(shortKeyId("abc")).toBe("abc")
+	})
+
+	it("returns an empty string for an empty key", () => {
+		expect(shortKeyId("")).toBe("")
+	})
+})

--- a/src/utils/short-key-id.ts
+++ b/src/utils/short-key-id.ts
@@ -1,0 +1,2 @@
+// The user-facing short id: last 6 hex chars of a 64-hex key id.
+export const shortKeyId = (keyId: string): string => keyId.slice(-6)


### PR DESCRIPTION
## Overview

Self-service account migration driven by the butler bot. Three bot-auth endpoints let a Discord user move their whole Better Lyrics history from an old key onto a new one they prove they control, in a single reversible transaction. The core reuses the local migrate-account script, ported into a real db module and wrapped in a transaction, with every touched row snapshotted as JSONB on an audit row so a commit can be undone later. Proving the new key piggybacks on the existing Discord link flow: when a Discord with a migration in progress links from the new extension, the callback attaches that key instead of relinking. After a commit it busts the leaderboard and submitter caches and recomputes the affected scores.
