### PR TITLE
fix(reputation): refresh submitter reputation on cached lyrics reads

### DIFF
--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -239,12 +239,49 @@ describe("findByVideoId", () => {
 		expect(result?.submitter_reputation).toBe(1.25)
 	})
 
-	it("short-circuits to cache without hitting DB on hit", async () => {
+	it("cache hit skips the ranking lookup but refreshes submitter reputation from users", async () => {
+		// reputation is user-global, re-read live on a cache hit, not served from the frozen blob
 		const cached = {
 			...baseRow,
 			submitter_id: 7,
 			submitter_key_id: "cached-key",
 			submitter_reputation: 1.5,
+		}
+		const cache = createMockCache({ "v:vid123": JSON.stringify(cached) })
+		const db = createMockDB([{ reputation: 1.9, nickname: null }])
+		const env = createEnv(db, cache)
+
+		const result = await findByVideoId(env, "vid123")
+
+		expect(result?.submitter_key_id).toBe("cached-key")
+		expect(result?.submitter_reputation).toBe(1.9)
+		expect(db.calls.some((c) => c.sql.includes("FROM lyrics l"))).toBe(false)
+	})
+
+	it("regression: cache hit returns live reputation, not the stale cached snapshot", async () => {
+		const stale = {
+			...baseRow,
+			submitter_id: 7,
+			submitter_key_id: "key7",
+			submitter_reputation: 1.3,
+			submitter_nickname: "boredkevin",
+		}
+		const cache = createMockCache({ "v:vid123": JSON.stringify(stale) })
+		const db = createMockDB([{ reputation: 2.0, nickname: "boredkevin" }])
+		const env = createEnv(db, cache)
+
+		const result = await findByVideoId(env, "vid123")
+
+		expect(result?.submitter_reputation).toBe(2.0)
+		expect(result?.submitter_nickname).toBe("boredkevin")
+	})
+
+	it("cache hit with an anonymous submitter does not query users", async () => {
+		const cached = {
+			...baseRow,
+			submitter_id: null,
+			submitter_key_id: null,
+			submitter_reputation: null,
 		}
 		const cache = createMockCache({ "v:vid123": JSON.stringify(cached) })
 		const db = createMockDB([])
@@ -253,8 +290,7 @@ describe("findByVideoId", () => {
 		const result = await findByVideoId(env, "vid123")
 
 		expect(db.calls).toHaveLength(0)
-		expect(result?.submitter_key_id).toBe("cached-key")
-		expect(result?.submitter_reputation).toBe(1.5)
+		expect(result?.submitter_reputation).toBeNull()
 	})
 
 	it("evicts and falls back to DB when cache entry is corrupt", async () => {

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -33,6 +33,17 @@ const LYRICS_WITH_SUBMITTER = `
 	LEFT JOIN users u ON l.submitter_id = u.id
 `
 
+async function hydrateSubmitter(env: Env, row: LyricsRow): Promise<void> {
+	if (row.submitter_id == null) return
+	const user = await env.DB.prepare("SELECT reputation, nickname FROM users WHERE id = ?")
+		.bind(row.submitter_id)
+		.first<{ reputation: number; nickname: string | null }>()
+	if (user) {
+		row.submitter_reputation = user.reputation
+		row.submitter_nickname = user.nickname
+	}
+}
+
 async function getPrimary(env: Env, videoId: string): Promise<LyricsRow | null> {
 	const cached = await env.CACHE.get(`v:${videoId}`)
 	if (cached) {
@@ -41,6 +52,7 @@ async function getPrimary(env: Env, videoId: string): Promise<LyricsRow | null> 
 			if (isCompressed(row.lyrics)) {
 				row.lyrics = await decompress(row.lyrics)
 			}
+			await hydrateSubmitter(env, row)
 			cacheLog.debug("hit", { key: `v:${videoId}` })
 			return row
 		} catch {
@@ -466,8 +478,7 @@ export async function softDeleteLyrics(
 
 	const shouldPenalise =
 		!row.reputation_penalized &&
-		(role === "admin" ||
-			(role === "submitter" && row.vote_count >= 2 && row.effective_score < 0))
+		(role === "admin" || (role === "submitter" && row.vote_count >= 2 && row.effective_score < 0))
 
 	await env.DB.transaction(async (tx) => {
 		if (shouldPenalise && row.submitter_id) {
@@ -483,9 +494,7 @@ export async function softDeleteLyrics(
 			if (flipped) {
 				const penalty = config.moderation.autoHide.reputationPenalty
 				await tx
-					.prepare(
-						"UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?"
-					)
+					.prepare("UPDATE users SET reputation = GREATEST(?, reputation - ?) WHERE id = ?")
 					.bind(config.reputation.min, penalty, row.submitter_id)
 					.run()
 			}


### PR DESCRIPTION
## Overview

A submitter's reputation, and the badge derived from it, jumped between songs because the per-video lyrics cache froze their reputation at cache time. Reputation is user-global and drifts as any of their songs get voted on, but a vote only busts the cache for the song that was voted, so every other song kept serving a different stale value. Now a cache hit re-reads the submitter's live reputation and nickname from the users table, and the expensive ranking query stays cached.
