### PR TITLE
Include submitter in lyric search results

### DIFF
--- a/src/db/lyrics.test.ts
+++ b/src/db/lyrics.test.ts
@@ -796,6 +796,7 @@ describe("searchByQuery", () => {
 			vote_count: 0,
 			confidence: "low",
 			created_at: 1700000000,
+			submitter_id: null,
 			match_score: 0.9,
 			tier: 1,
 		}
@@ -806,6 +807,39 @@ describe("searchByQuery", () => {
 		const results = await searchByQuery(env, "longer query", 10)
 
 		expect(results).toEqual([searchHit])
+	})
+
+	it("attaches submitter details from a follow-up user lookup", async () => {
+		const searchHit: LyricsSearchResult = {
+			id: 2,
+			video_id: "v2",
+			song: "S2",
+			artist: "A2",
+			album: null,
+			isrc: null,
+			duration: 100,
+			format: "lrc",
+			language: null,
+			sync_type: "linesync",
+			score: 0,
+			effective_score: 0,
+			vote_count: 0,
+			confidence: "low",
+			created_at: 1700000000,
+			submitter_id: 99,
+			match_score: 0.9,
+			tier: 1,
+		}
+		const userRow = { id: 99, key_id: "beef".repeat(16), reputation: 1.5, nickname: "Cat" }
+		const db = createMockDB([[searchHit], [userRow]])
+		const cache = createMockCache()
+		const env = createEnv(db, cache)
+
+		const results = await searchByQuery(env, "longer query", 10)
+
+		expect(results[0].submitter_key_id).toBe("beef".repeat(16))
+		expect(results[0].submitter_reputation).toBe(1.5)
+		expect(results[0].submitter_nickname).toBe("Cat")
 	})
 })
 

--- a/src/db/lyrics.ts
+++ b/src/db/lyrics.ts
@@ -522,7 +522,7 @@ export async function softDeleteLyrics(
 const SEARCH_COLUMNS = `
 	id, video_id, song, artist, album, isrc, duration,
 	format, language, sync_type, score, effective_score,
-	vote_count, confidence, created_at
+	vote_count, confidence, created_at, submitter_id
 `
 
 export async function searchByQuery(
@@ -605,5 +605,26 @@ export async function searchByQuery(
 		)
 		.all<LyricsSearchResult>()
 
+	await attachSubmitters(env, result.results)
 	return result.results
+}
+
+async function attachSubmitters(env: Env, rows: LyricsSearchResult[]): Promise<void> {
+	const ids = [...new Set(rows.map((r) => r.submitter_id).filter((id): id is number => id != null))]
+	if (ids.length === 0) return
+	const placeholders = ids.map(() => "?").join(", ")
+	const { results } = await env.DB.prepare(
+		`SELECT id, key_id, reputation, nickname FROM users WHERE id IN (${placeholders})`
+	)
+		.bind(...ids)
+		.all<{ id: number; key_id: string; reputation: number; nickname: string | null }>()
+	const byId = new Map(results.map((u) => [u.id, u]))
+	for (const row of rows) {
+		const user = row.submitter_id != null ? byId.get(row.submitter_id) : undefined
+		if (user) {
+			row.submitter_key_id = user.key_id
+			row.submitter_reputation = user.reputation
+			row.submitter_nickname = user.nickname
+		}
+	}
 }

--- a/src/routes/lyrics.transformers.test.ts
+++ b/src/routes/lyrics.transformers.test.ts
@@ -180,6 +180,7 @@ describe("toSearchResponse", () => {
 		vote_count: 4,
 		confidence: "low",
 		created_at: 1700000000,
+		submitter_id: null,
 		match_score: 0.85,
 		tier: 2,
 	}
@@ -214,5 +215,37 @@ describe("toSearchResponse", () => {
 	it("does not leak created_at as snake_case", () => {
 		const result = toSearchResponse(baseSearchRow) as Record<string, unknown>
 		expect(result.created_at).toBeUndefined()
+	})
+
+	it("exposes submitter when key id and reputation are present", () => {
+		const keyId = "deadbeef".repeat(8)
+		const result = toSearchResponse({
+			...baseSearchRow,
+			submitter_id: 99,
+			submitter_key_id: keyId,
+			submitter_reputation: 1.42,
+			submitter_nickname: "Curator Cat",
+		})
+		expect(result.submitter).toEqual({ keyId, reputation: 1.42, displayName: "Curator Cat" })
+	})
+
+	it("falls back to a pet name when nickname is null", () => {
+		const keyId = "abcdef12".repeat(8)
+		const result = toSearchResponse({
+			...baseSearchRow,
+			submitter_id: 5,
+			submitter_key_id: keyId,
+			submitter_reputation: 1,
+			submitter_nickname: null,
+		})
+		expect(result.submitter).toEqual({
+			keyId,
+			reputation: 1,
+			displayName: generatePetName(keyId),
+		})
+	})
+
+	it("omits submitter for anonymous rows", () => {
+		expect(toSearchResponse(baseSearchRow).submitter).toBeUndefined()
 	})
 })

--- a/src/routes/lyrics.transformers.ts
+++ b/src/routes/lyrics.transformers.ts
@@ -3,8 +3,22 @@ import type {
 	LyricsFulfillmentBadge,
 	LyricsResponse,
 	LyricsSearchResult,
+	SubmitterInfo,
 } from "@/types"
 import { generatePetName } from "@/utils/petname"
+
+function buildSubmitter(row: {
+	submitter_key_id?: string | null
+	submitter_reputation?: number | null
+	submitter_nickname?: string | null
+}): SubmitterInfo | undefined {
+	if (row.submitter_key_id == null || row.submitter_reputation == null) return undefined
+	return {
+		keyId: row.submitter_key_id,
+		reputation: row.submitter_reputation,
+		displayName: row.submitter_nickname ?? generatePetName(row.submitter_key_id),
+	}
+}
 
 export interface LyricsRowForResponse {
 	id: number
@@ -31,15 +45,6 @@ export function toResponse(
 	row: LyricsRowForResponse,
 	fulfilled?: LyricsFulfillmentBadge | null
 ): LyricsResponse {
-	const submitter =
-		row.submitter_key_id != null && row.submitter_reputation != null
-			? {
-					keyId: row.submitter_key_id,
-					reputation: row.submitter_reputation,
-					displayName: row.submitter_nickname ?? generatePetName(row.submitter_key_id),
-				}
-			: undefined
-
 	return {
 		id: row.id,
 		videoId: row.video_id,
@@ -56,7 +61,7 @@ export function toResponse(
 		voteCount: row.vote_count,
 		confidence: row.confidence,
 		hidden: row.hidden ?? false,
-		submitter,
+		submitter: buildSubmitter(row),
 		fulfilled: fulfilled ?? undefined,
 	}
 }
@@ -78,5 +83,6 @@ export function toSearchResponse(row: LyricsSearchResult) {
 		voteCount: row.vote_count,
 		confidence: row.confidence,
 		matchScore: row.match_score,
+		submitter: buildSubmitter(row),
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,10 @@ export interface LyricsSearchResult {
 	vote_count: number
 	confidence: Confidence
 	created_at: number
+	submitter_id: number | null
+	submitter_key_id?: string | null
+	submitter_reputation?: number | null
+	submitter_nickname?: string | null
 	match_score: number
 	tier: number
 }


### PR DESCRIPTION
Search hits only carried the lyric itself, so nothing downstream could tell who submitted a match. This adds the submitter (key id, display name, reputation) to each `/lyrics/search` result, resolved in one batched user lookup after ranking. The admin console uses it to jump from a lyric straight to the submitter's account.