### PR TITLE
feat(migrations): account migration web page and carry-over fixes

### DIFF
--- a/src/db/account-migration.integration.test.ts
+++ b/src/db/account-migration.integration.test.ts
@@ -92,26 +92,26 @@ describeIntegration("account migration (integration)", () => {
 		const l4 = await insertLyric(otherUser.id, "vidL4")
 
 		// both voted on L1 (collision); new also voted on L2/L3 (self) and L4 (not self)
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
-			l1,
-			oldUser.id,
-		])
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,-1,0)", [
-			l1,
-			newUser.id,
-		])
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)", [
-			l2,
-			newUser.id,
-		])
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
-			l3,
-			newUser.id,
-		])
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
-			l4,
-			newUser.id,
-		])
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)",
+			[l1, oldUser.id]
+		)
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,-1,0)",
+			[l1, newUser.id]
+		)
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)",
+			[l2, newUser.id]
+		)
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)",
+			[l3, newUser.id]
+		)
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)",
+			[l4, newUser.id]
+		)
 
 		// both reported L1 (collision)
 		await pool.query(
@@ -158,7 +158,11 @@ describeIntegration("account migration (integration)", () => {
 			newKey: NEW_KEY,
 			counts: plan.counts,
 		})
-		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
+		const result = await runMigration(env, {
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			migrationId: auditId,
+		})
 		if ("error" in result) throw new Error(result.error)
 
 		expect(result.moved).toEqual({
@@ -170,9 +174,13 @@ describeIntegration("account migration (integration)", () => {
 		})
 
 		// invariants (mirrors scripts/local/migrate-account.cjs)
-		expect(await num("SELECT count(*)::int n FROM lyrics WHERE submitter_id = $1", [oldUser.id])).toBe(3)
+		expect(
+			await num("SELECT count(*)::int n FROM lyrics WHERE submitter_id = $1", [oldUser.id])
+		).toBe(3)
 		expect(await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [oldUser.id])).toBe(4) // 1+4-1
-		expect(await num("SELECT count(*)::int n FROM reports WHERE user_id = $1", [oldUser.id])).toBe(1) // 1+1-1
+		expect(await num("SELECT count(*)::int n FROM reports WHERE user_id = $1", [oldUser.id])).toBe(
+			1
+		) // 1+1-1
 		expect(await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [OLD_KEY])).toBe(0)
 		expect(await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [NEW_KEY])).toBe(1)
 		expect(await num("SELECT count(*)::int n FROM users WHERE id = $1", [newUser.id])).toBe(0)
@@ -185,19 +193,19 @@ describeIntegration("account migration (integration)", () => {
 		// is_self_vote recomputed from the merged submitter/voter relationship:
 		// L1/L2/L3 are the survivor's own submissions (self), L4 is the third party's (not self)
 		expect(
-			await num(
-				"SELECT count(*)::int n FROM votes WHERE user_id = $1 AND is_self_vote = 1",
-				[oldUser.id]
-			)
+			await num("SELECT count(*)::int n FROM votes WHERE user_id = $1 AND is_self_vote = 1", [
+				oldUser.id,
+			])
 		).toBe(3)
 		expect(
-			await num(
-				"SELECT count(*)::int n FROM votes WHERE user_id = $1 AND is_self_vote = 0",
-				[oldUser.id]
-			)
+			await num("SELECT count(*)::int n FROM votes WHERE user_id = $1 AND is_self_vote = 0", [
+				oldUser.id,
+			])
 		).toBe(1)
 		// discord link followed to the new key
-		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])).toBe(1)
+		expect(
+			await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])
+		).toBe(1)
 		// extension requests deduped and relabelled
 		expect(
 			await num("SELECT count(*)::int n FROM lyrics_requests WHERE requester_id = $1", [NEW_KEY])
@@ -222,18 +230,18 @@ describeIntegration("account migration (integration)", () => {
 		)
 		const l1 = await insertLyric(oldUser.id, "vidL1")
 		const l2 = await insertLyric(newUser.id, "vidL2")
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)", [
-			l1,
-			oldUser.id,
-		])
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,-1,0)", [
-			l1,
-			newUser.id,
-		])
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)", [
-			l2,
-			newUser.id,
-		])
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,0)",
+			[l1, oldUser.id]
+		)
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,-1,0)",
+			[l1, newUser.id]
+		)
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)",
+			[l2, newUser.id]
+		)
 		await pool.query(
 			"INSERT INTO discord_links (discord_id, key_id, discord_username) VALUES ('disc-1', $1, 'alice')",
 			[OLD_KEY]
@@ -244,13 +252,14 @@ describeIntegration("account migration (integration)", () => {
 			usersNew: await num("SELECT count(*)::int n FROM users WHERE key_id = $1", [NEW_KEY]),
 			oldVotes: await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [oldUser.id]),
 			newVotes: await num("SELECT count(*)::int n FROM votes WHERE user_id = $1", [newUser.id]),
-			l2Submitter: (await one<{ submitter_id: number }>(
-				"SELECT submitter_id FROM lyrics WHERE id = $1",
-				[l2]
-			)).submitter_id,
-			newRep: (await one<{ reputation: number }>("SELECT reputation FROM users WHERE id = $1", [
-				newUser.id,
-			])).reputation,
+			l2Submitter: (
+				await one<{ submitter_id: number }>("SELECT submitter_id FROM lyrics WHERE id = $1", [l2])
+			).submitter_id,
+			newRep: (
+				await one<{ reputation: number }>("SELECT reputation FROM users WHERE id = $1", [
+					newUser.id,
+				])
+			).reputation,
 		}
 
 		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
@@ -262,7 +271,11 @@ describeIntegration("account migration (integration)", () => {
 			newKey: NEW_KEY,
 			counts: plan.counts,
 		})
-		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
+		const result = await runMigration(env, {
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			migrationId: auditId,
+		})
 		if ("error" in result) throw new Error(result.error)
 
 		const audit = await getAudit(env, auditId)
@@ -289,11 +302,18 @@ describeIntegration("account migration (integration)", () => {
 				.submitter_id
 		).toBe(before.l2Submitter)
 		expect(
-			(await one<{ reputation: number }>("SELECT reputation FROM users WHERE id = $1", [newUser.id]))
-				.reputation
+			(
+				await one<{ reputation: number }>("SELECT reputation FROM users WHERE id = $1", [
+					newUser.id,
+				])
+			).reputation
 		).toBe(before.newRep)
-		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [OLD_KEY])).toBe(1)
-		expect(await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])).toBe(0)
+		expect(
+			await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [OLD_KEY])
+		).toBe(1)
+		expect(
+			await num("SELECT count(*)::int n FROM discord_links WHERE key_id = $1", [NEW_KEY])
+		).toBe(0)
 	})
 
 	it("applies the new key's nickname when keepNickname is 'new', and restore reverts it", async () => {
@@ -340,7 +360,9 @@ describeIntegration("account migration (integration)", () => {
 			oldUser.id,
 		])
 		expect(reverted.nickname).toBe("Caplump")
-		expect(await num("SELECT count(*)::int n FROM users WHERE nickname = 'tropicawhale'", [])).toBe(1)
+		expect(await num("SELECT count(*)::int n FROM users WHERE nickname = 'tropicawhale'", [])).toBe(
+			1
+		)
 	})
 
 	it("markAuditFailed does not clobber an already-committed audit row", async () => {
@@ -359,7 +381,11 @@ describeIntegration("account migration (integration)", () => {
 			newKey: NEW_KEY,
 			counts: plan.counts,
 		})
-		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
+		const result = await runMigration(env, {
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			migrationId: auditId,
+		})
 		if ("error" in result) throw new Error(result.error)
 
 		await markAuditFailed(env, auditId, "late failure")
@@ -390,18 +416,95 @@ describeIntegration("account migration (integration)", () => {
 			newKey: NEW_KEY,
 			counts: plan.counts,
 		})
-		const result = await runMigration(env, { oldKey: OLD_KEY, newKey: NEW_KEY, migrationId: auditId })
+		const result = await runMigration(env, {
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			migrationId: auditId,
+		})
 		if ("error" in result) throw new Error(result.error)
 
 		// survivor (now NEW_KEY, id = oldUser.id) casts a vote after commit
 		const l2 = await insertLyric(oldUser.id, "vidL2")
-		await pool.query("INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)", [
-			l2,
-			oldUser.id,
-		])
+		await pool.query(
+			"INSERT INTO votes (lyrics_id, user_id, vote, is_self_vote) VALUES ($1,$2,1,1)",
+			[l2, oldUser.id]
+		)
 
 		expect(await restoreFromSnapshot(env, auditId)).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
 		expect(await num("SELECT count(*)::int n FROM votes WHERE lyrics_id = $1", [l2])).toBe(1)
 		expect((await getAudit(env, auditId))?.status).toBe("committed")
+	})
+
+	async function commitBasicMigration(sessionId: string): Promise<number> {
+		await pool.query("INSERT INTO public_keys (key_id, public_key) VALUES ($1, 'x'), ($2, 'y')", [
+			OLD_KEY,
+			NEW_KEY,
+		])
+		const oldUser = await one<{ id: number }>(
+			"INSERT INTO users (key_id) VALUES ($1) RETURNING id",
+			[OLD_KEY]
+		)
+		await pool.query("INSERT INTO users (key_id) VALUES ($1)", [NEW_KEY])
+		await insertLyric(oldUser.id, "vidL1")
+
+		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
+		if ("error" in plan) throw new Error(plan.error)
+		const auditId = await createPreviewAudit(env, {
+			sessionId,
+			discordId: "disc-1",
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			counts: plan.counts,
+		})
+		const result = await runMigration(env, {
+			oldKey: OLD_KEY,
+			newKey: NEW_KEY,
+			migrationId: auditId,
+		})
+		if ("error" in result) throw new Error(result.error)
+		return auditId
+	}
+
+	async function survivorId(): Promise<number> {
+		return (await one<{ id: number }>("SELECT id FROM users WHERE key_id = $1", [NEW_KEY])).id
+	}
+
+	it("refuses to restore over an interim lyric submitted after commit", async () => {
+		const auditId = await commitBasicMigration("sess-interim-lyric")
+		const interim = await insertLyric(await survivorId(), "vidNew")
+
+		expect(await restoreFromSnapshot(env, auditId)).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		expect(await num("SELECT count(*)::int n FROM lyrics WHERE id = $1", [interim])).toBe(1)
+	})
+
+	it("refuses to restore over an interim fulfillment credited after commit", async () => {
+		const auditId = await commitBasicMigration("sess-interim-fulfill")
+		const id = await survivorId()
+		const lyricId = await num("SELECT id::int n FROM lyrics WHERE video_id = 'vidL1'", [])
+		await pool.query(
+			"INSERT INTO request_fulfillments (video_id, lyrics_id, submitter_id, demand_snapshot, request_count_snapshot) VALUES ($1,$2,$3,1.0,1)",
+			["vidL1", lyricId, id]
+		)
+
+		expect(await restoreFromSnapshot(env, auditId)).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		expect(
+			await num("SELECT count(*)::int n FROM request_fulfillments WHERE submitter_id = $1", [id])
+		).toBe(1)
+	})
+
+	it("refuses to restore over an interim extension request made after commit", async () => {
+		const auditId = await commitBasicMigration("sess-interim-request")
+		await pool.query(
+			"INSERT INTO requested_songs (video_id, song, artist) VALUES ('vidReq','s','a')"
+		)
+		await pool.query(
+			"INSERT INTO lyrics_requests (video_id, requester_id, requester_type) VALUES ('vidReq',$1,'extension')",
+			[NEW_KEY]
+		)
+
+		expect(await restoreFromSnapshot(env, auditId)).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		expect(
+			await num("SELECT count(*)::int n FROM lyrics_requests WHERE requester_id = $1", [NEW_KEY])
+		).toBe(1)
 	})
 })

