### PR TITLE
feat(committee): bot-authenticated committee and boost endpoints

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,7 @@ export const config = {
 
 	rateLimit: {
 		read: {
-			maxRequests: 120,
+			maxRequests: 600,
 			windowSeconds: 60,
 		},
 		write: {

--- a/src/db/committee.integration.test.ts
+++ b/src/db/committee.integration.test.ts
@@ -3,7 +3,13 @@ import { D1Compat } from "@/infra/database"
 import type { Env } from "@/types"
 import pg from "pg"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
-import { addCommittee, isCommittee, listCommittee, removeCommittee } from "./committee"
+import {
+	addCommittee,
+	isCommittee,
+	listCommittee,
+	listCommitteeKeyIds,
+	removeCommittee,
+} from "./committee"
 
 const { Pool } = pg
 
@@ -62,6 +68,17 @@ describeIntegration("committee roster (integration)", () => {
 		expect(roster[0].userId).toBe(userId)
 		expect(roster[0].addedBy).toBe("admin")
 		expect(typeof roster[0].addedAt).toBe("number")
+	})
+
+	it("lists the roster keyIds by joining to users", async () => {
+		const keyA = "a".repeat(64)
+		const keyB = "b".repeat(64)
+		await addCommittee(env, await insertUser(keyA), "admin")
+		await addCommittee(env, await insertUser(keyB), "bot")
+
+		const keyIds = await listCommitteeKeyIds(env)
+		expect(keyIds).toHaveLength(2)
+		expect(new Set(keyIds)).toEqual(new Set([keyA, keyB]))
 	})
 
 	it("removes a member, leaving membership false and the roster empty", async () => {

--- a/src/db/committee.ts
+++ b/src/db/committee.ts
@@ -37,3 +37,12 @@ export async function listCommittee(env: Env): Promise<CommitteeMember[]> {
 		addedBy: row.added_by,
 	}))
 }
+
+export async function listCommitteeKeyIds(env: Env): Promise<string[]> {
+	const res = await env.DB.prepare(
+		"SELECT u.key_id FROM committee_members c JOIN users u ON u.id = c.user_id ORDER BY c.added_at DESC"
+	)
+		.bind()
+		.all<{ key_id: string }>()
+	return res.results.map((row) => row.key_id)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { auditThresholds } from "@/jobs/threshold-audit"
 import { adminRoutes } from "@/routes/admin"
 import { authRoutes } from "@/routes/auth"
 import { badgeRoutes } from "@/routes/badges"
+import { committeeBotRoutes } from "@/routes/committee"
 import { compatRoutes } from "@/routes/compat"
 import { feedRoutes } from "@/routes/feed"
 import { leaderboardRoutes } from "@/routes/leaderboard"
@@ -201,6 +202,7 @@ const app = new Elysia({ adapter: node() })
 	.use(feedRoutes(env))
 	.use(voteRoutes(env))
 	.use(voteBotRoutes(env))
+	.use(committeeBotRoutes(env))
 	.use(requestRoutes(env))
 	.use(leaderboardRoutes(env))
 	.use(translateRoutes(env))

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { migrationRoutes } from "@/routes/migrations"
 import { requestRoutes } from "@/routes/requests"
 import { translateRoutes } from "@/routes/translate"
 import { userRoutes } from "@/routes/users"
-import { voteRoutes } from "@/routes/votes"
+import { voteBotRoutes, voteRoutes } from "@/routes/votes"
 import { cors } from "@elysiajs/cors"
 import { cron } from "@elysiajs/cron"
 import { node } from "@elysiajs/node"
@@ -200,6 +200,7 @@ const app = new Elysia({ adapter: node() })
 	.use(lyricsRoutes(env))
 	.use(feedRoutes(env))
 	.use(voteRoutes(env))
+	.use(voteBotRoutes(env))
 	.use(requestRoutes(env))
 	.use(leaderboardRoutes(env))
 	.use(translateRoutes(env))

--- a/src/routes/committee.test.ts
+++ b/src/routes/committee.test.ts
@@ -1,0 +1,103 @@
+import { addCommittee, listCommitteeKeyIds, removeCommittee } from "@/db/committee"
+import { getUserByKeyId } from "@/db/users"
+import type { Env } from "@/types"
+import { isAuthorizedBot } from "@/utils/bot-auth"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { committeeBotRoutes } from "./committee"
+
+vi.mock("@/utils/bot-auth", () => ({ isAuthorizedBot: vi.fn() }))
+vi.mock("@/db/users", () => ({ getUserByKeyId: vi.fn() }))
+vi.mock("@/db/committee", () => ({
+	addCommittee: vi.fn(),
+	removeCommittee: vi.fn(),
+	listCommitteeKeyIds: vi.fn(),
+}))
+
+const KEY = "k".repeat(64)
+const member = { id: 7, key_id: KEY } as unknown as Awaited<ReturnType<typeof getUserByKeyId>>
+const app = () => committeeBotRoutes({} as Env)
+
+function bodyReq(method: "POST" | "DELETE", body: unknown) {
+	return new Request("http://localhost/committee/bot", {
+		method,
+		headers: { authorization: "Bearer secret", "content-type": "application/json" },
+		body: JSON.stringify(body),
+	})
+}
+
+function getReq() {
+	return new Request("http://localhost/committee/bot", {
+		method: "GET",
+		headers: { authorization: "Bearer secret" },
+	})
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("POST /committee/bot", () => {
+	it("rejects a bad bot secret with 401", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(false)
+		const res = await app().handle(bodyReq("POST", { keyId: KEY }))
+		expect(res.status).toBe(401)
+		expect(((await res.json()) as { code: string }).code).toBe("AUTH_REQUIRED")
+	})
+
+	it("returns 404 for an unresolved keyId", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(null)
+		const res = await app().handle(bodyReq("POST", { keyId: KEY }))
+		expect(res.status).toBe(404)
+		expect(((await res.json()) as { code: string }).code).toBe("NOT_FOUND")
+		expect(vi.mocked(addCommittee)).not.toHaveBeenCalled()
+	})
+
+	it("adds the member and echoes the keyId", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		const res = await app().handle(bodyReq("POST", { keyId: KEY }))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true, data: { keyId: KEY } })
+		expect(vi.mocked(addCommittee)).toHaveBeenCalledWith(expect.anything(), 7, "bot")
+	})
+})
+
+describe("DELETE /committee/bot", () => {
+	it("rejects a bad bot secret with 401", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(false)
+		const res = await app().handle(bodyReq("DELETE", { keyId: KEY }))
+		expect(res.status).toBe(401)
+	})
+
+	it("returns 404 for an unresolved keyId", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(null)
+		const res = await app().handle(bodyReq("DELETE", { keyId: KEY }))
+		expect(res.status).toBe(404)
+		expect(vi.mocked(removeCommittee)).not.toHaveBeenCalled()
+	})
+
+	it("removes the member", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		const res = await app().handle(bodyReq("DELETE", { keyId: KEY }))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true })
+		expect(vi.mocked(removeCommittee)).toHaveBeenCalledWith(expect.anything(), 7)
+	})
+})
+
+describe("GET /committee/bot", () => {
+	it("rejects a bad bot secret with 401", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(false)
+		const res = await app().handle(getReq())
+		expect(res.status).toBe(401)
+	})
+
+	it("returns the committee keyIds", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(listCommitteeKeyIds).mockResolvedValue([KEY, "a".repeat(64)])
+		const res = await app().handle(getReq())
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true, data: { keyIds: [KEY, "a".repeat(64)] } })
+	})
+})

