### PR TITLE
fix(translate): detect source language authoritatively

### DIFF
--- a/src/routes/translate.test.ts
+++ b/src/routes/translate.test.ts
@@ -591,7 +591,50 @@ describe("invariants", () => {
 		expect(json.lines).toHaveLength(request.lines.length)
 	})
 
-	it("echoes the caller-supplied from as detectedLang", async () => {
+	it("reports the reliably detected language over a conflicting caller from", async () => {
+		const routes = await loadFreshRoutes()
+		const fetchSpy = vi.fn(
+			async () =>
+				new Response(fixture("ja-en-no-romanization"), {
+					status: 200,
+					headers: { version: "v-1" },
+				})
+		)
+		vi.stubGlobal("fetch", fetchSpy)
+		const db = makeMockDB([null])
+		const app = routes(makeEnv(db))
+
+		const res = await post(app, { lines: ["夜に駆ける", "君の名は"], to: "en", from: "zh" })
+
+		const json = (await res.json()) as TranslateOk
+		expect(json.detectedLang).toBe("ja")
+	})
+})
+
+describe("regressions", () => {
+	it("regression: does not return all-null when a caller mislabels foreign lyrics as the target language", async () => {
+		const routes = await loadFreshRoutes()
+		const fetchSpy = vi.fn(
+			async () =>
+				new Response(fixture("ja-en-no-romanization"), {
+					status: 200,
+					headers: { version: "v-1" },
+				})
+		)
+		vi.stubGlobal("fetch", fetchSpy)
+		const db = makeMockDB([null])
+		const app = routes(makeEnv(db))
+
+		const res = await post(app, { lines: ["夜に駆ける", "君の名は"], to: "en", from: "en" })
+
+		expect(res.status).toBe(200)
+		const json = (await res.json()) as TranslateOk
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		expect(json.detectedLang).toBe("ja")
+		expect(json.lines.every((l) => l.translation === null)).toBe(false)
+	})
+
+	it("falls back to the caller from when detection is unreliable", async () => {
 		const routes = await loadFreshRoutes()
 		const fetchSpy = vi.fn(
 			async () =>
@@ -604,10 +647,12 @@ describe("invariants", () => {
 		const db = makeMockDB([null])
 		const app = routes(makeEnv(db))
 
-		const res = await post(app, { lines: ["你好世界"], to: "en", from: "zh" })
+		const res = await post(app, { lines: ["12345 67890 000 111"], to: "en", from: "zh" })
 
+		expect(res.status).toBe(200)
 		const json = (await res.json()) as TranslateOk
 		expect(json.detectedLang).toBe("zh")
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/src/routes/translate.ts
+++ b/src/routes/translate.ts
@@ -72,15 +72,14 @@ export const translateRoutes = (env: Env) => {
 				return status(400, { success: false, error: "No translatable lines" })
 			}
 
+			const detected = await detectLanguage(kept.join("\n"))
 			let from: string
-			if (body.from) {
+			if (detected.language) {
+				from = detected.language
+			} else if (body.from) {
 				from = body.from
 			} else {
-				const detected = await detectLanguage(kept.join("\n"))
-				if (!detected.language) {
-					return status(400, { success: false, error: "Could not detect source language" })
-				}
-				from = detected.language
+				return status(400, { success: false, error: "Could not detect source language" })
 			}
 
 			const to = body.to


### PR DESCRIPTION
## Overview

/translate returned null for every line whenever the caller passed a `from` equal to `to`. The client tags some tracks with the wrong language (a Japanese song came through as `en`), and since a supplied `from` was trusted as-is, `from === to` short-circuited to an all-null response without ever attempting a translation. Now the route runs eld on the lyrics every time and lets a confident detection win, so a mislabeled source gets corrected instead of quietly dropped. The caller's `from` sticks around as a fallback for text eld can't read confidently, and `detectedLang` now reports what was actually detected instead of echoing the caller.
