### PR TITLE
Default the featured badge showcase to a user's top medals

### DIFF
--- a/src/db/badge-summary.integration.test.ts
+++ b/src/db/badge-summary.integration.test.ts
@@ -141,13 +141,51 @@ describeIntegration("badge summaries (integration)", () => {
 		])
 	})
 
-	it("returns an empty featured list when the user has featured nothing", async () => {
+	it("auto-features the user's top medals when they have featured nothing", async () => {
 		const userId = await newUser()
 		await award(userId, "most-loved", null)
 
 		const summary = (await getBadgeSummaries(env, [userId])).get(userId)
 
-		expect(summary?.featured).toEqual([])
+		expect(summary?.featured).toEqual([
+			{ key: "most-loved", name: "Most Loved", tier: undefined },
+		])
+	})
+
+	it("auto-features the strongest medals by category, tier, then key, capped at the slot count", async () => {
+		const userId = await newUser()
+		await award(userId, "prolific", 2) // output
+		await award(userId, "verified-contributor", 2) // output, same tier, key after "prolific"
+		await award(userId, "karaoke-master", 3) // craft
+		await award(userId, "trailblazer", 3) // coverage
+		await award(userId, "sharp-ear", 3) // curation
+		await award(userId, "fan-favorite", null) // acclaim, dropped past the cap
+		await award(userId, "most-loved", null) // acclaim, dropped past the cap
+		await award(userId, "lyricist", null) // tier category, excluded
+		await award(userId, "community", null) // community, excluded
+
+		const summary = (await getBadgeSummaries(env, [userId])).get(userId)
+
+		expect(summary?.featured.map((b) => b.key)).toEqual([
+			"prolific",
+			"verified-contributor",
+			"karaoke-master",
+			"trailblazer",
+			"sharp-ear",
+		])
+	})
+
+	it("keeps an explicit featured selection instead of the auto default", async () => {
+		const userId = await newUser()
+		await award(userId, "verified-contributor", 2)
+		await award(userId, "most-loved", null)
+		await feature(userId, ["most-loved"])
+
+		const summary = (await getBadgeSummaries(env, [userId])).get(userId)
+
+		expect(summary?.featured).toEqual([
+			{ key: "most-loved", name: "Most Loved", tier: undefined },
+		])
 	})
 
 	it("returns a null topBadge but a nonzero count for a community-only user", async () => {

--- a/src/db/badge-summary.ts
+++ b/src/db/badge-summary.ts
@@ -66,6 +66,22 @@ function resolveFeatured(keys: string[], tierByKey: Map<string, number | null>):
 	return featured
 }
 
+// When a user has not chosen a featured set, showcase their strongest earned medals by the same
+// ranking topBadge uses (category order, then tier, then key), capped at the featured slot count.
+export function defaultFeaturedKeys(awards: { key: string; tier: number | null }[]): string[] {
+	const eligible = awards
+		.map((award) => ({ def: DEF_BY_KEY.get(award.key), tier: award.tier }))
+		.filter((entry): entry is { def: BadgeDef; tier: number | null } => {
+			return entry.def !== undefined && isEligible(entry.def) && !entry.def.secret
+		})
+	eligible.sort((a, b) => {
+		if (isBetter(a.def, a.tier ?? 0, b.def, b.tier ?? 0)) return -1
+		if (isBetter(b.def, b.tier ?? 0, a.def, a.tier ?? 0)) return 1
+		return 0
+	})
+	return eligible.slice(0, FEATURED_MAX).map((entry) => entry.def.key)
+}
+
 export async function getBadgeSummaries(
 	env: Env,
 	userIds: number[]
@@ -101,7 +117,14 @@ export async function getBadgeSummaries(
 	for (const [id, rows] of byUser) {
 		const tierByKey = new Map<string, number | null>()
 		for (const r of rows) tierByKey.set(r.badge_key, r.tier == null ? null : Number(r.tier))
-		const featured = resolveFeatured(featuredByUser.get(id) ?? [], tierByKey)
+		const stored = featuredByUser.get(id) ?? []
+		const keys =
+			stored.length > 0
+				? stored
+				: defaultFeaturedKeys(
+						rows.map((r) => ({ key: r.badge_key, tier: r.tier == null ? null : Number(r.tier) }))
+					)
+		const featured = resolveFeatured(keys, tierByKey)
 		summaries.set(id, { badgeCount: rows.length, topBadge: pickTopBadge(rows), featured })
 	}
 	return summaries

--- a/src/db/badges.integration.test.ts
+++ b/src/db/badges.integration.test.ts
@@ -31,7 +31,14 @@ describeIntegration("badges award and read model (integration)", () => {
 		pool = new Pool({ connectionString: url })
 		const schema = readFileSync(new URL("../../schema.sql", import.meta.url), "utf-8")
 		await pool.query(schema)
-		env = { DB: new D1Compat(pool) } as unknown as Env
+		const cache = {
+			async get() {
+				return null
+			},
+			async put() {},
+			async delete() {},
+		}
+		env = { DB: new D1Compat(pool), CACHE: cache } as unknown as Env
 	})
 
 	afterAll(async () => {
@@ -186,12 +193,13 @@ describeIntegration("badges award and read model (integration)", () => {
 	describe("getUserBadges", () => {
 		it("returns a zero-state for an unknown key", async () => {
 			const g = await getUserBadges(env, "does-not-exist")
-			const { level, xpForNext } = levelForXp(0, thresholds)
+			const { level, xpForNext, xpFloor } = levelForXp(0, thresholds)
 			expect(g).toEqual({
 				keyId: "does-not-exist",
 				level,
 				xp: 0,
 				xpForNext,
+				xpFloor,
 				tier: null,
 				tierRank: null,
 				badges: [],
@@ -250,6 +258,23 @@ describeIntegration("badges award and read model (integration)", () => {
 
 			expect(g.tier).toBe("legendary")
 			expect(g.tierRank).toBe(1)
+		})
+
+		it("auto-features the top earned medals when the user has featured nothing", async () => {
+			const keyId = "f".repeat(64)
+			const userId = (
+				await one<{ id: number }>(
+					"INSERT INTO users (key_id, created_at) VALUES ($1, 2000000000) RETURNING id",
+					[keyId]
+				)
+			).id
+			await insertLyric({ submitterId: userId, confidence: "medium" })
+
+			const g = await getUserBadges(env, keyId)
+
+			expect(g.featured).toEqual(["verified-contributor", "first-submission"])
+			expect(g.badges.find((b) => b.key === "verified-contributor")?.featured).toBe(true)
+			expect(g.badges.find((b) => b.key === "first-submission")?.featured).toBe(true)
 		})
 
 		it("gives a pure voter xp and level but no curator tier", async () => {

--- a/src/db/badges.ts
+++ b/src/db/badges.ts
@@ -1,4 +1,5 @@
 import { config } from "@/config"
+import { defaultFeaturedKeys } from "@/db/badge-summary"
 import { BADGES } from "@/db/badges/definitions"
 import { DERIVATIONS } from "@/db/badges/derivation"
 import { getXp } from "@/db/contribution-events"
@@ -182,7 +183,7 @@ export async function getUserBadges(env: Env, keyId: string): Promise<UserGamifi
 	const { level, xpForNext, xpFloor } = levelForXp(xp, thresholds)
 
 	const rank = await getCuratorRank(env, keyId)
-	const featured = parseFeatured(user.featured_badges)
+	const storedFeatured = parseFeatured(user.featured_badges)
 
 	const earnedRows = await env.DB.prepare(
 		"SELECT badge_key, tier, awarded_at FROM badge_awards WHERE user_id = ?"
@@ -208,9 +209,17 @@ export async function getUserBadges(env: Env, keyId: string): Promise<UserGamifi
 			earnedAt: award?.awardedAt,
 			tier: earned ? higherTier(award?.tier, evaluation.tier) : undefined,
 			progress: evaluation.progress,
-			featured: earned && featured.includes(key),
+			featured: false,
 		})
 	}
+
+	const earnedAwards = badges
+		.filter((b) => b.earned)
+		.map((b) => ({ key: b.key, tier: b.tier ?? null }))
+	const featured =
+		storedFeatured.length > 0 ? storedFeatured : defaultFeaturedKeys(earnedAwards)
+	const featuredSet = new Set(featured)
+	for (const b of badges) b.featured = b.earned && featuredSet.has(b.key)
 
 	const result: UserGamification = {
 		keyId,

--- a/src/db/leaderboard.integration.test.ts
+++ b/src/db/leaderboard.integration.test.ts
@@ -30,7 +30,14 @@ describeIntegration("curator leaderboard (integration)", () => {
 		pool = new Pool({ connectionString: url })
 		const schema = readFileSync(new URL("../../schema.sql", import.meta.url), "utf-8")
 		await pool.query(schema)
-		env = { DB: new D1Compat(pool) } as unknown as Env
+		const cache = {
+			async get() {
+				return null
+			},
+			async put() {},
+			async delete() {},
+		}
+		env = { DB: new D1Compat(pool), CACHE: cache } as unknown as Env
 	})
 
 	afterAll(async () => {
@@ -127,9 +134,11 @@ describeIntegration("curator leaderboard (integration)", () => {
 		expect(real[TOTAL - 1].tier).toBeNull()
 
 		expect(real[0].xp).toBe(4500)
-		expect({ level: real[0].level, xpForNext: real[0].xpForNext }).toEqual(
-			levelForXp(4500, thresholds)
-		)
+		expect({
+			level: real[0].level,
+			xpForNext: real[0].xpForNext,
+			xpFloor: real[0].xpFloor,
+		}).toEqual(levelForXp(4500, thresholds))
 		expect({ level: real[0].level, xpForNext: real[0].xpForNext }).toEqual({
 			level: 9,
 			xpForNext: null,
@@ -142,9 +151,11 @@ describeIntegration("curator leaderboard (integration)", () => {
 		})
 
 		expect(real[3].xp).toBe(200)
-		expect({ level: real[3].level, xpForNext: real[3].xpForNext }).toEqual(
-			levelForXp(200, thresholds)
-		)
+		expect({
+			level: real[3].level,
+			xpForNext: real[3].xpForNext,
+			xpFloor: real[3].xpFloor,
+		}).toEqual(levelForXp(200, thresholds))
 		expect({ level: real[3].level, xpForNext: real[3].xpForNext }).toEqual({
 			level: 3,
 			xpForNext: 350,
@@ -207,6 +218,7 @@ describeIntegration("curator leaderboard (integration)", () => {
 					"level",
 					"xp",
 					"xpForNext",
+					"xpFloor",
 					"badgeCount",
 					"topBadge",
 					"featured",


### PR DESCRIPTION
Fixes the leaderboard showing the single topBadge + "+N" instead of the multi-badge featured set.

Cause: the featured set was built only from a user's manually-chosen `users.featured_badges`. Nobody has picked any in prod, so every row returned `featured: []` and CuratorRow fell back to topBadge + +N. The design called for featured to be auto by default, which was never implemented.

Change: when a user has not chosen a featured set, default to their strongest earned medals (same ranking topBadge uses: category order, then tier, then key), capped at the featured slot count. Secret and tier-title badges are excluded from the default; a manual selection still overrides. Applied in one owner (`defaultFeaturedKeys` in badge-summary.ts) and reused by both the leaderboard summary and the profile (getUserBadges) so they agree.

Also repairs pre-existing integration-test breakage exposed here (unrelated to this feature, landed with the gamification merge): the leaderboard and badges integration envs were missing a CACHE stub (getCuratorLeaderboard now reads env.CACHE and was crashing every test), and three shape assertions had not been updated for the added `xpFloor` field.

Note for deploy: the leaderboard response is cached, so flush the curator board cache (and curator:tier-map) after deploy to see the change immediately, otherwise it waits for the TTL.

Gates: typecheck, lint, unit suite (1274), and the badge integration suite (78) all green.