### PR TITLE
fix(badges): feature earned secret badges in the showcase

### DIFF
--- a/src/db/badge-summary.integration.test.ts
+++ b/src/db/badge-summary.integration.test.ts
@@ -162,7 +162,7 @@ describeIntegration("badge summaries (integration)", () => {
 		await award(userId, "fan-favorite", null) // acclaim, dropped past the cap
 		await award(userId, "most-loved", null) // acclaim, dropped past the cap
 		await award(userId, "lyricist", null) // tier category, excluded
-		await award(userId, "community", null) // community, excluded
+		await award(userId, "community", null) // community, sorts last and drops past the cap
 
 		const summary = (await getBadgeSummaries(env, [userId])).get(userId)
 
@@ -188,14 +188,15 @@ describeIntegration("badge summaries (integration)", () => {
 		])
 	})
 
-	it("returns a null topBadge but a nonzero count for a community-only user", async () => {
+	it("features the community badge as topBadge for a community-only user", async () => {
 		const userId = await newUser()
 		await award(userId, "community", null)
 
 		const summary = (await getBadgeSummaries(env, [userId])).get(userId)
 
 		expect(summary?.badgeCount).toBe(1)
-		expect(summary?.topBadge).toBeNull()
+		expect(summary?.topBadge).toEqual({ key: "community", name: "Community", tier: undefined })
+		expect(summary?.featured).toEqual([{ key: "community", name: "Community", tier: undefined }])
 	})
 
 	it("omits users with no awards from the map", async () => {

--- a/src/db/badge-summary.test.ts
+++ b/src/db/badge-summary.test.ts
@@ -1,0 +1,51 @@
+import { defaultFeaturedKeys } from "@/db/badge-summary"
+import { describe, expect, it } from "vitest"
+
+describe("defaultFeaturedKeys", () => {
+	it("showcases the strongest eligible medals in category order", () => {
+		const keys = defaultFeaturedKeys([
+			{ key: "most-loved", tier: null },
+			{ key: "prolific", tier: 2 },
+		])
+		expect(keys).toEqual(["prolific", "most-loved"])
+	})
+
+	it("keeps earned secret badges but excludes tier badges", () => {
+		const keys = defaultFeaturedKeys([
+			{ key: "prolific", tier: 1 },
+			{ key: "lyricist", tier: null },
+			{ key: "early-adopter", tier: null },
+		])
+		expect(keys).toEqual(["prolific", "early-adopter"])
+	})
+
+	it("caps the set at the configured slot count", () => {
+		const many = [
+			"most-loved",
+			"sharp-ear",
+			"verified-contributor",
+			"trailblazer",
+			"first-responder",
+			"polyglot",
+			"prolific",
+		]
+		const keys = defaultFeaturedKeys(many.map((key) => ({ key, tier: null })))
+		expect(keys).toHaveLength(5)
+	})
+
+	describe("edge cases", () => {
+		it("returns an empty set when there are no awards", () => {
+			expect(defaultFeaturedKeys([])).toEqual([])
+		})
+
+		it("returns an empty set when every award is tier-only", () => {
+			expect(defaultFeaturedKeys([{ key: "lyricist", tier: null }])).toEqual([])
+		})
+	})
+
+	describe("regressions", () => {
+		it("regression: features the community badge for the community account", () => {
+			expect(defaultFeaturedKeys([{ key: "community", tier: null }])).toEqual(["community"])
+		})
+	})
+})

--- a/src/db/badge-summary.ts
+++ b/src/db/badge-summary.ts
@@ -19,7 +19,7 @@ interface AwardRow {
 }
 
 function isEligible(def: BadgeDef): boolean {
-	return def.key !== "community" && def.category !== "tier"
+	return def.category !== "tier"
 }
 
 function isBetter(aDef: BadgeDef, aTier: number, bDef: BadgeDef, bTier: number): boolean {
@@ -72,7 +72,7 @@ export function defaultFeaturedKeys(awards: { key: string; tier: number | null }
 	const eligible = awards
 		.map((award) => ({ def: DEF_BY_KEY.get(award.key), tier: award.tier }))
 		.filter((entry): entry is { def: BadgeDef; tier: number | null } => {
-			return entry.def !== undefined && isEligible(entry.def) && !entry.def.secret
+			return entry.def !== undefined && isEligible(entry.def)
 		})
 	eligible.sort((a, b) => {
 		if (isBetter(a.def, a.tier ?? 0, b.def, b.tier ?? 0)) return -1


### PR DESCRIPTION
An earned badge marked secret never showed in the featured strip next to the name or on the leaderboard row, even though the badge wall already displayed it. The auto-picker was dropping every secret badge instead of only hiding unearned ones. Now an earned badge can be showcased like any other, so the community account shows its community badge inline and early-adopter and committee holders get theirs too. Tier badges still stay out of the strip since they render as the tier chip.
