### PR TITLE
feat: admin account-migration endpoints

### DIFF
--- a/src/db/account-migration.ts
+++ b/src/db/account-migration.ts
@@ -416,7 +416,8 @@ export async function createPreviewAudit(
 			counts.collisions
 		)
 		.first<{ id: number }>()
-	return row!.id
+	// migration_requests.id is BIGSERIAL; node-postgres returns bigint as a string.
+	return Number(row!.id)
 }
 
 export async function markAuditFailed(env: Env, id: number, error: string): Promise<void> {
@@ -428,10 +429,37 @@ export async function markAuditFailed(env: Env, id: number, error: string): Prom
 		.run()
 }
 
+// Marks a committed migration as reverted by clearing its now-consumed snapshot,
+// so it is no longer offered for undo and reads as reverted in the history.
+export async function markAuditReverted(env: Env, id: number): Promise<void> {
+	await env.DB.prepare(
+		"UPDATE migration_requests SET snapshot = NULL, updated_at = EXTRACT(EPOCH FROM NOW())::INTEGER WHERE id = ?"
+	)
+		.bind(id)
+		.run()
+}
+
 export async function getAudit(env: Env, id: number): Promise<MigrationAuditRow | null> {
-	return env.DB.prepare("SELECT * FROM migration_requests WHERE id = ?")
+	const row = await env.DB.prepare("SELECT * FROM migration_requests WHERE id = ?")
 		.bind(id)
 		.first<MigrationAuditRow>()
+	// migration_requests.id is BIGSERIAL; node-postgres returns bigint as a string.
+	return row ? { ...row, id: Number(row.id) } : null
+}
+
+export type MigrationAuditSummary = Omit<MigrationAuditRow, "snapshot"> & { hasSnapshot: boolean }
+
+// Recent audit rows for the history view, newest first, without the heavy snapshot.
+export async function listAudits(env: Env, limit: number): Promise<MigrationAuditSummary[]> {
+	const { results } = await env.DB.prepare(
+		`SELECT id, session_id, discord_id, old_key, new_key, status,
+			moved_submissions, moved_votes, moved_reports, moved_fulfillments, collisions_dropped,
+			error, created_at, updated_at, (snapshot IS NOT NULL) AS "hasSnapshot"
+		 FROM migration_requests ORDER BY id DESC LIMIT ?`
+	)
+		.bind(limit)
+		.all<MigrationAuditSummary>()
+	return results.map((r) => ({ ...r, id: Number(r.id) }))
 }
 
 interface SnapUser {

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -51,9 +51,7 @@ export async function setNickname(
 ): Promise<SetNicknameResult> {
 	const now = Math.floor(Date.now() / 1000)
 	try {
-		await env.DB.prepare(
-			"UPDATE users SET nickname = ?, nickname_updated_at = ? WHERE key_id = ?"
-		)
+		await env.DB.prepare("UPDATE users SET nickname = ?, nickname_updated_at = ? WHERE key_id = ?")
 			.bind(nickname, now, keyId)
 			.run()
 	} catch (err) {
@@ -69,13 +67,58 @@ export async function setNickname(
 
 export async function clearNickname(env: Env, keyId: string): Promise<void> {
 	const now = Math.floor(Date.now() / 1000)
-	await env.DB.prepare(
-		"UPDATE users SET nickname = NULL, nickname_updated_at = ? WHERE key_id = ?"
-	)
+	await env.DB.prepare("UPDATE users SET nickname = NULL, nickname_updated_at = ? WHERE key_id = ?")
 		.bind(now, keyId)
 		.run()
 	await invalidateCacheForSubmitter(env, keyId)
 	await invalidateCuratorLeaderboardCache(env)
+}
+
+export interface AccountSearchRow {
+	id: number
+	key_id: string
+	nickname: string | null
+	reputation: number
+	discord_id: string | null
+	discord_username: string | null
+	submissions: number
+	votes: number
+	reports: number
+	requests: number
+}
+
+const ACCOUNT_SEARCH_SQL = `
+	SELECT
+		u.id, u.key_id, u.nickname, u.reputation,
+		dl.discord_id, dl.discord_username,
+		(SELECT COUNT(*)::int FROM lyrics l WHERE l.submitter_id = u.id AND l.deleted_at IS NULL) AS submissions,
+		(SELECT COUNT(*)::int FROM votes v WHERE v.user_id = u.id) AS votes,
+		(SELECT COUNT(*)::int FROM reports r WHERE r.user_id = u.id) AS reports,
+		(SELECT COUNT(*)::int FROM lyrics_requests lr
+			WHERE lr.requester_id = u.key_id AND lr.requester_type = 'extension') AS requests
+	FROM users u
+	LEFT JOIN discord_links dl ON dl.key_id = u.key_id
+	WHERE u.key_id = ?
+		OR u.key_id ILIKE ? || '%'
+		OR u.id = ?
+		OR u.nickname_lower LIKE '%' || LOWER(?) || '%'
+		OR dl.discord_id = ?
+		OR dl.discord_username ILIKE '%' || ? || '%'
+	ORDER BY (u.key_id = ?) DESC, (u.key_id ILIKE ? || '%') DESC, u.reputation DESC NULLS LAST
+	LIMIT ?
+`
+
+export async function searchAccounts(
+	env: Env,
+	query: string,
+	limit: number
+): Promise<AccountSearchRow[]> {
+	const q = query.trim()
+	const idMatch = /^\d{1,9}$/.test(q) ? Number.parseInt(q, 10) : null
+	const { results } = await env.DB.prepare(ACCOUNT_SEARCH_SQL)
+		.bind(q, q, idMatch, q, q, q, q, q, limit)
+		.all<AccountSearchRow>()
+	return results
 }
 
 export async function updateUserAvgVote(env: Env, userId: number): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { cleanupFulfilledRequests } from "@/jobs/cleanup-fulfilled-requests"
 import { runDumpJob } from "@/jobs/dump"
 import { updateScores } from "@/jobs/score-updater"
 import { auditThresholds } from "@/jobs/threshold-audit"
+import { adminRoutes } from "@/routes/admin"
 import { authRoutes } from "@/routes/auth"
 import { compatRoutes } from "@/routes/compat"
 import { feedRoutes } from "@/routes/feed"
@@ -204,6 +205,7 @@ const app = new Elysia({ adapter: node() })
 	.use(linkStartRoutes(env))
 	.use(linkRoutes(env))
 	.use(migrationRoutes(env))
+	.use(adminRoutes(env))
 	.get("/*", ({ request }) => {
 		const { pathname } = new URL(request.url)
 

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -82,6 +82,7 @@ export function createEnv(): Env {
 		DUMP_DATABASE_URL: process.env.DUMP_DATABASE_URL || null,
 		B2: readB2Config(),
 		BUTLER_BOT_SECRET: process.env.BUTLER_BOT_SECRET || null,
+		ADMIN_SECRET: process.env.ADMIN_SECRET || null,
 		DISCORD_OAUTH: readDiscordOAuthConfig(),
 	}
 }

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -1,0 +1,574 @@
+import type { Env } from "@/types"
+import { describe, expect, it } from "vitest"
+import { adminRoutes } from "./admin"
+
+interface DBCall {
+	sql: string
+	params: unknown[]
+}
+
+function makeMockDB(queue: unknown[] = []) {
+	const calls: DBCall[] = []
+	const db = {
+		calls,
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					return {
+						async first<T>(): Promise<T | null> {
+							calls.push({ sql, params: args })
+							const item = queue.shift()
+							if (item instanceof Error) throw item
+							return (item as T) ?? null
+						},
+						async all<T>(): Promise<{ results: T[] }> {
+							calls.push({ sql, params: args })
+							const item = queue.shift()
+							if (item instanceof Error) throw item
+							return { results: (item as T[]) ?? [] }
+						},
+						async run(): Promise<void> {
+							calls.push({ sql, params: args })
+						},
+					}
+				},
+			}
+		},
+		async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+			return fn(db)
+		},
+	}
+	return db
+}
+
+function makeMockCache(seed: Record<string, string> = {}) {
+	const store = new Map(Object.entries(seed))
+	const deletes: string[] = []
+	return {
+		store,
+		deletes,
+		async get(k: string) {
+			return store.get(k) ?? null
+		},
+		async put(k: string, v: string) {
+			store.set(k, v)
+		},
+		async delete(k: string) {
+			deletes.push(k)
+			store.delete(k)
+		},
+		async getDel(k: string) {
+			const v = store.get(k) ?? null
+			store.delete(k)
+			return v
+		},
+		async setNX() {
+			return true
+		},
+		async keys() {
+			return []
+		},
+	}
+}
+
+function makeEnv(
+	db: ReturnType<typeof makeMockDB>,
+	cache: ReturnType<typeof makeMockCache>,
+	overrides: Partial<Env> = {}
+): Env {
+	return {
+		DB: db as unknown as Env["DB"],
+		CACHE: cache as unknown as Env["CACHE"],
+		ADMIN_SECRET: "admin-secret",
+		BUTLER_BOT_SECRET: "bot-secret",
+		...overrides,
+	} as unknown as Env
+}
+
+const ADMIN = { authorization: "Bearer admin-secret" }
+
+function get(path: string, headers: Record<string, string> = ADMIN) {
+	return new Request(`http://localhost${path}`, { method: "GET", headers })
+}
+
+function post(path: string, body: unknown, headers: Record<string, string> = ADMIN) {
+	return new Request(`http://localhost${path}`, {
+		method: "POST",
+		headers: { "content-type": "application/json", ...headers },
+		body: JSON.stringify(body),
+	})
+}
+
+async function json(res: Response) {
+	return (await res.json()) as { success: boolean; data?: unknown; code?: string }
+}
+
+describe("GET /admin/accounts/search - auth", () => {
+	it("rejects a wrong bearer", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(
+			get("/admin/accounts/search?q=abc", { authorization: "Bearer wrong" })
+		)
+		expect(res.status).toBe(401)
+	})
+
+	it("returns 404 when ADMIN_SECRET is unset (deploy dark)", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache(), { ADMIN_SECRET: null }))
+		const res = await app.handle(get("/admin/accounts/search?q=abc"))
+		expect(res.status).toBe(404)
+	})
+
+	it("does not accept the butler bot secret", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(
+			get("/admin/accounts/search?q=abc", { authorization: "Bearer bot-secret" })
+		)
+		expect(res.status).toBe(401)
+	})
+})
+
+describe("GET /admin/accounts/search", () => {
+	it("returns 400 for a missing or too-short query", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		expect((await app.handle(get("/admin/accounts/search"))).status).toBe(400)
+		expect((await app.handle(get("/admin/accounts/search?q=a"))).status).toBe(400)
+	})
+
+	it("maps rows to account hits with holdings and a short key id", async () => {
+		const key = `${"a".repeat(58)}abc123`
+		const db = makeMockDB([
+			[
+				{
+					id: 5,
+					key_id: key,
+					nickname: "Caplump",
+					reputation: 1.5,
+					discord_id: "disc-9",
+					discord_username: "cap#1",
+					submissions: 3,
+					votes: 10,
+					reports: 1,
+					requests: 2,
+				},
+			],
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(get("/admin/accounts/search?q=capl"))
+		expect(res.status).toBe(200)
+		const data = (await json(res)).data as Record<string, unknown>[]
+		expect(data).toHaveLength(1)
+		expect(data[0]).toMatchObject({
+			userId: 5,
+			keyId: key,
+			keyShort: "abc123",
+			nickname: "Caplump",
+			discordId: "disc-9",
+			discordUsername: "cap#1",
+			reputation: 1.5,
+			submissions: 3,
+			votes: 10,
+			reports: 1,
+			requests: 2,
+		})
+	})
+
+	it("passes a numeric user-id match parameter when the query is all digits", async () => {
+		const db = makeMockDB([[]])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		await app.handle(get("/admin/accounts/search?q=42"))
+		const call = db.calls.at(-1)
+		expect(call?.params).toContain(42)
+	})
+
+	it("passes a null id match parameter when the query is not numeric", async () => {
+		const db = makeMockDB([[]])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		await app.handle(get("/admin/accounts/search?q=capl"))
+		const call = db.calls.at(-1)
+		expect(call?.params).toContain(null)
+	})
+})
+
+describe("POST /admin/migrations/preview", () => {
+	const oldKey = `${"a".repeat(58)}oldkey`
+	const newKey = `${"b".repeat(58)}newkey`
+
+	it("rejects without a valid admin bearer", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(
+			post("/admin/migrations/preview", { oldKey, newKey }, { authorization: "Bearer wrong" })
+		)
+		expect(res.status).toBe(401)
+	})
+
+	it("returns SAME_KEY when both keys are identical", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/preview", { oldKey, newKey: oldKey }))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_SAME_KEY")
+	})
+
+	it("returns BOTH_KEYS_LINKED when both keys already have a discord link", async () => {
+		const db = makeMockDB([
+			{ discord_id: "d1", key_id: oldKey },
+			{ discord_id: "d2", key_id: newKey },
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/preview", { oldKey, newKey }))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_BOTH_KEYS_LINKED")
+	})
+
+	it("returns OLD_KEY_NO_USER when the old key has no account", async () => {
+		const db = makeMockDB([
+			null, // oldLink
+			null, // newLink
+			null, // computeMigrationPlan -> old user lookup: none
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/preview", { oldKey, newKey }))
+		expect(res.status).toBe(404)
+		expect((await json(res)).code).toBe("MIGRATION_OLD_KEY_NO_USER")
+	})
+
+	it("computes the dry-run plan, writes a preview audit, and returns migrationId + plan", async () => {
+		const db = makeMockDB([
+			null, // oldLink
+			null, // newLink
+			{ id: 1, nickname: "Caplump" }, // plan: old user
+			null, // plan: new user (new key unseen)
+			{ n: 0 }, // plan: submissions (old identity holdings)
+			{ n: 0 }, // plan: votes
+			{ n: 0 }, // plan: reports
+			{ n: 0 }, // plan: fulfillments
+			{ n: 0 }, // plan: request collisions
+			{ id: "77" }, // createPreviewAudit RETURNING id (bigint -> string from pg)
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/preview", { oldKey, newKey }))
+		expect(res.status).toBe(200)
+		const data = (await json(res)).data as {
+			migrationId: number
+			plan: Record<string, unknown>
+		}
+		expect(data.migrationId).toBe(77)
+		expect(data.plan).toMatchObject({
+			oldUserId: 1,
+			newUserId: null,
+			oldNickname: "Caplump",
+			newNickname: null,
+			survivingNickname: "Caplump",
+			counts: { submissions: 0, votes: 0, reports: 0, fulfillments: 0, collisions: 0 },
+		})
+		const insert = db.calls.find((c) => c.sql.includes("INSERT INTO migration_requests"))
+		expect(insert?.params).toContain("admin")
+	})
+})
+
+describe("POST /admin/migrations/:id/commit", () => {
+	const oldKey = `${"a".repeat(58)}oldkey`
+	const newKey = `${"b".repeat(58)}newkey`
+
+	it("rejects without a valid admin bearer", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(
+			post("/admin/migrations/1/commit", {}, { authorization: "Bearer wrong" })
+		)
+		expect(res.status).toBe(401)
+	})
+
+	it("returns NOT_FOUND when the migration id does not exist", async () => {
+		const db = makeMockDB([null])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/999/commit", {}))
+		expect(res.status).toBe(404)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_FOUND")
+	})
+
+	it("returns ALREADY_COMMITTED for an already-committed migration", async () => {
+		const db = makeMockDB([{ id: 5, status: "committed", old_key: oldKey, new_key: newKey }])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/5/commit", {}))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_ALREADY_COMMITTED")
+	})
+
+	it("returns IN_PROGRESS when the commit lock is already held", async () => {
+		const db = makeMockDB([{ id: 5, status: "preview", old_key: oldKey, new_key: newKey }])
+		const cache = makeMockCache()
+		cache.setNX = async () => false
+		const app = adminRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/admin/migrations/5/commit", {}))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_IN_PROGRESS")
+		expect(db.calls.some((c) => c.sql.startsWith("UPDATE") || c.sql.startsWith("DELETE"))).toBe(
+			false
+		)
+	})
+
+	it("commits with keys read off the audit row, busts caches, returns moved + verification", async () => {
+		const db = makeMockDB([
+			{ id: 77, status: "preview", old_key: oldKey, new_key: newKey }, // getAudit (pre-commit)
+			{ id: 1 }, // runMigration: old user
+			null, // runMigration: new user (relabel case)
+			null, // old link
+			null, // new link
+			[{ id: 1, key_id: oldKey }], // users snapshot
+			[], // votes snapshot
+			[], // reports snapshot
+			[], // lyrics snapshot
+			[], // fulfillments snapshot
+			[], // discord snapshot
+			[], // requests snapshot
+			{ n: 0 }, // request collisions
+			[], // invalidateCacheForSubmitter: distinct video_ids
+			{
+				id: 77,
+				status: "committed",
+				moved_submissions: 0,
+				moved_votes: 0,
+				moved_reports: 0,
+				moved_fulfillments: 0,
+				collisions_dropped: 0,
+			}, // getAudit (verification)
+		])
+		const cache = makeMockCache()
+		const app = adminRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/admin/migrations/77/commit", {}))
+		expect(res.status).toBe(200)
+		const data = (await json(res)).data as {
+			moved: Record<string, number>
+			verification: Record<string, unknown>
+		}
+		expect(data.moved).toEqual({
+			submissions: 0,
+			votes: 0,
+			reports: 0,
+			fulfillments: 0,
+			collisionsDropped: 0,
+		})
+		expect(data.verification.status).toBe("committed")
+		expect(db.calls.some((c) => c.sql.includes("status = 'committed'"))).toBe(true)
+		expect(
+			db.calls.some((c) => c.sql.startsWith("UPDATE users SET key_id") && c.params.includes(newKey))
+		).toBe(true)
+	})
+
+	it("accepts a commit with no request body (body is optional)", async () => {
+		const db = makeMockDB([null]) // getAudit -> not found
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const req = new Request("http://localhost/admin/migrations/1/commit", {
+			method: "POST",
+			headers: ADMIN,
+		})
+		const res = await app.handle(req)
+		// Reaches the handler (404 not_found) rather than a 422 body-validation error.
+		expect(res.status).toBe(404)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_FOUND")
+	})
+
+	it("releases the commit lock and marks the audit failed when runMigration throws", async () => {
+		const db = makeMockDB([
+			{ id: 77, status: "preview", old_key: oldKey, new_key: newKey }, // getAudit (pre-commit)
+			new Error("db exploded mid-transaction"), // runMigration first read throws
+		])
+		const cache = makeMockCache()
+		const app = adminRoutes(makeEnv(db, cache))
+		const res = await app.handle(post("/admin/migrations/77/commit", {}))
+		expect(res.status).toBe(500)
+		expect(cache.deletes).toContain("admin:migration:commit:77")
+		expect(db.calls.some((c) => c.sql.includes("status = 'failed'"))).toBe(true)
+	})
+})
+
+describe("POST /admin/migrations/:id/undo", () => {
+	const oldKey = `${"a".repeat(58)}oldkey`
+	const newKey = `${"b".repeat(58)}newkey`
+
+	function committedAudit(snapshot: Record<string, unknown[]>) {
+		return {
+			id: 5,
+			status: "committed",
+			old_key: oldKey,
+			new_key: newKey,
+			snapshot,
+		}
+	}
+
+	const oldSnapUser = {
+		id: 1,
+		key_id: oldKey,
+		reputation: 1,
+		vote_count: 0,
+		avg_vote: 0,
+		created_at: 1,
+		nickname: null,
+		nickname_updated_at: null,
+	}
+
+	it("rejects without a valid admin bearer", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(
+			post("/admin/migrations/5/undo", {}, { authorization: "Bearer wrong" })
+		)
+		expect(res.status).toBe(401)
+	})
+
+	it("returns NOT_FOUND when the migration id does not exist", async () => {
+		const db = makeMockDB([null])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/999/undo", {}))
+		expect(res.status).toBe(404)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_FOUND")
+	})
+
+	it("returns NOT_COMMITTED for a non-committed migration", async () => {
+		const db = makeMockDB([
+			{ id: 5, status: "preview", old_key: oldKey, new_key: newKey, snapshot: null },
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/5/undo", {}))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_COMMITTED")
+	})
+
+	const fullSnap = {
+		users: [oldSnapUser],
+		votes: [] as { id: number }[],
+		reports: [] as { id: number }[],
+		lyrics: [],
+		request_fulfillments: [],
+		discord_links: [],
+		lyrics_requests: [],
+	}
+
+	it("returns HAS_INTERIM_ACTIVITY when new votes landed since the commit", async () => {
+		const snap = { ...fullSnap, votes: [{ id: 10 }] }
+		const db = makeMockDB([
+			committedAudit(snap), // route getAudit
+			null, // getUserByKeyId(old_key): does not resolve
+			committedAudit(snap), // restoreFromSnapshot getAudit
+			[{ id: 11 }], // current votes: an id not present in the snapshot
+			[], // current reports
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/5/undo", {}))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_HAS_INTERIM_ACTIVITY")
+	})
+
+	it("restores, marks the migration reverted, and returns restored:true", async () => {
+		const db = makeMockDB([
+			committedAudit(fullSnap), // route getAudit
+			null, // getUserByKeyId(old_key): does not resolve
+			committedAudit(fullSnap), // restoreFromSnapshot getAudit
+			[], // current votes
+			[], // current reports
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/5/undo", {}))
+		expect(res.status).toBe(200)
+		expect((await json(res)).data).toEqual({ restored: true })
+		expect(db.calls.some((c) => c.sql.includes("SET snapshot = NULL"))).toBe(true)
+	})
+
+	it("returns ALREADY_RESTORED when the old key resolves to a user again", async () => {
+		const db = makeMockDB([
+			committedAudit(fullSnap), // route getAudit (snapshot present)
+			{ id: 1, key_id: oldKey }, // getUserByKeyId: old key already resolves
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/5/undo", {}))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_ALREADY_RESTORED")
+		expect(db.calls.some((c) => c.sql.startsWith("UPDATE users SET key_id"))).toBe(false)
+	})
+
+	it("returns ALREADY_RESTORED when the snapshot was already consumed", async () => {
+		const db = makeMockDB([
+			{ id: 5, status: "committed", old_key: oldKey, new_key: newKey, snapshot: null },
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(post("/admin/migrations/5/undo", {}))
+		expect(res.status).toBe(409)
+		expect((await json(res)).code).toBe("MIGRATION_ALREADY_RESTORED")
+	})
+})
+
+describe("GET /admin/migrations (list)", () => {
+	it("rejects without a valid admin bearer", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(get("/admin/migrations", { authorization: "Bearer wrong" }))
+		expect(res.status).toBe(401)
+	})
+
+	it("returns recent audits with numeric ids and no snapshot", async () => {
+		const db = makeMockDB([
+			[
+				{
+					id: "2",
+					status: "committed",
+					old_key: "aaaa",
+					new_key: "bbbb",
+					moved_votes: 2,
+					hasSnapshot: true,
+				},
+				{
+					id: "1",
+					status: "preview",
+					old_key: "aaaa",
+					new_key: "bbbb",
+					moved_votes: 0,
+					hasSnapshot: false,
+				},
+			],
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(get("/admin/migrations?limit=10"))
+		expect(res.status).toBe(200)
+		const data = (await json(res)).data as Record<string, unknown>[]
+		expect(data).toHaveLength(2)
+		expect(data[0].id).toBe(2)
+		expect(data[0].status).toBe("committed")
+		expect(data[0].hasSnapshot).toBe(true)
+		expect("snapshot" in data[0]).toBe(false)
+	})
+})
+
+describe("GET /admin/migrations/:id", () => {
+	it("rejects without a valid admin bearer", async () => {
+		const app = adminRoutes(makeEnv(makeMockDB(), makeMockCache()))
+		const res = await app.handle(get("/admin/migrations/5", { authorization: "Bearer wrong" }))
+		expect(res.status).toBe(401)
+	})
+
+	it("returns NOT_FOUND for an unknown id", async () => {
+		const db = makeMockDB([null])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(get("/admin/migrations/999"))
+		expect(res.status).toBe(404)
+		expect((await json(res)).code).toBe("MIGRATION_NOT_FOUND")
+	})
+
+	it("returns the audit row with hasSnapshot and without the raw snapshot", async () => {
+		const db = makeMockDB([
+			{
+				id: "5",
+				status: "committed",
+				old_key: "old",
+				new_key: "new",
+				moved_votes: 3,
+				snapshot: { users: [] },
+			},
+		])
+		const app = adminRoutes(makeEnv(db, makeMockCache()))
+		const res = await app.handle(get("/admin/migrations/5"))
+		expect(res.status).toBe(200)
+		const data = (await json(res)).data as Record<string, unknown>
+		expect(data.id).toBe(5)
+		expect(data.status).toBe("committed")
+		expect(data.moved_votes).toBe(3)
+		expect(data.hasSnapshot).toBe(true)
+		expect(data.snapshot).toBeUndefined()
+	})
+})

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto"
+import { config } from "@/config"
+import {
+	type MigrationRunError,
+	computeMigrationPlan,
+	createPreviewAudit,
+	getAudit,
+	listAudits,
+	markAuditFailed,
+	markAuditReverted,
+	restoreFromSnapshot,
+	runMigration,
+} from "@/db/account-migration"
+import { getByKeyId } from "@/db/discordLinks"
+import { invalidateCuratorLeaderboardCache } from "@/db/leaderboard"
+import { invalidateCacheForSubmitter } from "@/db/lyrics"
+import { type AccountSearchRow, getUserByKeyId, searchAccounts } from "@/db/users"
+import { Logger } from "@/infra/logger"
+import { recalculateScore } from "@/jobs/score-updater"
+import type { Env } from "@/types"
+import { isAuthorizedAdmin } from "@/utils/admin-auth"
+import { ErrorCode, buildError } from "@/utils/errors"
+import { shortKeyId } from "@/utils/short-key-id"
+import { Elysia, NotFoundError, t } from "elysia"
+
+const log = new Logger("admin")
+
+const SEARCH_DEFAULT_LIMIT = 25
+const SEARCH_MAX_LIMIT = 50
+const MIN_QUERY_LENGTH = 2
+
+function clampLimit(raw: string | undefined): number {
+	const n = raw ? Number.parseInt(raw, 10) : Number.NaN
+	if (!Number.isFinite(n) || n <= 0) return SEARCH_DEFAULT_LIMIT
+	return Math.min(n, SEARCH_MAX_LIMIT)
+}
+
+function toAccountHit(row: AccountSearchRow) {
+	return {
+		userId: row.id,
+		keyId: row.key_id,
+		keyShort: shortKeyId(row.key_id),
+		nickname: row.nickname,
+		discordId: row.discord_id,
+		discordUsername: row.discord_username,
+		reputation: row.reputation,
+		submissions: row.submissions,
+		votes: row.votes,
+		reports: row.reports,
+		requests: row.requests,
+	}
+}
+
+const querySearch = t.Object({ q: t.Optional(t.String()), limit: t.Optional(t.String()) })
+const bodyKeys = t.Object({
+	oldKey: t.String({ minLength: 8 }),
+	newKey: t.String({ minLength: 8 }),
+})
+const bodyCommit = t.Optional(
+	t.Object({
+		keepNickname: t.Optional(t.Union([t.Literal("old"), t.Literal("new")])),
+	})
+)
+const paramsId = t.Object({ id: t.Numeric() })
+
+const RUN_ERROR: Record<MigrationRunError["error"], { httpStatus: number; code: ErrorCode }> = {
+	SAME_KEY: { httpStatus: 409, code: ErrorCode.MIGRATION_SAME_KEY },
+	OLD_KEY_NO_USER: { httpStatus: 404, code: ErrorCode.MIGRATION_OLD_KEY_NO_USER },
+	BOTH_KEYS_LINKED: { httpStatus: 409, code: ErrorCode.MIGRATION_BOTH_KEYS_LINKED },
+}
+
+type RestoreError = "NOT_FOUND" | "NOT_COMMITTED" | "HAS_INTERIM_ACTIVITY"
+const RESTORE_ERROR: Record<RestoreError, { httpStatus: number; code: ErrorCode }> = {
+	NOT_FOUND: { httpStatus: 404, code: ErrorCode.MIGRATION_NOT_FOUND },
+	NOT_COMMITTED: { httpStatus: 409, code: ErrorCode.MIGRATION_NOT_COMMITTED },
+	HAS_INTERIM_ACTIVITY: { httpStatus: 409, code: ErrorCode.MIGRATION_HAS_INTERIM_ACTIVITY },
+}
+
+const commitLockKey = (id: number) => `admin:migration:commit:${id}`
+
+export const adminRoutes = (env: Env) =>
+	new Elysia({ prefix: "/admin" })
+		.decorate("env", env)
+		// Deploy-dark: with no ADMIN_SECRET the whole surface is 404 (indistinguishable
+		// from a route that does not exist). With a secret set, unauthorized is 401.
+		.onBeforeHandle(({ env, headers, status }) => {
+			if (!env.ADMIN_SECRET) throw new NotFoundError()
+			if (!isAuthorizedAdmin(headers.authorization, env)) {
+				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+			}
+		})
+		.get(
+			"/accounts/search",
+			async ({ env, query, status }) => {
+				const q = (query.q ?? "").trim()
+				if (q.length < MIN_QUERY_LENGTH) {
+					return status(
+						400,
+						buildError(ErrorCode.MISSING_QUERY, {
+							error: "Query too short",
+							hint: "Enter at least 2 characters to search accounts.",
+						})
+					)
+				}
+				const rows = await searchAccounts(env, q, clampLimit(query.limit))
+				return status(200, { success: true, data: rows.map(toAccountHit) })
+			},
+			{ query: querySearch }
+		)
+		.post(
+			"/migrations/preview",
+			async ({ env, body, status }) => {
+				const { oldKey, newKey } = body
+				if (oldKey === newKey) return status(409, buildError(ErrorCode.MIGRATION_SAME_KEY))
+
+				const [oldLink, newLink] = await Promise.all([
+					getByKeyId(env, oldKey),
+					getByKeyId(env, newKey),
+				])
+				if (oldLink && newLink) {
+					return status(409, buildError(ErrorCode.MIGRATION_BOTH_KEYS_LINKED))
+				}
+
+				const plan = await computeMigrationPlan(env, oldKey, newKey)
+				if ("error" in plan) {
+					return status(404, buildError(ErrorCode.MIGRATION_OLD_KEY_NO_USER))
+				}
+
+				const migrationId = await createPreviewAudit(env, {
+					sessionId: `admin:${randomUUID()}`,
+					discordId: "admin",
+					oldKey,
+					newKey,
+					counts: plan.counts,
+				})
+
+				return status(200, {
+					success: true,
+					data: { migrationId, plan: { ...plan, survivingNickname: plan.oldNickname } },
+				})
+			},
+			{ body: bodyKeys }
+		)
+		.post(
+			"/migrations/:id/commit",
+			async ({ env, params, body, status }) => {
+				const id = params.id
+				const audit = await getAudit(env, id)
+				if (!audit) return status(404, buildError(ErrorCode.MIGRATION_NOT_FOUND))
+				if (audit.status === "committed") {
+					return status(409, buildError(ErrorCode.MIGRATION_ALREADY_COMMITTED))
+				}
+				if (audit.status !== "preview") {
+					return status(409, buildError(ErrorCode.MIGRATION_FAILED))
+				}
+
+				const lockKey = commitLockKey(id)
+				const locked = await env.CACHE.setNX(lockKey, "1", config.migration.commitLockSeconds)
+				if (!locked) return status(409, buildError(ErrorCode.MIGRATION_IN_PROGRESS))
+
+				try {
+					const result = await runMigration(env, {
+						oldKey: audit.old_key,
+						newKey: audit.new_key,
+						keepNickname: body?.keepNickname ?? "old",
+						migrationId: id,
+					})
+					if ("error" in result) {
+						await env.CACHE.delete(lockKey)
+						await markAuditFailed(env, id, result.error)
+						log.error("admin migration commit failed", { migrationId: id, error: result.error })
+						const mapped = RUN_ERROR[result.error]
+						return status(mapped.httpStatus, buildError(mapped.code))
+					}
+
+					await invalidateCuratorLeaderboardCache(env)
+					await invalidateCacheForSubmitter(env, audit.new_key)
+					for (const lyricsId of result.affectedLyricsIds) {
+						recalculateScore(env, lyricsId).catch((err) =>
+							log.error("post-migration recalc failed", { lyricsId, error: String(err) })
+						)
+					}
+
+					const verification = await getAudit(env, id)
+					log.info("admin migration committed", { migrationId: id, moved: result.moved })
+					return status(200, {
+						success: true,
+						data: {
+							moved: result.moved,
+							verification: verification && {
+								status: verification.status,
+								moved: {
+									submissions: verification.moved_submissions,
+									votes: verification.moved_votes,
+									reports: verification.moved_reports,
+									fulfillments: verification.moved_fulfillments,
+									collisionsDropped: verification.collisions_dropped,
+								},
+							},
+						},
+					})
+				} catch (err) {
+					await env.CACHE.delete(lockKey).catch(() => {})
+					await markAuditFailed(env, id, err instanceof Error ? err.message : String(err)).catch(
+						() => {}
+					)
+					throw err
+				}
+			},
+			{ params: paramsId, body: bodyCommit }
+		)
+		.post(
+			"/migrations/:id/undo",
+			async ({ env, params, status }) => {
+				const audit = await getAudit(env, params.id)
+				if (!audit) return status(404, buildError(ErrorCode.MIGRATION_NOT_FOUND))
+				if (audit.status !== "committed") {
+					return status(409, buildError(ErrorCode.MIGRATION_NOT_COMMITTED))
+				}
+				// Already restored: the snapshot was consumed, or the old key resolves to a
+				// user again. Re-running would collide, so refuse cleanly instead of 500ing.
+				if (!audit.snapshot || (await getUserByKeyId(env, audit.old_key))) {
+					return status(409, buildError(ErrorCode.MIGRATION_ALREADY_RESTORED))
+				}
+
+				const result = await restoreFromSnapshot(env, params.id)
+				if ("error" in result) {
+					const mapped = RESTORE_ERROR[result.error]
+					return status(mapped.httpStatus, buildError(mapped.code))
+				}
+				await markAuditReverted(env, params.id)
+				log.info("admin migration undone", { migrationId: params.id })
+				return status(200, { success: true, data: { restored: true } })
+			},
+			{ params: paramsId }
+		)
+		.get(
+			"/migrations",
+			async ({ env, query, status }) => {
+				const rows = await listAudits(env, clampLimit(query.limit))
+				return status(200, { success: true, data: rows })
+			},
+			{ query: t.Object({ limit: t.Optional(t.String()) }) }
+		)
+		.get(
+			"/migrations/:id",
+			async ({ env, params, status }) => {
+				const audit = await getAudit(env, params.id)
+				if (!audit) return status(404, buildError(ErrorCode.MIGRATION_NOT_FOUND))
+				const { snapshot, ...rest } = audit
+				return status(200, { success: true, data: { ...rest, hasSnapshot: snapshot !== null } })
+			},
+			{ params: paramsId }
+		)

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface Env {
 	DUMP_DATABASE_URL: string | null
 	B2: B2Config | null
 	BUTLER_BOT_SECRET?: string | null
+	ADMIN_SECRET?: string | null
 	DISCORD_OAUTH?: { clientId: string; clientSecret: string; redirectUri: string } | null
 }
 

--- a/src/utils/admin-auth.test.ts
+++ b/src/utils/admin-auth.test.ts
@@ -1,0 +1,36 @@
+import type { Env } from "@/types"
+import { describe, expect, it } from "vitest"
+import { isAuthorizedAdmin } from "./admin-auth"
+
+function env(adminSecret: string | null | undefined): Env {
+	return { ADMIN_SECRET: adminSecret } as unknown as Env
+}
+
+describe("isAuthorizedAdmin", () => {
+	it("rejects when ADMIN_SECRET is unset (deploy-dark default)", () => {
+		expect(isAuthorizedAdmin("Bearer anything", env(null))).toBe(false)
+		expect(isAuthorizedAdmin("Bearer anything", env(undefined))).toBe(false)
+	})
+
+	it("rejects a missing or malformed authorization header", () => {
+		expect(isAuthorizedAdmin(undefined, env("s3cret"))).toBe(false)
+		expect(isAuthorizedAdmin("s3cret", env("s3cret"))).toBe(false)
+		expect(isAuthorizedAdmin("Bearer ", env("s3cret"))).toBe(false)
+	})
+
+	it("rejects a wrong secret", () => {
+		expect(isAuthorizedAdmin("Bearer wrong", env("s3cret"))).toBe(false)
+	})
+
+	it("accepts the correct bearer secret", () => {
+		expect(isAuthorizedAdmin("Bearer s3cret", env("s3cret"))).toBe(true)
+	})
+
+	it("does not accept the butler bot secret (separate blast radius)", () => {
+		const mixed = {
+			ADMIN_SECRET: "admin-secret",
+			BUTLER_BOT_SECRET: "bot-secret",
+		} as unknown as Env
+		expect(isAuthorizedAdmin("Bearer bot-secret", mixed)).toBe(false)
+	})
+})

--- a/src/utils/admin-auth.ts
+++ b/src/utils/admin-auth.ts
@@ -1,0 +1,6 @@
+import type { Env } from "@/types"
+import { matchesBearerSecret } from "./bearer-secret"
+
+export function isAuthorizedAdmin(authorizationHeader: unknown, env: Env): boolean {
+	return matchesBearerSecret(authorizationHeader, env.ADMIN_SECRET)
+}

--- a/src/utils/bearer-secret.ts
+++ b/src/utils/bearer-secret.ts
@@ -1,0 +1,17 @@
+import { timingSafeEqual } from "node:crypto"
+
+function extractBearer(header: unknown): string | null {
+	if (typeof header !== "string") return null
+	const match = /^Bearer (.+)$/.exec(header)
+	return match ? match[1] : null
+}
+
+export function matchesBearerSecret(header: unknown, secret: string | null | undefined): boolean {
+	if (!secret) return false
+	const provided = extractBearer(header)
+	if (!provided) return false
+	const a = Buffer.from(provided)
+	const b = Buffer.from(secret)
+	if (a.length !== b.length) return false
+	return timingSafeEqual(a, b)
+}

--- a/src/utils/bot-auth.ts
+++ b/src/utils/bot-auth.ts
@@ -1,23 +1,6 @@
-import { timingSafeEqual } from "node:crypto"
 import type { Env } from "@/types"
-
-function extractBearer(header: unknown): string | null {
-	if (typeof header !== "string") return null
-	const match = /^Bearer (.+)$/.exec(header)
-	return match ? match[1] : null
-}
-
-function secretsMatch(provided: string, expected: string): boolean {
-	const a = Buffer.from(provided)
-	const b = Buffer.from(expected)
-	if (a.length !== b.length) return false
-	return timingSafeEqual(a, b)
-}
+import { matchesBearerSecret } from "./bearer-secret"
 
 export function isAuthorizedBot(authorizationHeader: unknown, env: Env): boolean {
-	const secret = env.BUTLER_BOT_SECRET
-	if (!secret) return false
-	const provided = extractBearer(authorizationHeader)
-	if (!provided) return false
-	return secretsMatch(provided, secret)
+	return matchesBearerSecret(authorizationHeader, env.BUTLER_BOT_SECRET)
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -38,6 +38,13 @@ export const ErrorCode = {
 	MIGRATION_IN_PROGRESS: "MIGRATION_IN_PROGRESS",
 	MIGRATION_EXPIRED: "MIGRATION_EXPIRED",
 	MIGRATION_FAILED: "MIGRATION_FAILED",
+	MIGRATION_SAME_KEY: "MIGRATION_SAME_KEY",
+	MIGRATION_OLD_KEY_NO_USER: "MIGRATION_OLD_KEY_NO_USER",
+	MIGRATION_BOTH_KEYS_LINKED: "MIGRATION_BOTH_KEYS_LINKED",
+	MIGRATION_NOT_FOUND: "MIGRATION_NOT_FOUND",
+	MIGRATION_NOT_COMMITTED: "MIGRATION_NOT_COMMITTED",
+	MIGRATION_HAS_INTERIM_ACTIVITY: "MIGRATION_HAS_INTERIM_ACTIVITY",
+	MIGRATION_ALREADY_RESTORED: "MIGRATION_ALREADY_RESTORED",
 } as const
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
@@ -184,6 +191,34 @@ const TEMPLATES: Record<ErrorCode, Template> = {
 	MIGRATION_FAILED: {
 		error: "Migration failed",
 		hint: "Something went wrong applying the migration. Nothing was changed. Try again in a moment.",
+	},
+	MIGRATION_SAME_KEY: {
+		error: "Same key",
+		hint: "The old and new keys are the same, so there is nothing to migrate.",
+	},
+	MIGRATION_OLD_KEY_NO_USER: {
+		error: "Old key has no account",
+		hint: "The old key doesn't match any account, so there's nothing to migrate.",
+	},
+	MIGRATION_BOTH_KEYS_LINKED: {
+		error: "Both keys are linked",
+		hint: "Both keys already have a Discord link. Unlink one before migrating, otherwise the merge is ambiguous.",
+	},
+	MIGRATION_NOT_FOUND: {
+		error: "Migration not found",
+		hint: "No migration exists for that id.",
+	},
+	MIGRATION_NOT_COMMITTED: {
+		error: "Migration not committed",
+		hint: "This migration was never committed, so there's nothing to undo.",
+	},
+	MIGRATION_HAS_INTERIM_ACTIVITY: {
+		error: "Account changed since migration",
+		hint: "New activity landed on the account after the migration, so it can't be safely rolled back.",
+	},
+	MIGRATION_ALREADY_RESTORED: {
+		error: "Already restored",
+		hint: "This migration was already undone, so there is nothing to roll back.",
 	},
 }
 


### PR DESCRIPTION
## Overview

Adds an admin surface under /admin for running account migrations from an operator tool, wrapping the existing account-migration core instead of reimplementing it. Auth is a dedicated ADMIN_SECRET bearer, separate from the butler token, and it's dark by default: with no secret set the routes 404, so this can land before it's switched on. It covers account search and the whole preview, commit, undo, list, and get flow, and finally wires up the restore path that was exported but never routed, so undo works. Undo also marks a migration reverted so nobody can run it twice. No new deps, no schema changes.
