### PR TITLE
feat(badges): replace the badge halo with a soft top-of-card glow

### DIFF
--- a/web/src/components/BadgeModal.tsx
+++ b/web/src/components/BadgeModal.tsx
@@ -209,8 +209,8 @@ export function BadgeModal({ selection, closing, onRequestClose, onExited }: Bad
               aria-hidden="true"
               draggable={false}
               className={cn(
-                "absolute top-1/2 left-1/2 size-[92px] -translate-x-1/2 -translate-y-1/2 scale-125 blur-[24px]",
-                earned ? "opacity-50" : "opacity-[0.28]",
+                "bm-glow absolute top-[-28%] left-1/2 size-[92px] -translate-x-1/2 -translate-y-1/2 scale-x-[4] scale-y-[1.5] blur-[24px]",
+                earned ? "opacity-40" : "opacity-20",
               )}
             />
             <img

--- a/web/src/components/profile.css
+++ b/web/src/components/profile.css
@@ -85,6 +85,11 @@
     transform: translateY(6px) scale(0.98);
   }
 }
+@keyframes bm-glow-in {
+  from {
+    opacity: 0;
+  }
+}
 
 .bm-overlay {
   animation: bm-fade 0.18s ease-out;
@@ -97,6 +102,9 @@
 }
 .bm-card.bm-closing {
   animation: bm-popout 0.16s ease-out forwards;
+}
+.bm-glow {
+  animation: bm-glow-in 0.6s ease-out 0.1s both;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -114,7 +122,8 @@
   .bm-overlay,
   .bm-overlay.bm-closing,
   .bm-card,
-  .bm-card.bm-closing {
+  .bm-card.bm-closing,
+  .bm-glow {
     animation: none;
   }
 }


### PR DESCRIPTION
## Overview

Swapped the tight glow halo behind the badge for a soft wash across the top of the card, tinted by the badge and blooming in just after the modal opens. Kept the silhouette so it never bleeds through the badge interior.