--- a/src/routes/committee.ts
+++ b/src/routes/committee.ts
@@ -1,0 +1,47 @@
+import { addCommittee, listCommitteeKeyIds, removeCommittee } from "@/db/committee"
+import { getUserByKeyId } from "@/db/users"
+import type { Env } from "@/types"
+import { isAuthorizedBot } from "@/utils/bot-auth"
+import { ErrorCode, buildError } from "@/utils/errors"
+import { Elysia, t } from "elysia"
+
+export const committeeBotRoutes = (env: Env) =>
+	new Elysia({ prefix: "/committee" })
+		.decorate("env", env)
+		.post(
+			"/bot",
+			async ({ env, headers, body, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const user = await getUserByKeyId(env, body.keyId)
+				if (!user) {
+					return status(404, buildError(ErrorCode.NOT_FOUND))
+				}
+				await addCommittee(env, user.id, "bot")
+				return status(200, { success: true, data: { keyId: body.keyId } })
+			},
+			{ body: t.Object({ keyId: t.String() }) }
+		)
+		.delete(
+			"/bot",
+			async ({ env, headers, body, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const user = await getUserByKeyId(env, body.keyId)
+				if (!user) {
+					return status(404, buildError(ErrorCode.NOT_FOUND))
+				}
+				await removeCommittee(env, user.id)
+				return status(200, { success: true })
+			},
+			{ body: t.Object({ keyId: t.String() }) }
+		)
+		.get("/bot", async ({ env, headers, status }) => {
+			if (!isAuthorizedBot(headers.authorization, env)) {
+				return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+			}
+			const keyIds = await listCommitteeKeyIds(env)
+			return status(200, { success: true, data: { keyIds } })
+		})

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -759,12 +759,12 @@ describe("bot-authenticated committee bridge", () => {
 		expect(((await res.json()) as { code: string }).code).toBe("AUTH_REQUIRED")
 	})
 
-	it("POST returns 403 NOT_COMMITTEE for an unresolved keyId", async () => {
+	it("POST returns 404 NOT_FOUND for an unresolved keyId", async () => {
 		vi.mocked(isAuthorizedBot).mockReturnValue(true)
 		vi.mocked(getUserByKeyId).mockResolvedValue(null)
 		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
-		expect(res.status).toBe(403)
-		expect(((await res.json()) as { code: string }).code).toBe("NOT_COMMITTEE")
+		expect(res.status).toBe(404)
+		expect(((await res.json()) as { code: string }).code).toBe("NOT_FOUND")
 	})
 
 	it("POST seals and echoes the quota for a resolved member", async () => {

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -1,10 +1,12 @@
 import { config } from "@/config"
 import { createBoost, getQuota, revokeBoost } from "@/db/boost"
 import { isCommittee } from "@/db/committee"
+import { getUserByKeyId } from "@/db/users"
 import type { Env } from "@/types"
+import { isAuthorizedBot } from "@/utils/bot-auth"
 import { canonicalJson, hashPublicKey } from "@/utils/crypto"
 import { describe, expect, it, vi } from "vitest"
-import { voteRoutes } from "./votes"
+import { voteBotRoutes, voteRoutes } from "./votes"
 
 vi.mock("@/jobs/score-updater", () => ({
 	recalculateScore: vi.fn(() => Promise.resolve()),
@@ -14,6 +16,7 @@ vi.mock("@/db/users", async () => {
 	return {
 		...actual,
 		updateUserAvgVote: vi.fn(() => Promise.resolve()),
+		getUserByKeyId: vi.fn(),
 	}
 })
 vi.mock("@/db/boost", () => ({
@@ -23,6 +26,9 @@ vi.mock("@/db/boost", () => ({
 }))
 vi.mock("@/db/committee", () => ({
 	isCommittee: vi.fn(),
+}))
+vi.mock("@/utils/bot-auth", () => ({
+	isAuthorizedBot: vi.fn(),
 }))
 
 interface DBCall {
@@ -723,5 +729,114 @@ describe("vote rate limiting", () => {
 		)
 		expect(res.status).toBe(429)
 		expect(((await res.json()) as { code: string }).code).toBe("RATE_LIMITED")
+	})
+})
+
+describe("bot-authenticated committee bridge", () => {
+	const KEY = "k".repeat(64)
+	const member = { id: 7, key_id: KEY } as unknown as Awaited<ReturnType<typeof getUserByKeyId>>
+	const app = () => voteBotRoutes(makeEnv(makeMockDB(), makeMockCache()))
+
+	function botReq(id: number, method: "POST" | "DELETE", body: unknown) {
+		return new Request(`http://localhost/lyrics/${id}/boost/bot`, {
+			method,
+			headers: { authorization: "Bearer secret", "content-type": "application/json" },
+			body: JSON.stringify(body),
+		})
+	}
+
+	function quotaBotReq() {
+		return new Request(`http://localhost/lyrics/boost/quota/bot?keyId=${KEY}`, {
+			method: "GET",
+			headers: { authorization: "Bearer secret" },
+		})
+	}
+
+	it("POST rejects a bad bot secret with 401", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(false)
+		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
+		expect(res.status).toBe(401)
+		expect(((await res.json()) as { code: string }).code).toBe("AUTH_REQUIRED")
+	})
+
+	it("POST returns 403 NOT_COMMITTEE for an unresolved keyId", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(null)
+		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
+		expect(res.status).toBe(403)
+		expect(((await res.json()) as { code: string }).code).toBe("NOT_COMMITTEE")
+	})
+
+	it("POST seals and echoes the quota for a resolved member", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(createBoost).mockResolvedValue({ ok: true, quota: BOOST_QUOTA })
+		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true, quota: BOOST_QUOTA })
+	})
+
+	it("POST maps not_committee to 403", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(createBoost).mockResolvedValue({ ok: false, reason: "not_committee" })
+		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
+		expect(res.status).toBe(403)
+		expect(((await res.json()) as { code: string }).code).toBe("NOT_COMMITTEE")
+	})
+
+	it("POST maps self to 400 BOOST_SELF", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(createBoost).mockResolvedValue({ ok: false, reason: "self" })
+		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
+		expect(res.status).toBe(400)
+		expect(((await res.json()) as { code: string }).code).toBe("BOOST_SELF")
+	})
+
+	it("POST maps over_quota to 429", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(createBoost).mockResolvedValue({ ok: false, reason: "over_quota" })
+		const res = await app().handle(botReq(5, "POST", { keyId: KEY }))
+		expect(res.status).toBe(429)
+		expect(((await res.json()) as { code: string }).code).toBe("BOOST_QUOTA_EXCEEDED")
+	})
+
+	it("DELETE revokes for the owning member", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(revokeBoost).mockResolvedValue({ ok: true })
+		const res = await app().handle(botReq(5, "DELETE", { keyId: KEY }))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true })
+	})
+
+	it("DELETE maps forbidden to 403 BOOST_NOT_OWNER", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(revokeBoost).mockResolvedValue({ ok: false, reason: "forbidden" })
+		const res = await app().handle(botReq(5, "DELETE", { keyId: KEY }))
+		expect(res.status).toBe(403)
+		expect(((await res.json()) as { code: string }).code).toBe("BOOST_NOT_OWNER")
+	})
+
+	it("GET quota returns the quota for a committee member", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(isCommittee).mockResolvedValue(true)
+		vi.mocked(getQuota).mockResolvedValue(BOOST_QUOTA)
+		const res = await app().handle(quotaBotReq())
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ success: true, quota: BOOST_QUOTA })
+	})
+
+	it("GET quota returns 403 for a non-committee member", async () => {
+		vi.mocked(isAuthorizedBot).mockReturnValue(true)
+		vi.mocked(getUserByKeyId).mockResolvedValue(member)
+		vi.mocked(isCommittee).mockResolvedValue(false)
+		const res = await app().handle(quotaBotReq())
+		expect(res.status).toBe(403)
+		expect(((await res.json()) as { code: string }).code).toBe("NOT_COMMITTEE")
 	})
 })

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -223,7 +223,7 @@ export const voteBotRoutes = (env: Env) =>
 				}
 				const user = await getUserByKeyId(env, body.keyId)
 				if (!user) {
-					return status(403, buildError(ErrorCode.NOT_COMMITTEE))
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 				const result = await createBoost(env, user.id, id)
 				if (!result.ok) {
@@ -246,7 +246,7 @@ export const voteBotRoutes = (env: Env) =>
 				}
 				const user = await getUserByKeyId(env, body.keyId)
 				if (!user) {
-					return status(403, buildError(ErrorCode.NOT_COMMITTEE))
+					return status(404, buildError(ErrorCode.NOT_FOUND))
 				}
 				const result = await revokeBoost(env, user.id, id)
 				if (!result.ok) {
@@ -264,7 +264,10 @@ export const voteBotRoutes = (env: Env) =>
 					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
 				}
 				const user = await getUserByKeyId(env, query.keyId)
-				if (!user || !(await isCommittee(env, user.id))) {
+				if (!user) {
+					return status(404, buildError(ErrorCode.NOT_FOUND))
+				}
+				if (!(await isCommittee(env, user.id))) {
 					return status(403, buildError(ErrorCode.NOT_COMMITTEE))
 				}
 				return { success: true, quota: await getQuota(env, user.id) }

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -3,8 +3,10 @@ import { type BoostResult, type RevokeResult, createBoost, getQuota, revokeBoost
 import { isCommittee } from "@/db/committee"
 import { getLyricsById } from "@/db/lyrics"
 import { submitReport } from "@/db/reports"
+import { getUserByKeyId } from "@/db/users"
 import { castVote, removeVote } from "@/db/votes"
 import type { Env } from "@/types"
+import { isAuthorizedBot } from "@/utils/bot-auth"
 import { eitherAuth } from "@/utils/either-auth"
 import { ErrorCode, buildError } from "@/utils/errors"
 import { Elysia, t } from "elysia"
@@ -205,3 +207,67 @@ export const voteRoutes = (env: Env) =>
 
 			return { success: true, quota: await getQuota(env, userId) }
 		})
+
+export const voteBotRoutes = (env: Env) =>
+	new Elysia({ prefix: "/lyrics" })
+		.decorate("env", env)
+		.post(
+			"/:id/boost/bot",
+			async ({ params, env, headers, body, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const id = Number(params.id)
+				if (Number.isNaN(id)) {
+					return status(400, buildError(ErrorCode.INVALID_ID))
+				}
+				const user = await getUserByKeyId(env, body.keyId)
+				if (!user) {
+					return status(403, buildError(ErrorCode.NOT_COMMITTEE))
+				}
+				const result = await createBoost(env, user.id, id)
+				if (!result.ok) {
+					const mapped = BOOST_ERROR[result.reason]
+					return status(mapped.status, buildError(mapped.code))
+				}
+				return { success: true, quota: result.quota }
+			},
+			{ params: t.Object({ id: t.String() }), body: t.Object({ keyId: t.String() }) }
+		)
+		.delete(
+			"/:id/boost/bot",
+			async ({ params, env, headers, body, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const id = Number(params.id)
+				if (Number.isNaN(id)) {
+					return status(400, buildError(ErrorCode.INVALID_ID))
+				}
+				const user = await getUserByKeyId(env, body.keyId)
+				if (!user) {
+					return status(403, buildError(ErrorCode.NOT_COMMITTEE))
+				}
+				const result = await revokeBoost(env, user.id, id)
+				if (!result.ok) {
+					const mapped = REVOKE_ERROR[result.reason]
+					return status(mapped.status, buildError(mapped.code))
+				}
+				return { success: true }
+			},
+			{ params: t.Object({ id: t.String() }), body: t.Object({ keyId: t.String() }) }
+		)
+		.get(
+			"/boost/quota/bot",
+			async ({ env, headers, query, status }) => {
+				if (!isAuthorizedBot(headers.authorization, env)) {
+					return status(401, buildError(ErrorCode.AUTH_REQUIRED))
+				}
+				const user = await getUserByKeyId(env, query.keyId)
+				if (!user || !(await isCommittee(env, user.id))) {
+					return status(403, buildError(ErrorCode.NOT_COMMITTEE))
+				}
+				return { success: true, quota: await getQuota(env, user.id) }
+			},
+			{ query: t.Object({ keyId: t.String() }) }
+		)


### PR DESCRIPTION
## Overview

Bot-authenticated committee endpoints for butler. It can add or remove committee members and apply, revoke, or check committee boosts on a lyric, all gated behind bot auth so they sit next to the existing member-facing routes. Also raised the read rate limit from 120 to 600 a minute for the heavier first-party polling.