--- a/src/db/account-migration.integration.test.ts
+++ b/src/db/account-migration.integration.test.ts
@@ -142,11 +142,12 @@ describeIntegration("account migration (integration)", () => {
 
 		const plan = await computeMigrationPlan(env, OLD_KEY, NEW_KEY)
 		if ("error" in plan) throw new Error(plan.error)
+		// counts describe the old identity's carried history (L1 submission, 1 vote, 1 report)
 		expect(plan.counts).toEqual({
-			submissions: 2,
-			votes: 4,
+			submissions: 1,
+			votes: 1,
 			reports: 1,
-			fulfillments: 1,
+			fulfillments: 0,
 			collisions: 3, // 1 vote + 1 report + 1 request
 		})
 
@@ -161,10 +162,10 @@ describeIntegration("account migration (integration)", () => {
 		if ("error" in result) throw new Error(result.error)
 
 		expect(result.moved).toEqual({
-			submissions: 2,
-			votes: 4,
+			submissions: 1,
+			votes: 1,
 			reports: 1,
-			fulfillments: 1,
+			fulfillments: 0,
 			collisionsDropped: 3,
 		})
 

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -177,15 +177,15 @@ function mergeSeed(): unknown[] {
 }
 
 describe("runMigration (merge case)", () => {
-	it("returns moved counts and collisionsDropped from the snapshot and collision queries", async () => {
+	it("reports the old identity's carried history as moved, plus collisionsDropped", async () => {
 		const db = makeMockDB(mergeSeed())
 		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		if ("error" in result) throw new Error(`unexpected error: ${result.error}`)
 		expect(result.moved).toEqual({
-			submissions: 2,
+			submissions: 1,
 			votes: 2,
-			reports: 1,
-			fulfillments: 2,
+			reports: 0,
+			fulfillments: 1,
 			collisionsDropped: 2,
 		})
 	})
@@ -357,9 +357,11 @@ describe("runMigration (relabel case)", () => {
 		const db = makeMockDB(relabelSeed())
 		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
 		if ("error" in result) throw new Error("unexpected error")
+		// regression: the relabel case carries the old identity's whole history, so moved is
+		// its holdings (1 submission, 1 vote here), never all-zeros
 		expect(result.moved).toEqual({
-			submissions: 0,
-			votes: 0,
+			submissions: 1,
+			votes: 1,
 			reports: 0,
 			fulfillments: 0,
 			collisionsDropped: 0,

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -307,6 +307,30 @@ describe("runMigration nickname handling", () => {
 		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
 		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
 	})
+
+	it("regression: keeps the new key's nickname when the old identity has none, even with keepNickname:'old'", async () => {
+		const seed = mergeSeed()
+		seed[4] = [
+			{ id: 1, key_id: "oldkey", nickname: null },
+			{ id: 2, key_id: "newkey", nickname: "newnick" },
+		]
+		const db = makeMockDB(seed)
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "old", migrationId: 7 })
+		const call = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
+		expect(call).toBeDefined()
+		expect(call?.params[0]).toBe("newnick")
+	})
+
+	it("writes no nickname when neither identity has one, so the generated petname stands", async () => {
+		const seed = mergeSeed()
+		seed[4] = [
+			{ id: 1, key_id: "oldkey", nickname: null },
+			{ id: 2, key_id: "newkey", nickname: null },
+		]
+		const db = makeMockDB(seed)
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
+		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
+	})
 })
 
 describe("runMigration audit", () => {

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -134,7 +134,17 @@ describe("computeMigrationPlan", () => {
 	})
 
 	it("scopes request collisions to extension requesters and the collision subquery", async () => {
-		const db = makeMockDB([{ id: 1 }, { id: 2 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }])
+		const db = makeMockDB([
+			{ id: 1 },
+			{ id: 2 },
+			{ n: 0 },
+			{ n: 0 },
+			{ n: 0 },
+			{ n: 0 },
+			{ n: 0 },
+			{ n: 0 },
+			{ n: 0 },
+		])
 		await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
 		const reqCall = db.calls.find(
 			(c) => c.sql.includes("lyrics_requests") && c.sql.toLowerCase().includes("count")
@@ -184,7 +194,11 @@ function mergeSeed(): unknown[] {
 describe("runMigration (merge case)", () => {
 	it("reports the old identity's carried history as moved, plus collisionsDropped", async () => {
 		const db = makeMockDB(mergeSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
 		if ("error" in result) throw new Error(`unexpected error: ${result.error}`)
 		expect(result.moved).toEqual({
 			submissions: 1,
@@ -197,7 +211,11 @@ describe("runMigration (merge case)", () => {
 
 	it("captures a snapshot of every touched table", async () => {
 		const db = makeMockDB(mergeSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
 		if ("error" in result) throw new Error("unexpected error")
 		expect(Object.keys(result.snapshot).sort()).toEqual(
 			[
@@ -216,7 +234,11 @@ describe("runMigration (merge case)", () => {
 
 	it("reports affected lyrics and video ids for cache busting and score recompute", async () => {
 		const db = makeMockDB(mergeSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
 		if ("error" in result) throw new Error("unexpected error")
 		expect(result.affectedLyricsIds).toEqual(expect.arrayContaining([10, 11, 12, 20, 21]))
 		expect(result.affectedVideoIds).toEqual(expect.arrayContaining(["vidA", "vidB", "vidC"]))
@@ -253,9 +275,15 @@ describe("runMigration (merge case)", () => {
 			{ discord_id: "disc-old", key_id: "oldkey" }, // old link
 			{ discord_id: "disc-new", key_id: "newkey" }, // new link
 		])
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
 		expect(result).toEqual({ error: "BOTH_KEYS_LINKED" })
-		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(false)
+		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(
+			false
+		)
 	})
 
 	it("rejects SAME_KEY defensively", async () => {
@@ -270,7 +298,11 @@ describe("runMigration (merge case)", () => {
 
 	it("reports OLD_KEY_NO_USER when the old key has no user row", async () => {
 		const db = makeMockDB([null])
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
 		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
 	})
 })
@@ -293,13 +325,20 @@ describe("runMigration nickname handling", () => {
 
 	it("applies the new key's nickname to the survivor when keepNickname is 'new'", async () => {
 		const db = makeMockDB(seedWithNewNickname())
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
+		await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			keepNickname: "new",
+			migrationId: 7,
+		})
 		const call = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
 		expect(call).toBeDefined()
 		expect(call?.params[0]).toBe("newnick")
 		expect(call?.params[call.params.length - 1]).toBe(1) // survivor id
 		// nickname is applied only after the new user row is deleted (frees the unique nickname_lower)
-		expect(idx(db.calls, "DELETE FROM users")).toBeLessThan(idx(db.calls, "UPDATE users SET nickname"))
+		expect(idx(db.calls, "DELETE FROM users")).toBeLessThan(
+			idx(db.calls, "UPDATE users SET nickname")
+		)
 	})
 
 	it("falls back to the old nickname when keepNickname is 'new' but the new key has none", async () => {
@@ -309,7 +348,12 @@ describe("runMigration nickname handling", () => {
 			{ id: 2, key_id: "newkey", nickname: null },
 		]
 		const db = makeMockDB(seed)
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
+		await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			keepNickname: "new",
+			migrationId: 7,
+		})
 		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
 	})
 
@@ -320,7 +364,12 @@ describe("runMigration nickname handling", () => {
 			{ id: 2, key_id: "newkey", nickname: "newnick" },
 		]
 		const db = makeMockDB(seed)
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "old", migrationId: 7 })
+		await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			keepNickname: "old",
+			migrationId: 7,
+		})
 		const call = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
 		expect(call).toBeDefined()
 		expect(call?.params[0]).toBe("newnick")
@@ -333,7 +382,12 @@ describe("runMigration nickname handling", () => {
 			{ id: 2, key_id: "newkey", nickname: null },
 		]
 		const db = makeMockDB(seed)
-		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", keepNickname: "new", migrationId: 7 })
+		await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			keepNickname: "new",
+			migrationId: 7,
+		})
 		expect(db.calls.some((c) => c.sql.includes("UPDATE users SET nickname"))).toBe(false)
 	})
 })
@@ -401,9 +455,9 @@ describe("runMigration audit", () => {
 		)
 		expect(auditUpdate).toBeDefined()
 		expect(auditUpdate?.params[auditUpdate.params.length - 1]).toBe(7)
-		expect(
-			auditUpdate?.params.some((p) => typeof p === "string" && p.includes('"users"'))
-		).toBe(true)
+		expect(auditUpdate?.params.some((p) => typeof p === "string" && p.includes('"users"'))).toBe(
+			true
+		)
 	})
 
 	it("does not write a committed audit row on an error short-circuit", async () => {
@@ -438,7 +492,11 @@ describe("runMigration (relabel case)", () => {
 
 	it("does not re-point votes or reports (no colliding user row), but relabels requests and the key", async () => {
 		const db = makeMockDB(relabelSeed())
-		const result = await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		const result = await runMigration(makeEnv(db), {
+			oldKey: "oldkey",
+			newKey: "newkey",
+			migrationId: 7,
+		})
 		if ("error" in result) throw new Error("unexpected error")
 		// regression: the relabel case carries the old identity's whole history, so moved is
 		// its holdings (1 submission, 1 vote here), never all-zeros
@@ -590,6 +648,55 @@ describe("restoreFromSnapshot", () => {
 					c.sql.startsWith("DELETE") || c.sql.startsWith("UPDATE") || c.sql.startsWith("INSERT")
 			)
 		).toBe(false)
+	})
+
+	it("refuses when the survivor submitted a lyric after commit", async () => {
+		const db = makeMockDB([
+			committedAuditRow(), // getAudit
+			[{ id: 11 }], // votes: snapshot only
+			[], // reports
+			[{ id: 10 }, { id: 777 }], // lyrics: snapshot's 10 + interim 777
+			[{ id: 5 }], // fulfillments: snapshot only
+			[{ id: 3 }], // requests: snapshot only
+		])
+		const result = await restoreFromSnapshot(makeEnv(db), 7)
+		expect(result).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		expect(
+			db.calls.some(
+				(c) =>
+					c.sql.startsWith("DELETE") || c.sql.startsWith("UPDATE") || c.sql.startsWith("INSERT")
+			)
+		).toBe(false)
+	})
+
+	it("refuses when the survivor gained a fulfillment after commit", async () => {
+		const db = makeMockDB([
+			committedAuditRow(), // getAudit
+			[{ id: 11 }], // votes
+			[], // reports
+			[{ id: 10 }], // lyrics
+			[{ id: 5 }, { id: 888 }], // fulfillments: snapshot's 5 + interim 888
+			[{ id: 3 }], // requests
+		])
+		const result = await restoreFromSnapshot(makeEnv(db), 7)
+		expect(result).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+	})
+
+	it("refuses when the survivor made an extension request after commit", async () => {
+		const db = makeMockDB([
+			committedAuditRow(), // getAudit
+			[{ id: 11 }], // votes
+			[], // reports
+			[{ id: 10 }], // lyrics
+			[{ id: 5 }], // fulfillments
+			[{ id: 3 }, { id: 999 }], // requests: snapshot's 3 + interim 999
+		])
+		const result = await restoreFromSnapshot(makeEnv(db), 7)
+		expect(result).toEqual({ error: "HAS_INTERIM_ACTIVITY" })
+		const reqCheck = db.calls.find((c) =>
+			c.sql.includes("SELECT id FROM lyrics_requests WHERE requester_id")
+		)
+		expect(reqCheck?.params).toEqual([["oldkey", "newkey"]])
 	})
 
 	it("reverses the migration: survivor first, new user re-inserted, leaf tables delete+reinsert, lyrics updated", async () => {

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -333,6 +333,60 @@ describe("runMigration nickname handling", () => {
 	})
 })
 
+describe("runMigration reputation merge", () => {
+	function seedWithReps(oldRep: number, newRep: number) {
+		const seed = mergeSeed()
+		seed[4] = [
+			{ id: 1, key_id: "oldkey", reputation: oldRep },
+			{ id: 2, key_id: "newkey", reputation: newRep },
+		]
+		return seed
+	}
+
+	function repParam(db: ReturnType<typeof makeMockDB>): number | undefined {
+		return db.calls.find((c) => c.sql.includes("UPDATE users SET reputation"))?.params[0] as
+			| number
+			| undefined
+	}
+
+	it("sums the earned deltas around the baseline so neither side is dropped", async () => {
+		const db = makeMockDB(seedWithReps(1.5, 1.4))
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		expect(repParam(db)).toBeCloseTo(1.9) // 1.5 + 1.4 - 1.0
+	})
+
+	it("clamps the merged reputation to the max", async () => {
+		const db = makeMockDB(seedWithReps(1.8, 1.7))
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		expect(repParam(db)).toBe(2.0)
+	})
+
+	it("carries a penalty from either side instead of laundering it", async () => {
+		const db = makeMockDB(seedWithReps(1.0, 0.4))
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		expect(repParam(db)).toBeCloseTo(0.4) // 1.0 + 0.4 - 1.0
+	})
+
+	it("does not merge reputation in the relabel case (no new identity)", async () => {
+		const db = makeMockDB([
+			{ id: 1 }, // old user
+			null, // new user (none)
+			{ discord_id: "disc-old", key_id: "oldkey" }, // old link
+			null, // new link
+			[{ id: 1, key_id: "oldkey", reputation: 1.5 }], // users snapshot
+			[], // votes
+			[], // reports
+			[], // lyrics
+			[], // fulfillments
+			[{ discord_id: "disc-old", key_id: "oldkey" }], // discord snapshot
+			[], // requests
+			{ n: 0 }, // request collisions
+		])
+		await runMigration(makeEnv(db), { oldKey: "oldkey", newKey: "newkey", migrationId: 7 })
+		expect(repParam(db)).toBeUndefined()
+	})
+})
+
 describe("runMigration audit", () => {
 	it("writes the committed audit row inside the migration transaction", async () => {
 		const db = makeMockDB(mergeSeed())

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -61,10 +61,14 @@ describe("computeMigrationPlan", () => {
 		expect(result).toEqual({ error: "OLD_KEY_NO_USER" })
 	})
 
-	it("relabel case: new key has no user, only request collisions can be non-zero", async () => {
+	it("relabel case: counts the old identity's holdings; new key has no user", async () => {
 		const db = makeMockDB([
 			{ id: 1, nickname: "oldnick" }, // old user
 			null, // new user (none)
+			{ n: 2 }, // OLD submissions
+			{ n: 2 }, // OLD votes
+			{ n: 0 }, // OLD reports
+			{ n: 0 }, // OLD fulfillments
 			{ n: 2 }, // request collisions
 		])
 		const result = await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
@@ -73,18 +77,18 @@ describe("computeMigrationPlan", () => {
 			newUserId: null,
 			oldNickname: "oldnick",
 			newNickname: null,
-			counts: { submissions: 0, votes: 0, reports: 0, fulfillments: 0, collisions: 2 },
+			counts: { submissions: 2, votes: 2, reports: 0, fulfillments: 0, collisions: 2 },
 		})
 	})
 
-	it("merge case: projects moved counts, collisions, and both nicknames", async () => {
+	it("merge case: counts the old identity's holdings, collisions, and both nicknames", async () => {
 		const db = makeMockDB([
 			{ id: 1, nickname: "oldnick" }, // old user
 			{ id: 2, nickname: "newnick" }, // new user
-			{ n: 5 }, // submissions on new user
-			{ n: 9 }, // votes on new user
-			{ n: 1 }, // reports on new user
-			{ n: 2 }, // fulfillments on new user
+			{ n: 5 }, // OLD submissions
+			{ n: 9 }, // OLD votes
+			{ n: 1 }, // OLD reports
+			{ n: 2 }, // OLD fulfillments
 			{ n: 3 }, // vote collisions
 			{ n: 1 }, // report collisions
 			{ n: 4 }, // request collisions
@@ -97,6 +101,31 @@ describe("computeMigrationPlan", () => {
 			newNickname: "newnick",
 			counts: { submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisions: 3 + 1 + 4 },
 		})
+	})
+
+	it("regression: counts reflect the OLD identity's holdings, not the new key's", async () => {
+		const db = makeMockDB([
+			{ id: 52188, nickname: "gwuhbruh" }, // old user: 2 submissions, 2 votes
+			{ id: 53466, nickname: "runner_66" }, // new user: 0 submissions, 1 vote
+			{ n: 2 }, // OLD submissions
+			{ n: 2 }, // OLD votes
+			{ n: 0 }, // OLD reports
+			{ n: 0 }, // OLD fulfillments
+			{ n: 0 }, // vote collisions
+			{ n: 0 }, // report collisions
+			{ n: 0 }, // request collisions
+		])
+		const result = await computeMigrationPlan(makeEnv(db), "oldkey", "newkey")
+		if ("error" in result) throw new Error("unexpected error")
+		expect(result.counts).toEqual({
+			submissions: 2,
+			votes: 2,
+			reports: 0,
+			fulfillments: 0,
+			collisions: 0,
+		})
+		const subCall = db.calls.find((c) => c.sql.includes("FROM lyrics WHERE submitter_id"))
+		expect(subCall?.params).toEqual([52188])
 	})
 
 	it("scopes request collisions to extension requesters and the collision subquery", async () => {

--- a/src/db/account-migration.test.ts
+++ b/src/db/account-migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { Env } from "@/types"
+import { generatePetName } from "@/utils/petname"
 import {
 	computeMigrationPlan,
 	createPreviewAudit,
@@ -77,6 +78,8 @@ describe("computeMigrationPlan", () => {
 			newUserId: null,
 			oldNickname: "oldnick",
 			newNickname: null,
+			oldDisplayName: "oldnick",
+			newDisplayName: generatePetName("newkey"),
 			counts: { submissions: 2, votes: 2, reports: 0, fulfillments: 0, collisions: 2 },
 		})
 	})
@@ -99,6 +102,8 @@ describe("computeMigrationPlan", () => {
 			newUserId: 2,
 			oldNickname: "oldnick",
 			newNickname: "newnick",
+			oldDisplayName: "oldnick",
+			newDisplayName: "newnick",
 			counts: { submissions: 5, votes: 9, reports: 1, fulfillments: 2, collisions: 3 + 1 + 4 },
 		})
 	})

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -1,3 +1,4 @@
+import { config } from "@/config"
 import type { D1Compat } from "@/infra/database"
 import type { Env } from "@/types"
 import type { MigrationCounts } from "@/utils/migration-session"
@@ -294,6 +295,17 @@ export async function runMigration(
 				.prepare("UPDATE users SET nickname = ?, nickname_updated_at = ? WHERE id = ?")
 				.bind(survivingNickname, now(), oldId)
 				.run()
+		}
+
+		if (newId !== null) {
+			const snapReps = snapshot.users as { key_id: string; reputation: number }[]
+			const oldRep = snapReps.find((u) => u.key_id === oldKey)?.reputation ?? config.reputation.default
+			const newRep = snapReps.find((u) => u.key_id === newKey)?.reputation ?? config.reputation.default
+			const mergedRep = Math.max(
+				config.reputation.min,
+				Math.min(config.reputation.max, oldRep + newRep - config.reputation.default)
+			)
+			await tx.prepare("UPDATE users SET reputation = ? WHERE id = ?").bind(mergedRep, oldId).run()
 		}
 
 		if (oldLink) {

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -2,6 +2,7 @@ import { config } from "@/config"
 import type { D1Compat } from "@/infra/database"
 import type { Env } from "@/types"
 import type { MigrationCounts } from "@/utils/migration-session"
+import { generatePetName } from "@/utils/petname"
 
 const now = () => Math.floor(Date.now() / 1000)
 
@@ -10,6 +11,8 @@ export interface MigrationResolved {
 	newUserId: number | null
 	oldNickname: string | null
 	newNickname: string | null
+	oldDisplayName: string
+	newDisplayName: string
 	counts: MigrationCounts
 }
 
@@ -110,6 +113,8 @@ export async function computeMigrationPlan(
 		newUserId,
 		oldNickname: oldUser.nickname ?? null,
 		newNickname: newUser?.nickname ?? null,
+		oldDisplayName: oldUser.nickname ?? generatePetName(oldKey),
+		newDisplayName: newUser?.nickname ?? generatePetName(newKey),
 		counts: {
 			submissions,
 			votes,

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -195,10 +195,10 @@ export async function runMigration(
 		const fulfillmentRows = snapshot.request_fulfillments as { submitter_id: number | null }[]
 
 		const moved = {
-			submissions: newId !== null ? lyricsRows.filter((r) => r.submitter_id === newId).length : 0,
-			votes: votesRows.filter((r) => r.user_id === newId).length,
-			reports: reportsRows.filter((r) => r.user_id === newId).length,
-			fulfillments: fulfillmentRows.filter((r) => r.submitter_id === newId).length,
+			submissions: lyricsRows.filter((r) => r.submitter_id === oldId).length,
+			votes: votesRows.filter((r) => r.user_id === oldId).length,
+			reports: reportsRows.filter((r) => r.user_id === oldId).length,
+			fulfillments: fulfillmentRows.filter((r) => r.submitter_id === oldId).length,
 			collisionsDropped: 0,
 		}
 

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -277,16 +277,23 @@ export async function runMigration(
 		}
 		await tx.prepare("UPDATE users SET key_id = ? WHERE id = ?").bind(newKey, oldId).run()
 
-		if (keepNickname === "new" && newId !== null) {
-			const newSnapUser = (snapshot.users as { key_id: string; nickname: string | null }[]).find(
-				(u) => u.key_id === newKey
-			)
-			if (newSnapUser?.nickname) {
-				await tx
-					.prepare("UPDATE users SET nickname = ?, nickname_updated_at = ? WHERE id = ?")
-					.bind(newSnapUser.nickname, now(), oldId)
-					.run()
-			}
+		// Nickname survival is a data rule, not the client's call: keep whichever real nickname
+		// exists. keepNickname only breaks the tie when both identities carry one; it can never
+		// drop a nickname that has no counterpart.
+		const snapUsers = snapshot.users as { key_id: string; nickname: string | null }[]
+		const oldNickname = snapUsers.find((u) => u.key_id === oldKey)?.nickname ?? null
+		const newNickname = snapUsers.find((u) => u.key_id === newKey)?.nickname ?? null
+		const survivingNickname =
+			oldNickname && newNickname
+				? keepNickname === "new"
+					? newNickname
+					: oldNickname
+				: (oldNickname ?? newNickname)
+		if (survivingNickname !== null && survivingNickname !== oldNickname) {
+			await tx
+				.prepare("UPDATE users SET nickname = ?, nickname_updated_at = ? WHERE id = ?")
+				.bind(survivingNickname, now(), oldId)
+				.run()
 		}
 
 		if (oldLink) {

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -47,7 +47,7 @@ async function count(env: Env, sql: string, params: unknown[]): Promise<number> 
 	return row?.n ?? 0
 }
 
-// Reads only: resolve the two identities and project what a commit would move.
+// Reads only: resolve the two identities and count the old identity's holdings (what the survivor keeps).
 export async function computeMigrationPlan(
 	env: Env,
 	oldKey: string,
@@ -64,26 +64,26 @@ export async function computeMigrationPlan(
 		.first<{ id: number; nickname: string | null }>()
 	const newUserId = newUser?.id ?? null
 
-	let submissions = 0
-	let votes = 0
-	let reports = 0
-	let fulfillments = 0
+	const submissions = await count(
+		env,
+		"SELECT COUNT(*)::int AS n FROM lyrics WHERE submitter_id = ?",
+		[oldUserId]
+	)
+	const votes = await count(env, "SELECT COUNT(*)::int AS n FROM votes WHERE user_id = ?", [
+		oldUserId,
+	])
+	const reports = await count(env, "SELECT COUNT(*)::int AS n FROM reports WHERE user_id = ?", [
+		oldUserId,
+	])
+	const fulfillments = await count(
+		env,
+		"SELECT COUNT(*)::int AS n FROM request_fulfillments WHERE submitter_id = ?",
+		[oldUserId]
+	)
+
 	let voteCollisions = 0
 	let reportCollisions = 0
-
 	if (newUserId !== null) {
-		submissions = await count(env, "SELECT COUNT(*)::int AS n FROM lyrics WHERE submitter_id = ?", [
-			newUserId,
-		])
-		votes = await count(env, "SELECT COUNT(*)::int AS n FROM votes WHERE user_id = ?", [newUserId])
-		reports = await count(env, "SELECT COUNT(*)::int AS n FROM reports WHERE user_id = ?", [
-			newUserId,
-		])
-		fulfillments = await count(
-			env,
-			"SELECT COUNT(*)::int AS n FROM request_fulfillments WHERE submitter_id = ?",
-			[newUserId]
-		)
 		voteCollisions = await count(
 			env,
 			"SELECT COUNT(*)::int AS n FROM votes WHERE user_id = ? AND lyrics_id IN (SELECT lyrics_id FROM votes WHERE user_id = ?)",

--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -196,7 +196,11 @@ export async function runMigration(
 		}
 
 		const votesRows = snapshot.votes as { user_id: number; lyrics_id: number }[]
-		const lyricsRows = snapshot.lyrics as { id: number; submitter_id: number | null; video_id: string }[]
+		const lyricsRows = snapshot.lyrics as {
+			id: number
+			submitter_id: number | null
+			video_id: string
+		}[]
 		const reportsRows = snapshot.reports as { user_id: number }[]
 		const fulfillmentRows = snapshot.request_fulfillments as { submitter_id: number | null }[]
 
@@ -283,9 +287,7 @@ export async function runMigration(
 		}
 		await tx.prepare("UPDATE users SET key_id = ? WHERE id = ?").bind(newKey, oldId).run()
 
-		// Nickname survival is a data rule, not the client's call: keep whichever real nickname
-		// exists. keepNickname only breaks the tie when both identities carry one; it can never
-		// drop a nickname that has no counterpart.
+		// keepNickname only breaks the tie when both identities carry a nickname; a lone one always survives.
 		const snapUsers = snapshot.users as { key_id: string; nickname: string | null }[]
 		const oldNickname = snapUsers.find((u) => u.key_id === oldKey)?.nickname ?? null
 		const newNickname = snapUsers.find((u) => u.key_id === newKey)?.nickname ?? null
@@ -304,8 +306,10 @@ export async function runMigration(
 
 		if (newId !== null) {
 			const snapReps = snapshot.users as { key_id: string; reputation: number }[]
-			const oldRep = snapReps.find((u) => u.key_id === oldKey)?.reputation ?? config.reputation.default
-			const newRep = snapReps.find((u) => u.key_id === newKey)?.reputation ?? config.reputation.default
+			const oldRep =
+				snapReps.find((u) => u.key_id === oldKey)?.reputation ?? config.reputation.default
+			const newRep =
+				snapReps.find((u) => u.key_id === newKey)?.reputation ?? config.reputation.default
 			const mergedRep = Math.max(
 				config.reputation.min,
 				Math.min(config.reputation.max, oldRep + newRep - config.reputation.default)
@@ -501,6 +505,11 @@ export async function restoreFromSnapshot(
 	return env.DB.transaction(async (tx) => {
 		const snapVoteIds = new Set((snap.votes as SnapVote[]).map((v) => v.id))
 		const snapReportIds = new Set((snap.reports as SnapReport[]).map((r) => r.id))
+		const snapLyricsIds = new Set((snap.lyrics as SnapLyrics[]).map((l) => l.id))
+		const snapFulfillmentIds = new Set(
+			(snap.request_fulfillments as SnapFulfillment[]).map((f) => f.id)
+		)
+		const snapRequestIds = new Set((snap.lyrics_requests as SnapRequest[]).map((r) => r.id))
 		const currentVotes = await all<{ id: number }>(
 			tx,
 			"SELECT id FROM votes WHERE user_id = ANY(?)",
@@ -511,9 +520,27 @@ export async function restoreFromSnapshot(
 			"SELECT id FROM reports WHERE user_id = ANY(?)",
 			[ids]
 		)
+		const currentLyrics = await all<{ id: number }>(
+			tx,
+			"SELECT id FROM lyrics WHERE submitter_id = ANY(?)",
+			[ids]
+		)
+		const currentFulfillments = await all<{ id: number }>(
+			tx,
+			"SELECT id FROM request_fulfillments WHERE submitter_id = ANY(?)",
+			[ids]
+		)
+		const currentRequests = await all<{ id: number }>(
+			tx,
+			"SELECT id FROM lyrics_requests WHERE requester_id = ANY(?)",
+			[[oldKey, newKey]]
+		)
 		if (
 			currentVotes.some((v) => !snapVoteIds.has(v.id)) ||
-			currentReports.some((r) => !snapReportIds.has(r.id))
+			currentReports.some((r) => !snapReportIds.has(r.id)) ||
+			currentLyrics.some((l) => !snapLyricsIds.has(l.id)) ||
+			currentFulfillments.some((f) => !snapFulfillmentIds.has(f.id)) ||
+			currentRequests.some((r) => !snapRequestIds.has(r.id))
 		) {
 			return { error: "HAS_INTERIM_ACTIVITY" } as const
 		}

--- a/src/routes/links.test.ts
+++ b/src/routes/links.test.ts
@@ -318,8 +318,18 @@ describe("GET /links/discord/callback - migration attach", () => {
 	it("treats a link from a discord with an active migration session as the proof, and does NOT relink", async () => {
 		const cache = makeMockCache({ "link_state:st-m": newKey })
 		seedActiveSession(cache)
-		// computeMigrationPlan (relabel: old user with nickname, no new user, req collisions) + createPreviewAudit
-		const db = makeMockDB([{ id: 1, nickname: "Caplump" }, null, { n: 0 }, { id: 99 }])
+		// computeMigrationPlan (relabel: old user with nickname, no new user): old holdings then req
+		// collisions, then createPreviewAudit
+		const db = makeMockDB([
+			{ id: 1, nickname: "Caplump" }, // old user
+			null, // new user (none)
+			{ n: 2 }, // OLD submissions
+			{ n: 2 }, // OLD votes
+			{ n: 0 }, // OLD reports
+			{ n: 0 }, // OLD fulfillments
+			{ n: 0 }, // request collisions
+			{ id: 99 }, // createPreviewAudit
+		])
 		const app = linkRoutes(
 			makeEnv(db, cache),
 			discordFetch({ id: "d-1", username: "alice", global_name: "Alice" })
@@ -340,8 +350,8 @@ describe("GET /links/discord/callback - migration attach", () => {
 		expect(updated.oldNickname).toBe("Caplump")
 		expect(updated.newNickname).toBeNull()
 		expect(updated.counts).toEqual({
-			submissions: 0,
-			votes: 0,
+			submissions: 2,
+			votes: 2,
 			reports: 0,
 			fulfillments: 0,
 			collisions: 0,

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -65,6 +65,8 @@ async function attachMigrationProof(
 		counts: plan.counts,
 		oldNickname: plan.oldNickname,
 		newNickname: plan.newNickname,
+		oldDisplayName: plan.oldDisplayName,
+		newDisplayName: plan.newDisplayName,
 		status: "ready",
 		migrationId,
 	})

--- a/src/routes/migrations.test.ts
+++ b/src/routes/migrations.test.ts
@@ -122,6 +122,8 @@ function baseSession(overrides: Partial<MigrationSession> = {}): MigrationSessio
 		status: "awaiting_new_key",
 		oldNickname: null,
 		newNickname: null,
+		oldDisplayName: null,
+		newDisplayName: null,
 		counts: null,
 		migrationId: null,
 		createdAt: 100,
@@ -215,6 +217,8 @@ describe("GET /migrations/bot/:sessionId", () => {
 				migrationId: 7,
 				oldNickname: "Caplump",
 				newNickname: "tropicawhale",
+				oldDisplayName: "Caplump",
+				newDisplayName: "tropicawhale",
 				counts: { submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 },
 			})
 		)
@@ -225,6 +229,8 @@ describe("GET /migrations/bot/:sessionId", () => {
 		expect(data.newKeyId).toBe("newkey")
 		expect(data.oldNickname).toBe("Caplump")
 		expect(data.newNickname).toBe("tropicawhale")
+		expect(data.oldDisplayName).toBe("Caplump")
+		expect(data.newDisplayName).toBe("tropicawhale")
 		expect(data.counts).toEqual({ submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 })
 	})
 })

--- a/src/routes/migrations.test.ts
+++ b/src/routes/migrations.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { Env } from "@/types"
-import type { MigrationSession } from "@/utils/migration-session"
+import { commitLockKey, type MigrationSession } from "@/utils/migration-session"
 import { migrationRoutes } from "./migrations"
 
 interface DBCall {
@@ -135,7 +135,9 @@ describe("migration bot endpoints - auth", () => {
 	it("rejects all three without a valid bearer token", async () => {
 		const app = migrationRoutes(makeEnv(makeMockDB(), makeMockCache()))
 		const noauth = { authorization: "Bearer wrong" }
-		expect((await app.handle(post("/migrations/bot/start", { discordId: "d" }, noauth))).status).toBe(401)
+		expect(
+			(await app.handle(post("/migrations/bot/start", { discordId: "d" }, noauth))).status
+		).toBe(401)
 		expect((await app.handle(get("/migrations/bot/sess-1", noauth))).status).toBe(401)
 		expect(
 			(await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "d" }, noauth))).status
@@ -231,7 +233,13 @@ describe("GET /migrations/bot/:sessionId", () => {
 		expect(data.newNickname).toBe("tropicawhale")
 		expect(data.oldDisplayName).toBe("Caplump")
 		expect(data.newDisplayName).toBe("tropicawhale")
-		expect(data.counts).toEqual({ submissions: 2, votes: 3, reports: 0, fulfillments: 1, collisions: 1 })
+		expect(data.counts).toEqual({
+			submissions: 2,
+			votes: 3,
+			reports: 0,
+			fulfillments: 1,
+			collisions: 1,
+		})
 	})
 })
 
@@ -287,7 +295,9 @@ describe("POST /migrations/bot/:sessionId/commit", () => {
 		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
 		expect(res.status).toBe(409)
 		expect((await json(res)).code).toBe("MIGRATION_IN_PROGRESS")
-		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(false)
+		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(
+			false
+		)
 	})
 
 	it("commits: runs the migration, marks audit, busts caches, returns moved", async () => {
@@ -364,6 +374,24 @@ describe("POST /migrations/bot/:sessionId/commit", () => {
 		const nick = db.calls.find((c) => c.sql.includes("UPDATE users SET nickname"))
 		expect(nick).toBeDefined()
 		expect(nick?.params[0]).toBe("tropicawhale")
+	})
+
+	it("releases the lock and marks failed when runMigration throws", async () => {
+		const cache = makeMockCache()
+		seedSession(cache, readySession())
+		const db = makeMockDB([
+			{ discord_id: "disc-1", key_id: oldKey }, // re-verify link
+		])
+		db.transaction = async () => {
+			throw new Error("db exploded")
+		}
+		const app = migrationRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/migrations/bot/sess-1/commit", { discordId: "disc-1" }))
+		expect(res.status).toBe(500)
+		expect((await json(res)).code).toBe("MIGRATION_FAILED")
+		expect(cache.deletes).toContain(commitLockKey("sess-1"))
+		const stored = JSON.parse(cache.store.get("migration:sess-1") ?? "{}") as MigrationSession
+		expect(stored.status).toBe("failed")
 	})
 
 	it("returns already_committed for a committed session", async () => {

--- a/src/routes/migrations.ts
+++ b/src/routes/migrations.ts
@@ -85,6 +85,8 @@ export const migrationRoutes = (env: Env) =>
 							newKeyId: null,
 							oldNickname: null,
 							newNickname: null,
+							oldDisplayName: null,
+							newDisplayName: null,
 							counts: null,
 						},
 					})
@@ -97,6 +99,8 @@ export const migrationRoutes = (env: Env) =>
 						newKeyId: session.newKey ? shortKeyId(session.newKey) : null,
 						oldNickname: session.oldNickname,
 						newNickname: session.newNickname,
+						oldDisplayName: session.oldDisplayName,
+						newDisplayName: session.newDisplayName,
 						counts: session.counts,
 					},
 				})

--- a/src/routes/migrations.ts
+++ b/src/routes/migrations.ts
@@ -136,17 +136,33 @@ export const migrationRoutes = (env: Env) =>
 				const locked = await env.CACHE.setNX(lockKey, "1", config.migration.commitLockSeconds)
 				if (!locked) return status(409, buildError(ErrorCode.MIGRATION_IN_PROGRESS))
 
-				const result = await runMigration(env, {
-					oldKey: session.oldKey,
-					newKey: session.newKey,
-					keepNickname: keepNickname ?? "old",
-					migrationId: session.migrationId,
-				})
+				let result: Awaited<ReturnType<typeof runMigration>>
+				try {
+					result = await runMigration(env, {
+						oldKey: session.oldKey,
+						newKey: session.newKey,
+						keepNickname: keepNickname ?? "old",
+						migrationId: session.migrationId,
+					})
+				} catch (err) {
+					await env.CACHE.delete(lockKey)
+					await markAuditFailed(env, session.migrationId, String(err))
+					await saveSession(env, {
+						...session,
+						status: "failed",
+						failureReason: "MIGRATION_FAILED",
+					})
+					log.error("migration commit threw", { sessionId: session.sessionId, error: String(err) })
+					return status(500, buildError(ErrorCode.MIGRATION_FAILED))
+				}
 				if ("error" in result) {
 					await env.CACHE.delete(lockKey)
 					await markAuditFailed(env, session.migrationId, result.error)
 					await saveSession(env, { ...session, status: "failed", failureReason: result.error })
-					log.error("migration commit failed", { sessionId: session.sessionId, error: result.error })
+					log.error("migration commit failed", {
+						sessionId: session.sessionId,
+						error: result.error,
+					})
 					return status(500, buildError(ErrorCode.MIGRATION_FAILED))
 				}
 

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -58,7 +58,6 @@ describe("buildError", () => {
 		const codes: ErrorCode[] = [
 			ErrorCode.NOT_LINKED,
 			ErrorCode.MIGRATION_ALREADY_ACTIVE,
-			ErrorCode.MIGRATION_SAME_KEY,
 			ErrorCode.MIGRATION_NOT_READY,
 			ErrorCode.MIGRATION_NOT_OWNER,
 			ErrorCode.MIGRATION_ALREADY_COMMITTED,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -32,7 +32,6 @@ export const ErrorCode = {
 	LINKING_DISABLED: "LINKING_DISABLED",
 	NOT_LINKED: "NOT_LINKED",
 	MIGRATION_ALREADY_ACTIVE: "MIGRATION_ALREADY_ACTIVE",
-	MIGRATION_SAME_KEY: "MIGRATION_SAME_KEY",
 	MIGRATION_NOT_READY: "MIGRATION_NOT_READY",
 	MIGRATION_NOT_OWNER: "MIGRATION_NOT_OWNER",
 	MIGRATION_ALREADY_COMMITTED: "MIGRATION_ALREADY_COMMITTED",
@@ -161,10 +160,6 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	MIGRATION_ALREADY_ACTIVE: {
 		error: "Migration already in progress",
 		hint: "You already have a migration underway. Finish it, or wait for it to expire, before starting another.",
-	},
-	MIGRATION_SAME_KEY: {
-		error: "Same key",
-		hint: "The new install proved the same key as the old one, so there's nothing to migrate.",
 	},
 	MIGRATION_NOT_READY: {
 		error: "Migration not ready",

--- a/src/utils/migration-session.ts
+++ b/src/utils/migration-session.ts
@@ -21,6 +21,8 @@ export interface MigrationSession {
 	failureReason?: string
 	oldNickname: string | null
 	newNickname: string | null
+	oldDisplayName: string | null
+	newDisplayName: string | null
 	counts: MigrationCounts | null
 	migrationId: number | null
 	createdAt: number
@@ -47,6 +49,8 @@ export async function createSession(
 		status: "awaiting_new_key",
 		oldNickname: null,
 		newNickname: null,
+		oldDisplayName: null,
+		newDisplayName: null,
 		counts: null,
 		migrationId: null,
 		createdAt: Math.floor(Date.now() / 1000),

--- a/web/src/components/AuthFlowLayout.tsx
+++ b/web/src/components/AuthFlowLayout.tsx
@@ -1,0 +1,31 @@
+import { LogoPair } from "@/components/LogoPair"
+import type { ReactNode } from "react"
+
+export function AuthFlowLayout({
+  partner,
+  pulsing = false,
+  children,
+}: {
+  partner: ReactNode
+  pulsing?: boolean
+  children: ReactNode
+}) {
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 py-10 text-center">
+      <LogoPair partner={partner} pulsing={pulsing} />
+      {children}
+    </div>
+  )
+}
+
+export function AuthFlowTitle({ children }: { children: ReactNode }) {
+  return <h1 className="text-xl font-semibold text-unison-text">{children}</h1>
+}
+
+export function AuthFlowBody({ children }: { children: ReactNode }) {
+  return <p className="max-w-sm text-sm leading-relaxed text-unison-text-secondary">{children}</p>
+}
+
+export function AuthFlowError({ children }: { children: ReactNode }) {
+  return <p className="max-w-sm text-sm text-red-400">{children}</p>
+}

--- a/web/src/components/LinkView.tsx
+++ b/web/src/components/LinkView.tsx
@@ -1,32 +1,15 @@
-import { IconAlertTriangle, IconBrandDiscordFilled, IconLoader2, IconProgressDown } from "@tabler/icons-react"
-import type { ReactNode } from "react"
+import {
+  AuthFlowBody as Body,
+  AuthFlowError as ErrorText,
+  AuthFlowLayout as Layout,
+  AuthFlowTitle as Title,
+} from "@/components/AuthFlowLayout"
 import { discordButtonClass, secondaryButtonClass } from "@/components/discord-ui"
-import { LogoPair } from "@/components/LogoPair"
+import { IconAlertTriangle, IconBrandDiscordFilled, IconLoader2, IconProgressDown } from "@tabler/icons-react"
 
 const installIcon = <IconProgressDown className="size-7 text-unison-text-secondary" stroke={1.5} />
 const discordIcon = <IconBrandDiscordFilled className="size-7 text-white" />
 const warnIcon = <IconAlertTriangle className="size-7 text-amber-400" stroke={1.5} />
-
-function Layout({ partner, pulsing = false, children }: { partner: ReactNode; pulsing?: boolean; children: ReactNode }) {
-  return (
-    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 py-10 text-center">
-      <LogoPair partner={partner} pulsing={pulsing} />
-      {children}
-    </div>
-  )
-}
-
-function Title({ children }: { children: ReactNode }) {
-  return <h1 className="text-xl font-semibold text-unison-text">{children}</h1>
-}
-
-function Body({ children }: { children: ReactNode }) {
-  return <p className="max-w-sm text-sm leading-relaxed text-unison-text-secondary">{children}</p>
-}
-
-function ErrorText({ children }: { children: ReactNode }) {
-  return <p className="max-w-sm text-sm text-red-400">{children}</p>
-}
 
 export type LinkViewModel =
   | { kind: "loading" }
@@ -55,12 +38,7 @@ export function LinkView({ model }: { model: LinkViewModel }) {
             Linking happens through the Better Lyrics extension. Install it, then come back to this page to connect your
             Discord.
           </Body>
-          <a
-            href="https://betterlyrics.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={secondaryButtonClass}
-          >
+          <a href="https://betterlyrics.org" target="_blank" rel="noopener noreferrer" className={secondaryButtonClass}>
             Get Better Lyrics
           </a>
         </Layout>
@@ -90,15 +68,8 @@ export function LinkView({ model }: { model: LinkViewModel }) {
       return (
         <Layout partner={discordIcon}>
           <Title>Connected to Discord</Title>
-          <Body>
-            Your account is linked{model.name ? ` as ${model.name}` : ""}. Roles update on their own.
-          </Body>
-          <button
-            type="button"
-            onClick={model.onDisconnect}
-            disabled={model.working}
-            className={secondaryButtonClass}
-          >
+          <Body>Your account is linked{model.name ? ` as ${model.name}` : ""}. Roles update on their own.</Body>
+          <button type="button" onClick={model.onDisconnect} disabled={model.working} className={secondaryButtonClass}>
             {model.working ? "Disconnecting..." : "Disconnect"}
           </button>
           {model.error ? <ErrorText>{model.error}</ErrorText> : null}

--- a/web/src/components/MigrateView.test.tsx
+++ b/web/src/components/MigrateView.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { MigrateView } from "./MigrateView"
+
+afterEach(cleanup)
+
+describe("MigrateView", () => {
+  it("prove: shows the connect button", () => {
+    render(<MigrateView model={{ kind: "prove", connecting: false, error: null, onConnect: vi.fn() }} />)
+    expect(screen.getByRole("button", { name: /connect with discord/i })).toBeTruthy()
+    expect(screen.getByText(/prove your new key/i)).toBeTruthy()
+  })
+
+  it("prove: surfaces an error and a spinner while connecting", () => {
+    render(<MigrateView model={{ kind: "prove", connecting: true, error: "nope", onConnect: vi.fn() }} />)
+    expect(screen.getByText("nope")).toBeTruthy()
+    expect(screen.getByRole("button", { name: /connecting/i })).toBeTruthy()
+  })
+
+  it("ready: greets by name and points back to Discord", () => {
+    render(<MigrateView model={{ kind: "ready", name: "gwuhbruh" }} />)
+    expect(screen.getByText(/new key verified/i)).toBeTruthy()
+    expect(screen.getByText(/gwuhbruh/)).toBeTruthy()
+    expect(screen.getByText(/back to discord/i)).toBeTruthy()
+  })
+
+  it("ready: works without a name", () => {
+    render(<MigrateView model={{ kind: "ready", name: null }} />)
+    expect(screen.getByText(/new key verified/i)).toBeTruthy()
+  })
+
+  it("same_key: explains there is nothing to move", () => {
+    render(<MigrateView model={{ kind: "same_key" }} />)
+    expect(screen.getByText(/same key/i)).toBeTruthy()
+  })
+
+  it("expired: tells the user to run migrate again", () => {
+    render(<MigrateView model={{ kind: "expired" }} />)
+    expect(screen.getByText(/that timed out/i)).toBeTruthy()
+  })
+
+  it("error: tells the user to try again from Discord", () => {
+    render(<MigrateView model={{ kind: "error" }} />)
+    expect(screen.getByText(/something went wrong/i)).toBeTruthy()
+  })
+
+  it("start: directs the user to begin from Discord", () => {
+    render(<MigrateView model={{ kind: "start" }} />)
+    expect(screen.getByText(/start from discord/i)).toBeTruthy()
+  })
+
+  it("install: prompts to install the extension", () => {
+    render(<MigrateView model={{ kind: "install" }} />)
+    expect(screen.getByRole("link", { name: /get better lyrics/i })).toBeTruthy()
+  })
+})

--- a/web/src/components/MigrateView.tsx
+++ b/web/src/components/MigrateView.tsx
@@ -1,0 +1,117 @@
+import {
+  AuthFlowBody as Body,
+  AuthFlowError as ErrorText,
+  AuthFlowLayout as Layout,
+  AuthFlowTitle as Title,
+} from "@/components/AuthFlowLayout"
+import { discordButtonClass, secondaryButtonClass } from "@/components/discord-ui"
+import {
+  IconAlertTriangle,
+  IconBrandDiscordFilled,
+  IconCircleCheck,
+  IconLoader2,
+  IconProgressDown,
+} from "@tabler/icons-react"
+
+const installIcon = <IconProgressDown className="size-7 text-unison-text-secondary" stroke={1.5} />
+const discordIcon = <IconBrandDiscordFilled className="size-7 text-white" />
+const warnIcon = <IconAlertTriangle className="size-7 text-amber-400" stroke={1.5} />
+const successIcon = <IconCircleCheck className="size-7 text-emerald-400" stroke={1.5} />
+
+export type MigrateViewModel =
+  | { kind: "loading" }
+  | { kind: "install" }
+  | { kind: "prove"; connecting: boolean; error: string | null; onConnect: () => void }
+  | { kind: "ready"; name: string | null }
+  | { kind: "same_key" }
+  | { kind: "expired" }
+  | { kind: "error" }
+  | { kind: "start" }
+
+export function MigrateView({ model }: { model: MigrateViewModel }) {
+  switch (model.kind) {
+    case "loading":
+      return (
+        <Layout partner={discordIcon} pulsing>
+          <IconLoader2 className="size-6 animate-spin text-unison-text-muted" stroke={1.5} />
+        </Layout>
+      )
+
+    case "install":
+      return (
+        <Layout partner={installIcon}>
+          <Title>Install Better Lyrics here</Title>
+          <Body>
+            Proving your new key happens through the Better Lyrics extension. Install it on this device, then reopen the
+            link from Discord.
+          </Body>
+          <a href="https://betterlyrics.org" target="_blank" rel="noopener noreferrer" className={secondaryButtonClass}>
+            Get Better Lyrics
+          </a>
+        </Layout>
+      )
+
+    case "prove":
+      return (
+        <Layout partner={discordIcon} pulsing={model.connecting}>
+          <Title>Prove your new key</Title>
+          <Body>
+            Confirm this is your new Better Lyrics install so we can move your history onto it. Two quick taps: confirm
+            it is you in Better Lyrics, then approve Discord.
+          </Body>
+          <button type="button" onClick={model.onConnect} disabled={model.connecting} className={discordButtonClass}>
+            {model.connecting ? (
+              <IconLoader2 className="size-5 animate-spin" stroke={1.5} />
+            ) : (
+              <IconBrandDiscordFilled className="size-5" />
+            )}
+            {model.connecting ? "Connecting..." : "Connect with Discord"}
+          </button>
+          {model.error ? <ErrorText>{model.error}</ErrorText> : null}
+        </Layout>
+      )
+
+    case "ready":
+      return (
+        <Layout partner={successIcon}>
+          <Title>New key verified</Title>
+          <Body>
+            You are verified{model.name ? ` as ${model.name}` : ""}. Head back to Discord and press Continue to review
+            and confirm the move.
+          </Body>
+        </Layout>
+      )
+
+    case "same_key":
+      return (
+        <Layout partner={warnIcon}>
+          <Title>Same key</Title>
+          <Body>This install already uses the key you are migrating from, so there is nothing to move.</Body>
+        </Layout>
+      )
+
+    case "expired":
+      return (
+        <Layout partner={warnIcon}>
+          <Title>That timed out</Title>
+          <Body>This migration expired before it finished. Run /migrate in Discord to start a fresh one.</Body>
+        </Layout>
+      )
+
+    case "error":
+      return (
+        <Layout partner={warnIcon}>
+          <Title>Something went wrong</Title>
+          <Body>We could not verify your new key. Run /migrate in Discord to try again.</Body>
+        </Layout>
+      )
+
+    case "start":
+      return (
+        <Layout partner={discordIcon}>
+          <Title>Start from Discord</Title>
+          <Body>Account migrations begin in Discord. Run /migrate there and open the link it gives you.</Body>
+        </Layout>
+      )
+  }
+}

--- a/web/src/pages/DevIndex.tsx
+++ b/web/src/pages/DevIndex.tsx
@@ -4,6 +4,7 @@ const previews = [
   { to: "/dev/link", title: "Link UI", desc: "Every state of the link page and Discord section." },
   { to: "/dev/curators", title: "Curators", desc: "Leaderboard rows with Discord icons, from fixtures." },
   { to: "/dev/me", title: "Me page", desc: "Profile, nickname, and Discord cards from fixtures." },
+  { to: "/dev/migrate", title: "Migrate UI", desc: "Every state of the account migration page." },
 ]
 
 export default function DevIndex() {

--- a/web/src/pages/DevMigratePreview.tsx
+++ b/web/src/pages/DevMigratePreview.tsx
@@ -1,0 +1,53 @@
+import { MigrateView, type MigrateViewModel } from "@/components/MigrateView"
+import { useState } from "react"
+
+const noop = () => {}
+
+const states: { label: string; model: MigrateViewModel }[] = [
+  { label: "loading", model: { kind: "loading" } },
+  { label: "install", model: { kind: "install" } },
+  { label: "prove", model: { kind: "prove", connecting: false, error: null, onConnect: noop } },
+  { label: "prove (connecting)", model: { kind: "prove", connecting: true, error: null, onConnect: noop } },
+  {
+    label: "prove (error)",
+    model: {
+      kind: "prove",
+      connecting: false,
+      error: "We could not start the proof. Make sure Better Lyrics is installed, then try again.",
+      onConnect: noop,
+    },
+  },
+  { label: "ready", model: { kind: "ready", name: "gwuhbruh" } },
+  { label: "ready (no name)", model: { kind: "ready", name: null } },
+  { label: "same_key", model: { kind: "same_key" } },
+  { label: "expired", model: { kind: "expired" } },
+  { label: "error", model: { kind: "error" } },
+  { label: "start", model: { kind: "start" } },
+]
+
+const tabClass = (active: boolean) =>
+  `cursor-pointer rounded-md border px-3 py-1.5 text-sm transition-colors ${
+    active
+      ? "border-unison-border-strong bg-unison-bg-hover text-unison-text"
+      : "border-unison-border bg-unison-bg-elevated text-unison-text-muted hover:text-unison-text"
+  }`
+
+export default function DevMigratePreview() {
+  const [idx, setIdx] = useState(5)
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-base font-semibold text-unison-text">MigratePage states</h2>
+      <div className="flex flex-wrap gap-2">
+        {states.map((s, i) => (
+          <button key={s.label} type="button" className={tabClass(i === idx)} onClick={() => setIdx(i)}>
+            {s.label}
+          </button>
+        ))}
+      </div>
+      <div className="rounded-lg border border-unison-border bg-unison-bg">
+        <MigrateView model={states[idx].model} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/MigratePage.test.tsx
+++ b/web/src/pages/MigratePage.test.tsx
@@ -1,0 +1,141 @@
+import { AuthProvider } from "@/auth/AuthProvider"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { MigratePage } from "./MigratePage"
+
+function renderAt(entry: string) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <AuthProvider>
+        <MigratePage />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+function stubExtension(available: boolean, onAuth?: (req: { type: string }) => unknown) {
+  if (!available) {
+    vi.stubGlobal("chrome", undefined)
+    return
+  }
+  vi.stubGlobal("chrome", {
+    runtime: {
+      connect: (_id: string, info: { name: string }) => {
+        let onMessageListener: ((m: unknown) => void) | null = null
+        return {
+          name: info.name,
+          onMessage: {
+            addListener: (l: (m: unknown) => void) => {
+              onMessageListener = l
+            },
+          },
+          onDisconnect: {
+            addListener: (l: () => void) => {
+              if (info.name === "bl-probe") queueMicrotask(l)
+            },
+          },
+          postMessage: (req: { type: string }) => {
+            queueMicrotask(() => onMessageListener?.(onAuth?.(req)))
+          },
+          disconnect: () => {},
+        }
+      },
+    },
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+describe("MigratePage result screens", () => {
+  it("shows the verified screen with the Discord name", async () => {
+    stubExtension(false)
+    renderAt("/migrate?status=ready&name=gwuhbruh")
+    expect(await screen.findByText(/new key verified/i)).toBeTruthy()
+    expect(screen.getByText(/gwuhbruh/)).toBeTruthy()
+  })
+
+  it("shows the same_key screen", async () => {
+    stubExtension(false)
+    renderAt("/migrate?status=same_key")
+    expect(await screen.findByText(/same key/i)).toBeTruthy()
+  })
+
+  it("shows the expired screen", async () => {
+    stubExtension(false)
+    renderAt("/migrate?status=expired")
+    expect(await screen.findByText(/that timed out/i)).toBeTruthy()
+  })
+
+  it("shows the error screen for any other status", async () => {
+    stubExtension(false)
+    renderAt("/migrate?status=error")
+    expect(await screen.findByText(/something went wrong/i)).toBeTruthy()
+  })
+})
+
+describe("MigratePage prove flow", () => {
+  it("directs to Discord when opened without a session or status", async () => {
+    stubExtension(false)
+    renderAt("/migrate")
+    expect(await screen.findByText(/start from discord/i)).toBeTruthy()
+  })
+
+  it("prompts to install when the extension is missing", async () => {
+    stubExtension(false)
+    renderAt("/migrate?session=msess")
+    expect(await screen.findByText(/install better lyrics here/i)).toBeTruthy()
+  })
+
+  it("shows the connect button when the extension is available", async () => {
+    stubExtension(true, () => ({ ok: true }))
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{}", { status: 200 })))
+    renderAt("/migrate?session=msess")
+    expect(await screen.findByRole("button", { name: /connect with discord/i })).toBeTruthy()
+  })
+
+  it("runs the sign-and-start flow when Connect is clicked", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/auth/challenge")) {
+        return new Response(JSON.stringify({ success: true, data: { nonce: "n".repeat(16), expiresAt: 1 } }), {
+          status: 200,
+        })
+      }
+      if (url.endsWith("/links/discord/start")) {
+        return new Response(
+          JSON.stringify({ success: true, data: { authorizeUrl: "https://discord.com/oauth2/authorize?x=1" } }),
+          { status: 200 },
+        )
+      }
+      return new Response("{}", { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    vi.spyOn(window.location, "assign").mockImplementation(() => {})
+    stubExtension(true, (req) =>
+      req.type === "bl-auth-request"
+        ? { ok: true, signedBody: { payload: {}, signature: "", publicKey: {} } }
+        : { ok: true },
+    )
+
+    renderAt("/migrate?session=msess")
+    const button = await screen.findByRole("button", { name: /connect with discord/i })
+    await act(async () => {
+      button.click()
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/auth/challenge"))
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith("/links/discord/start"))).toBe(true),
+    )
+  })
+})

--- a/web/src/pages/MigratePage.tsx
+++ b/web/src/pages/MigratePage.tsx
@@ -1,0 +1,41 @@
+import { useSession } from "@/auth/useSession"
+import { MigrateView, type MigrateViewModel } from "@/components/MigrateView"
+import { useDiscordLink } from "@/hooks/useDiscordLink"
+import { useSearchParams } from "react-router-dom"
+
+export function MigratePage() {
+  const [params] = useSearchParams()
+  const status = params.get("status")
+  const sessionId = params.get("session")
+  const session = useSession()
+  const link = useDiscordLink({ enabled: false })
+
+  if (status) {
+    const name = params.get("name")
+    const model: MigrateViewModel =
+      status === "ready"
+        ? { kind: "ready", name }
+        : status === "same_key"
+          ? { kind: "same_key" }
+          : status === "expired"
+            ? { kind: "expired" }
+            : { kind: "error" }
+    return <MigrateView model={model} />
+  }
+
+  if (!sessionId) {
+    return <MigrateView model={{ kind: "start" }} />
+  }
+
+  if (session.status === "loading") {
+    return <MigrateView model={{ kind: "loading" }} />
+  }
+
+  if (!session.extensionAvailable) {
+    return <MigrateView model={{ kind: "install" }} />
+  }
+
+  return (
+    <MigrateView model={{ kind: "prove", connecting: link.connecting, error: link.error, onConnect: link.connect }} />
+  )
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -8,6 +8,7 @@ import { DownloadsPage } from "./pages/DownloadsPage"
 import { LinkPage } from "./pages/LinkPage"
 import { LyricsPage } from "./pages/LyricsPage"
 import { MePage } from "./pages/MePage"
+import { MigratePage } from "./pages/MigratePage"
 import { QueuePage } from "./pages/QueuePage"
 import { SearchPage } from "./pages/SearchPage"
 import { SongsPage } from "./pages/SongsPage"
@@ -23,6 +24,7 @@ if (import.meta.env.DEV) {
     { path: "dev/link", load: () => import("./pages/DevLinkPreview") },
     { path: "dev/curators", load: () => import("./pages/DevCuratorsPreview") },
     { path: "dev/me", load: () => import("./pages/DevMePreview") },
+    { path: "dev/migrate", load: () => import("./pages/DevMigratePreview") },
   ]
   for (const { path, load } of devPages) {
     const Page = lazy(load)
@@ -53,6 +55,7 @@ const router = createBrowserRouter([
       { path: "downloads", element: <DownloadsPage /> },
       { path: "docs", element: <DocsPage /> },
       { path: "link", element: <LinkPage /> },
+      { path: "migrate", element: <MigratePage /> },
       ...devRoutes,
     ],
   },


### PR DESCRIPTION
## Overview

The migration preview and success card were counting the new key's rows instead of the history being carried over, so a real migration told people they had 0 submissions when they actually had plenty. Both now show what the old identity keeps. Also builds the /migrate page the OAuth callback redirects to, since the route never existed and just 404'd, and moves nickname and reputation handling server-side so a bad flag from the bot can't quietly drop someone's data: a lone nickname always survives, and the two accounts' reputations merge instead of the new one getting tossed.
