### PR TITLE
feat(song): download and copy lyrics from the song page

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,8 +14,8 @@
     "format": "biome format --write ./src"
   },
   "dependencies": {
-    "@braccato/core": "^1.1.0",
-    "@braccato/parsers": "^0.2.0",
+    "@braccato/core": "^1.6.2",
+    "@braccato/parsers": "^0.2.1",
     "@dicebear/collection": "^9.2.2",
     "@dicebear/core": "^9.2.2",
     "@number-flow/react": "^0.6.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@braccato/core':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@braccato/parsers':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       '@dicebear/collection':
         specifier: ^9.2.2
         version: 9.4.2(@dicebear/core@9.4.2)
@@ -230,11 +230,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@braccato/core@1.1.0':
-    resolution: {integrity: sha512-BBpwxZq6268HeImaJElD9dBSUcqZCgSon2tF0HlVNSCoqnIqr+FwNrkb99r20rZYCk+z6crOS4zmUw6xyxTHUg==}
+  '@braccato/core@1.6.2':
+    resolution: {integrity: sha512-uOmcUHjxyuLQNx+EIYp785Gs9tZhqsmSUj0OoA66K7xIv97fcElnyZGAhqWhFMWu87mMWVP1YsgGx/IEBafXew==}
 
-  '@braccato/parsers@0.2.0':
-    resolution: {integrity: sha512-vHdNv7t1DQnKw7tWTc/AfrGsK/nHLiihqM/xLm0gbTE+iN9WNKsupQ/jAeheQHaQQzZNCYnZicnXb5cxiXjqwg==}
+  '@braccato/parsers@0.2.1':
+    resolution: {integrity: sha512-Yzmj6KlPkGd2NXMQUSvm9NV2oZuJrGwf2xk5aOXCOazty6wgivXrOqtXQoOejAkzgiCUpnDeNFza6wd8rYHrow==}
 
   '@braccato/types@1.0.0':
     resolution: {integrity: sha512-BHrCdJ5Uuc8IYJJqKT/4ULHkkbL8lk6KtAhfrx8bh3gC/huYwLDTBtOQAQSMriu3yMhV7TSvDd8L0loB5b1oeA==}
@@ -1627,11 +1627,11 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@braccato/core@1.1.0':
+  '@braccato/core@1.6.2':
     dependencies:
       '@braccato/types': 1.0.0
 
-  '@braccato/parsers@0.2.0':
+  '@braccato/parsers@0.2.1':
     dependencies:
       '@braccato/types': 1.0.0
       fast-xml-parser: 5.10.1

--- a/web/src/components/CopyButton.test.tsx
+++ b/web/src/components/CopyButton.test.tsx
@@ -1,6 +1,23 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MotionGlobalConfig } from "motion/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { CopyButton } from "./CopyButton"
+
+MotionGlobalConfig.skipAnimations = true
+if (typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false
+    },
+  })
+}
 
 afterEach(() => {
   cleanup()
@@ -39,6 +56,14 @@ describe("CopyButton", () => {
     await waitFor(() => expect(screen.getByRole("button").textContent).toBe("Copy failed"))
     vi.advanceTimersByTime(2500)
     await waitFor(() => expect(screen.getByRole("button").textContent).toBe("Copy"))
+  })
+
+  it("applies the liked-style treatment when copied", async () => {
+    stubClipboard()
+    render(<CopyButton text="x" />)
+    const btn = screen.getByRole("button", { name: /copy lyrics body to clipboard/i })
+    fireEvent.click(btn)
+    await waitFor(() => expect(btn.className).toContain("bg-green-500/10"))
   })
 
   describe("edge cases", () => {

--- a/web/src/components/CopyButton.test.tsx
+++ b/web/src/components/CopyButton.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { CopyButton } from "./CopyButton"
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+function stubClipboard(writeText = vi.fn().mockResolvedValue(undefined)) {
+  vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
+  return writeText
+}
+
+describe("CopyButton", () => {
+  it("writes the given text to the clipboard on click", () => {
+    const writeText = stubClipboard()
+    render(<CopyButton text="hello world" />)
+    fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+    expect(writeText).toHaveBeenCalledWith("hello world")
+  })
+
+  it("shows Copied! then reverts after the success timer", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    stubClipboard()
+    render(<CopyButton text="x" />)
+    fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+    await waitFor(() => expect(screen.getByRole("button").textContent).toBe("Copied!"))
+    vi.advanceTimersByTime(1500)
+    await waitFor(() => expect(screen.getByRole("button").textContent).toBe("Copy"))
+  })
+
+  it("shows Copy failed then reverts after the failure timer", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    stubClipboard(vi.fn().mockRejectedValue(new DOMException("no", "NotAllowedError")))
+    render(<CopyButton text="x" />)
+    fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+    await waitFor(() => expect(screen.getByRole("button").textContent).toBe("Copy failed"))
+    vi.advanceTimersByTime(2500)
+    await waitFor(() => expect(screen.getByRole("button").textContent).toBe("Copy"))
+  })
+
+  describe("edge cases", () => {
+    it("is disabled when the clipboard API is unavailable", () => {
+      vi.stubGlobal("navigator", { ...navigator, clipboard: undefined })
+      render(<CopyButton text="x" />)
+      expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(true)
+    })
+  })
+})

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,6 +1,8 @@
 import { IconCheck, IconCopy, IconX } from "@tabler/icons-react"
+import { AnimatePresence, MotionConfig, motion } from "motion/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/cn"
+import { iconSwapVariants, labelSwapVariants, LAYOUT_TRANSITION, SWAP_TRANSITION } from "@/lib/motion-variants"
 
 type CopyState = "idle" | "copied" | "failed"
 
@@ -13,6 +15,12 @@ const LABEL: Record<CopyState, string> = {
   idle: "Copy",
   copied: "Copied!",
   failed: "Copy failed",
+}
+
+const ICON: Record<CopyState, typeof IconCopy> = {
+  idle: IconCopy,
+  copied: IconCheck,
+  failed: IconX,
 }
 
 interface CopyButtonProps {
@@ -61,30 +69,62 @@ export function CopyButton({ text, className, iconClassName = "size-4", withText
     )
   }, [text, scheduleReset])
 
+  const Icon = ICON[state]
+
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={!canCopy}
-      aria-label="Copy lyrics body to clipboard"
-      aria-live="polite"
-      title="Copy lyrics"
-      className={cn(
-        className,
-        !canCopy && "cursor-not-allowed opacity-60",
-        state === "idle" && "text-unison-text-secondary",
-        state === "copied" && "text-green-500",
-        state === "failed" && "text-amber-500",
-      )}
-    >
-      {state === "copied" ? (
-        <IconCheck className={iconClassName} stroke={1.75} />
-      ) : state === "failed" ? (
-        <IconX className={iconClassName} stroke={1.75} />
-      ) : (
-        <IconCopy className={iconClassName} stroke={1.75} />
-      )}
-      <span className={withText ? undefined : "sr-only"}>{LABEL[state]}</span>
-    </button>
+    <MotionConfig reducedMotion="user">
+      <motion.button
+        layout
+        type="button"
+        onClick={handleClick}
+        disabled={!canCopy}
+        aria-label="Copy lyrics body to clipboard"
+        aria-live="polite"
+        title="Copy lyrics"
+        style={{ borderRadius: 6 }}
+        transition={{ layout: LAYOUT_TRANSITION }}
+        className={cn(
+          className,
+          "relative cursor-pointer whitespace-nowrap",
+          !canCopy && "cursor-not-allowed opacity-60",
+          state === "copied" &&
+            "border-green-500/60 bg-green-500/10 text-green-300 hover:border-green-500/60 hover:bg-green-500/10 hover:text-green-300",
+          state === "failed" &&
+            "border-amber-500/60 bg-amber-500/10 text-amber-300 hover:border-amber-500/60 hover:bg-amber-500/10 hover:text-amber-300",
+        )}
+      >
+        <AnimatePresence initial={false} mode="popLayout">
+          <motion.span
+            key={state}
+            layout
+            variants={iconSwapVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={SWAP_TRANSITION}
+            className="inline-flex"
+          >
+            <Icon className={iconClassName} stroke={1.75} />
+          </motion.span>
+        </AnimatePresence>
+        {withText ? (
+          <AnimatePresence initial={false} mode="popLayout">
+            <motion.span
+              key={LABEL[state]}
+              layout
+              variants={labelSwapVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              transition={SWAP_TRANSITION}
+            >
+              {LABEL[state]}
+            </motion.span>
+          </AnimatePresence>
+        ) : (
+          <span className="sr-only">{LABEL[state]}</span>
+        )}
+      </motion.button>
+    </MotionConfig>
   )
 }

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,90 @@
+import { IconCheck, IconCopy, IconX } from "@tabler/icons-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { cn } from "@/lib/cn"
+
+type CopyState = "idle" | "copied" | "failed"
+
+const RESET_MS: Record<Exclude<CopyState, "idle">, number> = {
+  copied: 1500,
+  failed: 2500,
+}
+
+const LABEL: Record<CopyState, string> = {
+  idle: "Copy",
+  copied: "Copied!",
+  failed: "Copy failed",
+}
+
+interface CopyButtonProps {
+  text: string
+  className?: string
+  iconClassName?: string
+  withText?: boolean
+}
+
+export function CopyButton({ text, className, iconClassName = "size-4", withText = false }: CopyButtonProps) {
+  const [state, setState] = useState<CopyState>("idle")
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const scheduleReset = useCallback((next: Exclude<CopyState, "idle">) => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      if (mountedRef.current) setState("idle")
+    }, RESET_MS[next])
+  }, [])
+
+  const canCopy = typeof navigator !== "undefined" && !!navigator.clipboard
+
+  const handleClick = useCallback(() => {
+    if (!navigator.clipboard) return
+    navigator.clipboard.writeText(text).then(
+      () => {
+        if (!mountedRef.current) return
+        setState("copied")
+        scheduleReset("copied")
+      },
+      () => {
+        if (!mountedRef.current) return
+        setState("failed")
+        scheduleReset("failed")
+      },
+    )
+  }, [text, scheduleReset])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={!canCopy}
+      aria-label="Copy lyrics body to clipboard"
+      aria-live="polite"
+      title="Copy lyrics"
+      className={cn(
+        className,
+        !canCopy && "cursor-not-allowed opacity-60",
+        state === "idle" && "text-unison-text-secondary",
+        state === "copied" && "text-green-500",
+        state === "failed" && "text-amber-500",
+      )}
+    >
+      {state === "copied" ? (
+        <IconCheck className={iconClassName} stroke={1.75} />
+      ) : state === "failed" ? (
+        <IconX className={iconClassName} stroke={1.75} />
+      ) : (
+        <IconCopy className={iconClassName} stroke={1.75} />
+      )}
+      <span className={withText ? undefined : "sr-only"}>{LABEL[state]}</span>
+    </button>
+  )
+}

--- a/web/src/components/DownloadButton.test.tsx
+++ b/web/src/components/DownloadButton.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { DownloadButton } from "./DownloadButton"
+
+afterEach(() => cleanup())
+
+describe("DownloadButton", () => {
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn()
+    render(<DownloadButton onClick={onClick} />)
+    fireEvent.click(screen.getByRole("button", { name: /download lyrics file/i }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire onClick while disabled", () => {
+    const onClick = vi.fn()
+    render(<DownloadButton onClick={onClick} disabled />)
+    fireEvent.click(screen.getByRole("button", { name: /download lyrics file/i }))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/DownloadButton.tsx
+++ b/web/src/components/DownloadButton.tsx
@@ -1,0 +1,31 @@
+import { IconDownload } from "@tabler/icons-react"
+
+interface DownloadButtonProps {
+  onClick: () => void
+  disabled?: boolean
+  className?: string
+  iconClassName?: string
+  withText?: boolean
+}
+
+export function DownloadButton({
+  onClick,
+  disabled,
+  className,
+  iconClassName = "size-4",
+  withText = false,
+}: DownloadButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Download lyrics file"
+      title="Download lyrics"
+      className={className}
+    >
+      <IconDownload className={iconClassName} stroke={1.75} />
+      {withText ? <span>Download</span> : null}
+    </button>
+  )
+}

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { downloadTextFile } from "./download"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("downloadTextFile", () => {
+  it("clicks a transient anchor carrying the filename and body, then revokes the url", async () => {
+    const createObjectURL = vi.fn(() => "blob:mock-url")
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL } as unknown as typeof URL)
+    let anchor: HTMLAnchorElement | undefined
+    const create = document.createElement.bind(document)
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = create(tag)
+      if (tag === "a") anchor = el as HTMLAnchorElement
+      return el
+    })
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+
+    downloadTextFile("Song - Artist.lrc", "[00:01.00]hi", "text/plain;charset=utf-8")
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(anchor?.download).toBe("Song - Artist.lrc")
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    const blob = createObjectURL.mock.calls[0][0] as unknown as Blob
+    expect(blob.type).toBe("text/plain;charset=utf-8")
+    expect(await blob.text()).toBe("[00:01.00]hi")
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url")
+  })
+
+  it("leaves no anchor attached to the document afterward", () => {
+    vi.stubGlobal("URL", { createObjectURL: () => "blob:x", revokeObjectURL: () => {} } as unknown as typeof URL)
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+    const before = document.querySelectorAll("a").length
+    downloadTextFile("f.txt", "x", "text/plain;charset=utf-8")
+    expect(document.querySelectorAll("a").length).toBe(before)
+  })
+})

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 
 describe("downloadTextFile", () => {
   it("clicks a transient anchor carrying the filename and body, then revokes the url", async () => {
-    const createObjectURL = vi.fn(() => "blob:mock-url")
+    const createObjectURL = vi.fn<(blob: Blob) => string>(() => "blob:mock-url")
     const revokeObjectURL = vi.fn()
     vi.stubGlobal("URL", { createObjectURL, revokeObjectURL } as unknown as typeof URL)
     let anchor: HTMLAnchorElement | undefined
@@ -25,7 +25,7 @@ describe("downloadTextFile", () => {
     expect(clickSpy).toHaveBeenCalledTimes(1)
     expect(anchor?.download).toBe("Song - Artist.lrc")
     expect(createObjectURL).toHaveBeenCalledTimes(1)
-    const blob = createObjectURL.mock.calls[0][0] as unknown as Blob
+    const blob = createObjectURL.mock.calls[0][0]
     expect(blob.type).toBe("text/plain;charset=utf-8")
     expect(await blob.text()).toBe("[00:01.00]hi")
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url")

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -1,0 +1,12 @@
+export function downloadTextFile(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = url
+  anchor.download = filename
+  anchor.rel = "noopener"
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}

--- a/web/src/lib/lyrics-download.test.ts
+++ b/web/src/lib/lyrics-download.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+import { EXTENSION_BY_FORMAT, lyricsFilename, MIME_BY_FORMAT, sanitizeFilename } from "./lyrics-download"
+
+describe("lyrics-download", () => {
+  describe("EXTENSION_BY_FORMAT / MIME_BY_FORMAT", () => {
+    it("maps each format to its file extension", () => {
+      expect(EXTENSION_BY_FORMAT.ttml).toBe("ttml")
+      expect(EXTENSION_BY_FORMAT.lrc).toBe("lrc")
+      expect(EXTENSION_BY_FORMAT.plain).toBe("txt")
+    })
+
+    it("serves ttml as xml and the rest as plain text, always utf-8", () => {
+      expect(MIME_BY_FORMAT.ttml).toBe("application/xml;charset=utf-8")
+      expect(MIME_BY_FORMAT.lrc).toBe("text/plain;charset=utf-8")
+      expect(MIME_BY_FORMAT.plain).toBe("text/plain;charset=utf-8")
+    })
+  })
+
+  describe("lyricsFilename", () => {
+    it("builds '<song> - <artist>.<ext>' for each format", () => {
+      expect(lyricsFilename({ song: "Midnight City", artist: "M83", videoId: "v1", format: "ttml" })).toBe(
+        "Midnight City - M83.ttml",
+      )
+      expect(lyricsFilename({ song: "Song", artist: "Artist", videoId: "v1", format: "lrc" })).toBe("Song - Artist.lrc")
+      expect(lyricsFilename({ song: "Song", artist: "Artist", videoId: "v1", format: "plain" })).toBe(
+        "Song - Artist.txt",
+      )
+    })
+
+    describe("edge cases", () => {
+      it("uses only the artist when the song is empty", () => {
+        expect(lyricsFilename({ song: "   ", artist: "M83", videoId: "v1", format: "lrc" })).toBe("M83.lrc")
+      })
+
+      it("uses only the song when the artist is empty", () => {
+        expect(lyricsFilename({ song: "Solo", artist: "", videoId: "v1", format: "lrc" })).toBe("Solo.lrc")
+      })
+
+      it("falls back to the videoId when song and artist are both empty", () => {
+        expect(lyricsFilename({ song: "", artist: "  ", videoId: "dQw4w9WgXcQ", format: "ttml" })).toBe(
+          "dQw4w9WgXcQ.ttml",
+        )
+      })
+
+      it("keeps non-latin characters", () => {
+        expect(lyricsFilename({ song: "夜に駆ける", artist: "YOASOBI", videoId: "v1", format: "lrc" })).toBe(
+          "夜に駆ける - YOASOBI.lrc",
+        )
+      })
+
+      it("strips characters that are invalid in filenames", () => {
+        expect(lyricsFilename({ song: 'A/B:C*?"<>|D', artist: "E\\F", videoId: "v1", format: "plain" })).toBe(
+          "ABCD - EF.txt",
+        )
+      })
+
+      it("collapses internal whitespace and trims edges", () => {
+        expect(
+          lyricsFilename({ song: "  Too   Many   Spaces  ", artist: "The\tBand", videoId: "v1", format: "lrc" }),
+        ).toBe("Too Many Spaces - The Band.lrc")
+      })
+    })
+
+    describe("invariants", () => {
+      it("never contains a path separator", () => {
+        const name = lyricsFilename({ song: "a/b\\c", artist: "d/e\\f", videoId: "g/h", format: "lrc" })
+        expect(name.includes("/")).toBe(false)
+        expect(name.includes("\\")).toBe(false)
+      })
+
+      it("always ends with the extension for the given format", () => {
+        for (const format of ["ttml", "lrc", "plain"] as const) {
+          const name = lyricsFilename({ song: "S", artist: "A", videoId: "v", format })
+          expect(name.endsWith(`.${EXTENSION_BY_FORMAT[format]}`)).toBe(true)
+        }
+      })
+    })
+  })
+
+  describe("sanitizeFilename", () => {
+    it("removes control characters", () => {
+      expect(sanitizeFilename("abcd")).toBe("abcd")
+    })
+
+    it("trims leading and trailing dots and whitespace", () => {
+      expect(sanitizeFilename("  ..name..  ")).toBe("name")
+    })
+
+    it("returns an empty string when nothing survives", () => {
+      expect(sanitizeFilename("///")).toBe("")
+    })
+  })
+})

--- a/web/src/lib/lyrics-download.ts
+++ b/web/src/lib/lyrics-download.ts
@@ -1,0 +1,41 @@
+import type { LyricsFormat } from "@/lib/types"
+
+export const EXTENSION_BY_FORMAT: Record<LyricsFormat, string> = {
+  ttml: "ttml",
+  lrc: "lrc",
+  plain: "txt",
+}
+
+export const MIME_BY_FORMAT: Record<LyricsFormat, string> = {
+  ttml: "application/xml;charset=utf-8",
+  lrc: "text/plain;charset=utf-8",
+  plain: "text/plain;charset=utf-8",
+}
+
+const INVALID_FILENAME_CHARS = /[/\\:*?"<>|]/g
+
+export function sanitizeFilename(name: string): string {
+  const collapsed = name.replace(/\s+/g, " ")
+  let printable = ""
+  for (const ch of collapsed) {
+    const code = ch.codePointAt(0) ?? 0
+    if (code >= 0x20 && code !== 0x7f) printable += ch
+  }
+  return printable
+    .replace(INVALID_FILENAME_CHARS, "")
+    .replace(/^[\s.]+/, "")
+    .replace(/[\s.]+$/, "")
+}
+
+export function lyricsFilename(v: {
+  song: string
+  artist: string
+  videoId: string
+  format: LyricsFormat
+}): string {
+  const song = v.song.trim()
+  const artist = v.artist.trim()
+  const base = song && artist ? `${song} - ${artist}` : song || artist || v.videoId
+  const safe = sanitizeFilename(base) || sanitizeFilename(v.videoId) || "lyrics"
+  return `${safe}.${EXTENSION_BY_FORMAT[v.format]}`
+}

--- a/web/src/lib/motion-variants.test.ts
+++ b/web/src/lib/motion-variants.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { iconSwapVariants, labelSwapVariants } from "./motion-variants"
+
+describe("motion-variants", () => {
+  it("blurs the icon on entry and exit and clears it while visible", () => {
+    expect(iconSwapVariants.initial).toMatchObject({ filter: "blur(2px)" })
+    expect(iconSwapVariants.exit).toMatchObject({ filter: "blur(2px)" })
+    expect(iconSwapVariants.animate).toMatchObject({ filter: "blur(0px)" })
+  })
+
+  it("blurs the label on entry and exit and clears it while visible", () => {
+    expect(labelSwapVariants.initial).toMatchObject({ filter: "blur(2px)" })
+    expect(labelSwapVariants.exit).toMatchObject({ filter: "blur(2px)" })
+    expect(labelSwapVariants.animate).toMatchObject({ filter: "blur(0px)" })
+  })
+
+  it("swaps the label vertically in opposite directions on entry and exit", () => {
+    expect(labelSwapVariants.initial).toMatchObject({ y: 4 })
+    expect(labelSwapVariants.exit).toMatchObject({ y: -4 })
+    expect(labelSwapVariants.animate).toMatchObject({ y: 0 })
+  })
+})

--- a/web/src/lib/motion-variants.ts
+++ b/web/src/lib/motion-variants.ts
@@ -1,0 +1,17 @@
+import type { Transition, Variants } from "motion/react"
+
+export const SWAP_TRANSITION: Transition = { duration: 0.18, ease: "easeInOut" }
+
+export const LAYOUT_TRANSITION: Transition = { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
+
+export const iconSwapVariants: Variants = {
+  initial: { opacity: 0, scale: 0.5, filter: "blur(2px)" },
+  animate: { opacity: 1, scale: 1, filter: "blur(0px)" },
+  exit: { opacity: 0, scale: 0.5, filter: "blur(2px)" },
+}
+
+export const labelSwapVariants: Variants = {
+  initial: { opacity: 0, y: 4, filter: "blur(2px)" },
+  animate: { opacity: 1, y: 0, filter: "blur(0px)" },
+  exit: { opacity: 0, y: -4, filter: "blur(2px)" },
+}

--- a/web/src/pages/LyricsPage.test.tsx
+++ b/web/src/pages/LyricsPage.test.tsx
@@ -48,6 +48,11 @@ vi.mock("@/lib/api", () => ({
   fetchLyricsVariant: (...args: unknown[]) => fetchVariant(...args),
 }))
 
+const downloadTextFile = vi.fn()
+vi.mock("@/lib/download", () => ({
+  downloadTextFile: (...args: unknown[]) => downloadTextFile(...args),
+}))
+
 import { LyricsPage } from "./LyricsPage"
 
 function makeSummary(overrides: Partial<VariantSummary> = {}): VariantSummary {
@@ -98,6 +103,7 @@ beforeEach(() => {
   lastLineClick = null
   fetchVariants.mockReset()
   fetchVariant.mockReset()
+  downloadTextFile.mockReset()
 })
 
 afterEach(() => {
@@ -237,6 +243,46 @@ describe("LyricsPage", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it("downloads the raw body with the native extension from the sidebar button", async () => {
+    fetchVariants.mockResolvedValue({
+      variants: [makeSummary({ id: 1, format: "lrc", song: "Song", artist: "Artist" })],
+    })
+    fetchVariant.mockResolvedValue({
+      variant: makeFull({ id: 1, format: "lrc", song: "Song", artist: "Artist", lyrics: "[00:01.00]hi" }),
+    })
+    renderAt(["/song/v1"])
+    await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
+    const buttons = screen.getAllByRole("button", { name: /download/i })
+    fireEvent.click(buttons[0])
+    expect(downloadTextFile).toHaveBeenCalledWith("Song - Artist.lrc", "[00:01.00]hi", "text/plain;charset=utf-8")
+  })
+
+  it("also downloads from the inline header button", async () => {
+    fetchVariants.mockResolvedValue({
+      variants: [makeSummary({ id: 1, format: "ttml", song: "Song", artist: "Artist" })],
+    })
+    fetchVariant.mockResolvedValue({
+      variant: makeFull({ id: 1, format: "ttml", song: "Song", artist: "Artist", lyrics: "<tt>x</tt>" }),
+    })
+    renderAt(["/song/v1"])
+    await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
+    const buttons = screen.getAllByRole("button", { name: /download/i })
+    expect(buttons.length).toBe(2)
+    fireEvent.click(buttons[1])
+    expect(downloadTextFile).toHaveBeenCalledWith("Song - Artist.ttml", "<tt>x</tt>", "application/xml;charset=utf-8")
+  })
+
+  it("disables the sidebar download until the variant body is loaded", async () => {
+    fetchVariants.mockResolvedValue({ variants: [makeSummary({ id: 1 })] })
+    fetchVariant.mockReturnValue(new Promise(() => {}))
+    renderAt(["/song/v1"])
+    await waitFor(() => expect(screen.getByRole("button", { name: /download/i })).toBeTruthy())
+    const button = screen.getByRole("button", { name: /download/i }) as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+    fireEvent.click(button)
+    expect(downloadTextFile).not.toHaveBeenCalled()
   })
 
   it("renders the hidden banner when the selected variant is hidden", async () => {

--- a/web/src/pages/LyricsPage.test.tsx
+++ b/web/src/pages/LyricsPage.test.tsx
@@ -1,8 +1,25 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MotionGlobalConfig } from "motion/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { VariantFull, VariantSummary } from "@/lib/types"
+
+MotionGlobalConfig.skipAnimations = true
+if (typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false
+    },
+  })
+}
 
 const seekTo = vi.fn()
 const play = vi.fn()

--- a/web/src/pages/LyricsPage.test.tsx
+++ b/web/src/pages/LyricsPage.test.tsx
@@ -195,7 +195,7 @@ describe("LyricsPage", () => {
     renderAt(["/song/v1"])
     await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
     fireEvent.click(screen.getByRole("button", { name: /raw/i }))
-    fireEvent.click(screen.getByRole("button", { name: /copy/i }))
+    fireEvent.click(screen.getAllByRole("button", { name: /copy/i })[0])
     expect(writeText).toHaveBeenCalledWith("to copy")
   })
 
@@ -209,13 +209,15 @@ describe("LyricsPage", () => {
       renderAt(["/song/v1"])
       await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
       fireEvent.click(screen.getByRole("button", { name: /raw/i }))
-      fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+      fireEvent.click(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0])
       await waitFor(() =>
-        expect(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }).textContent).toBe("Copied!"),
+        expect(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0].textContent).toBe(
+          "Copied!",
+        ),
       )
       vi.advanceTimersByTime(1500)
       await waitFor(() =>
-        expect(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }).textContent).toBe("Copy"),
+        expect(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0].textContent).toBe("Copy"),
       )
     } finally {
       vi.useRealTimers()
@@ -232,20 +234,22 @@ describe("LyricsPage", () => {
       renderAt(["/song/v1"])
       await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
       fireEvent.click(screen.getByRole("button", { name: /raw/i }))
-      fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+      fireEvent.click(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0])
       await waitFor(() =>
-        expect(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }).textContent).toBe("Copy failed"),
+        expect(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0].textContent).toBe(
+          "Copy failed",
+        ),
       )
       vi.advanceTimersByTime(2500)
       await waitFor(() =>
-        expect(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }).textContent).toBe("Copy"),
+        expect(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0].textContent).toBe("Copy"),
       )
     } finally {
       vi.useRealTimers()
     }
   })
 
-  it("downloads the raw body with the native extension from the sidebar button", async () => {
+  it("downloads the raw body with the native extension from the header button", async () => {
     fetchVariants.mockResolvedValue({
       variants: [makeSummary({ id: 1, format: "lrc", song: "Song", artist: "Artist" })],
     })
@@ -254,7 +258,7 @@ describe("LyricsPage", () => {
     })
     renderAt(["/song/v1"])
     await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
-    fireEvent.click(screen.getByRole("button", { name: /download/i }))
+    fireEvent.click(screen.getAllByRole("button", { name: /download/i })[0])
     expect(downloadTextFile).toHaveBeenCalledWith("Song - Artist.lrc", "[00:01.00]hi", "text/plain;charset=utf-8")
   })
 
@@ -267,29 +271,27 @@ describe("LyricsPage", () => {
     })
     renderAt(["/song/v1"])
     await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
-    fireEvent.click(screen.getByRole("button", { name: /download/i }))
+    fireEvent.click(screen.getAllByRole("button", { name: /download/i })[0])
     expect(downloadTextFile).toHaveBeenCalledWith("Song - Artist.ttml", "<tt>x</tt>", "application/xml;charset=utf-8")
   })
 
-  it("disables the sidebar download until the variant body is loaded", async () => {
+  it("does not render the action buttons until the variant body is loaded", async () => {
     fetchVariants.mockResolvedValue({ variants: [makeSummary({ id: 1 })] })
     fetchVariant.mockReturnValue(new Promise(() => {}))
     renderAt(["/song/v1"])
-    await waitFor(() => expect(screen.getByRole("button", { name: /download/i })).toBeTruthy())
-    const button = screen.getByRole("button", { name: /download/i }) as HTMLButtonElement
-    expect(button.disabled).toBe(true)
-    fireEvent.click(button)
-    expect(downloadTextFile).not.toHaveBeenCalled()
+    await waitFor(() => expect(screen.getByRole("button", { name: /raw/i })).toBeTruthy())
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull()
+    expect(screen.queryByRole("button", { name: /copy lyrics body to clipboard/i })).toBeNull()
   })
 
-  it("copies from the sidebar while still in synced mode", async () => {
+  it("copies from the header while still in synced mode", async () => {
     fetchVariants.mockResolvedValue({ variants: [makeSummary({ id: 1 })] })
     fetchVariant.mockResolvedValue({ variant: makeFull({ id: 1, lyrics: "sync copy" }) })
     const writeText = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
     renderAt(["/song/v1"])
     await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
-    fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+    fireEvent.click(screen.getAllByRole("button", { name: /copy lyrics body to clipboard/i })[0])
     expect(writeText).toHaveBeenCalledWith("sync copy")
   })
 

--- a/web/src/pages/LyricsPage.test.tsx
+++ b/web/src/pages/LyricsPage.test.tsx
@@ -254,12 +254,11 @@ describe("LyricsPage", () => {
     })
     renderAt(["/song/v1"])
     await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
-    const buttons = screen.getAllByRole("button", { name: /download/i })
-    fireEvent.click(buttons[0])
+    fireEvent.click(screen.getByRole("button", { name: /download/i }))
     expect(downloadTextFile).toHaveBeenCalledWith("Song - Artist.lrc", "[00:01.00]hi", "text/plain;charset=utf-8")
   })
 
-  it("also downloads from the inline header button", async () => {
+  it("uses the xml mime and .ttml extension for a ttml variant", async () => {
     fetchVariants.mockResolvedValue({
       variants: [makeSummary({ id: 1, format: "ttml", song: "Song", artist: "Artist" })],
     })
@@ -268,9 +267,7 @@ describe("LyricsPage", () => {
     })
     renderAt(["/song/v1"])
     await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
-    const buttons = screen.getAllByRole("button", { name: /download/i })
-    expect(buttons.length).toBe(2)
-    fireEvent.click(buttons[1])
+    fireEvent.click(screen.getByRole("button", { name: /download/i }))
     expect(downloadTextFile).toHaveBeenCalledWith("Song - Artist.ttml", "<tt>x</tt>", "application/xml;charset=utf-8")
   })
 
@@ -283,6 +280,17 @@ describe("LyricsPage", () => {
     expect(button.disabled).toBe(true)
     fireEvent.click(button)
     expect(downloadTextFile).not.toHaveBeenCalled()
+  })
+
+  it("copies from the sidebar while still in synced mode", async () => {
+    fetchVariants.mockResolvedValue({ variants: [makeSummary({ id: 1 })] })
+    fetchVariant.mockResolvedValue({ variant: makeFull({ id: 1, lyrics: "sync copy" }) })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
+    renderAt(["/song/v1"])
+    await waitFor(() => expect(screen.getByTestId("lyrics-renderer")).toBeTruthy())
+    fireEvent.click(screen.getByRole("button", { name: /copy lyrics body to clipboard/i }))
+    expect(writeText).toHaveBeenCalledWith("sync copy")
   })
 
   it("renders the hidden banner when the selected variant is hidden", async () => {

--- a/web/src/pages/LyricsPage.tsx
+++ b/web/src/pages/LyricsPage.tsx
@@ -1,4 +1,4 @@
-import { IconBrandYoutube } from "@tabler/icons-react"
+import { IconBrandYoutube, IconDownload } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom"
@@ -13,6 +13,8 @@ import { YouTubeEmbed } from "@/components/YouTubeEmbed"
 import { useYouTubePlayer } from "@/hooks/useYouTubePlayer"
 import { cn } from "@/lib/cn"
 import { fetchLyricsVariant, fetchLyricsVariants } from "@/lib/api"
+import { downloadTextFile } from "@/lib/download"
+import { EXTENSION_BY_FORMAT, lyricsFilename, MIME_BY_FORMAT } from "@/lib/lyrics-download"
 
 type Mode = "synced" | "raw"
 type CopyState = "idle" | "copied" | "failed"
@@ -129,6 +131,12 @@ export function LyricsPage() {
     )
   }, [variantQuery.data, scheduleCopyReset])
 
+  const handleDownload = useCallback(() => {
+    const v = variantQuery.data?.variant
+    if (!v) return
+    downloadTextFile(lyricsFilename(v), v.lyrics, MIME_BY_FORMAT[v.format])
+  }, [variantQuery.data])
+
   if (!videoId) return <EmptyState title="No video specified" />
 
   if (variantsQuery.isLoading) return <LoadingPlaceholder rows={4} />
@@ -173,6 +181,16 @@ export function LyricsPage() {
             <IconBrandYoutube className="size-4" stroke={1.75} />
             Open on YouTube Music
           </a>
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={!variant}
+            aria-label="Download lyrics file"
+            className="flex items-center justify-center gap-2 rounded-md border border-unison-border bg-unison-bg-elevated py-2 pr-4 pl-3 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <IconDownload className="size-4" stroke={1.75} />
+            Download {variant ? EXTENSION_BY_FORMAT[variant.format].toUpperCase() : "lyrics"}
+          </button>
           {variant ? <VariantMetadata variant={variant} /> : null}
         </div>
         <div className="space-y-4">
@@ -205,26 +223,38 @@ export function LyricsPage() {
                   Raw
                 </button>
               </fieldset>
-              {mode === "raw" && variant ? (
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  disabled={!canCopy}
-                  aria-label="Copy lyrics body to clipboard"
-                  aria-live="polite"
-                  className={cn(
-                    "rounded border border-unison-border px-2 py-1 text-xs transition-colors",
-                    canCopy
-                      ? "hover:border-unison-border-strong"
-                      : "cursor-not-allowed text-unison-text-muted opacity-60",
-                    canCopy && copyState === "idle" && "text-unison-text-secondary hover:text-unison-text",
-                    canCopy && copyState === "copied" && "text-green-500",
-                    canCopy && copyState === "failed" && "text-amber-500",
-                  )}
-                >
-                  {COPY_LABEL[copyState]}
-                </button>
-              ) : null}
+              <div className="flex items-center gap-2">
+                {variant ? (
+                  <button
+                    type="button"
+                    onClick={handleDownload}
+                    aria-label="Download lyrics file"
+                    className="rounded border border-unison-border px-2 py-1 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:text-unison-text"
+                  >
+                    Download
+                  </button>
+                ) : null}
+                {mode === "raw" && variant ? (
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    disabled={!canCopy}
+                    aria-label="Copy lyrics body to clipboard"
+                    aria-live="polite"
+                    className={cn(
+                      "rounded border border-unison-border px-2 py-1 text-xs transition-colors",
+                      canCopy
+                        ? "hover:border-unison-border-strong"
+                        : "cursor-not-allowed text-unison-text-muted opacity-60",
+                      canCopy && copyState === "idle" && "text-unison-text-secondary hover:text-unison-text",
+                      canCopy && copyState === "copied" && "text-green-500",
+                      canCopy && copyState === "failed" && "text-amber-500",
+                    )}
+                  >
+                    {COPY_LABEL[copyState]}
+                  </button>
+                ) : null}
+              </div>
             </div>
             <div className="p-4">
               {variantQuery.isLoading || !variant ? (

--- a/web/src/pages/LyricsPage.tsx
+++ b/web/src/pages/LyricsPage.tsx
@@ -21,7 +21,7 @@ import { lyricsFilename, MIME_BY_FORMAT } from "@/lib/lyrics-download"
 type Mode = "synced" | "raw"
 
 const HEADER_ACTION_CLASS =
-  "inline-flex items-center gap-1.5 rounded-md border border-unison-border bg-unison-bg-elevated px-2 py-1 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-unison-border bg-unison-bg-elevated px-2 py-1 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
 
 export function LyricsPage() {
   const { videoId } = useParams<{ videoId: string }>()

--- a/web/src/pages/LyricsPage.tsx
+++ b/web/src/pages/LyricsPage.tsx
@@ -1,7 +1,9 @@
-import { IconBrandYoutube, IconCheck, IconCopy, IconDownload, IconX } from "@tabler/icons-react"
+import { IconBrandYoutube } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom"
+import { CopyButton } from "@/components/CopyButton"
+import { DownloadButton } from "@/components/DownloadButton"
 import { EmptyState } from "@/components/EmptyState"
 import { LoadingPlaceholder } from "@/components/LoadingPlaceholder"
 import { LyricsRenderer } from "@/components/LyricsRenderer"
@@ -17,21 +19,9 @@ import { downloadTextFile } from "@/lib/download"
 import { lyricsFilename, MIME_BY_FORMAT } from "@/lib/lyrics-download"
 
 type Mode = "synced" | "raw"
-type CopyState = "idle" | "copied" | "failed"
 
-const COPY_RESET_MS: Record<Exclude<CopyState, "idle">, number> = {
-  copied: 1500,
-  failed: 2500,
-}
-
-const COPY_LABEL: Record<CopyState, string> = {
-  idle: "Copy",
-  copied: "Copied!",
-  failed: "Copy failed",
-}
-
-const ICON_BUTTON_CLASS =
-  "flex items-center justify-center rounded-md border border-unison-border bg-unison-bg-elevated p-2 text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
+const HEADER_ACTION_CLASS =
+  "inline-flex items-center gap-1.5 rounded-md border border-unison-border bg-unison-bg-elevated px-2 py-1 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
 
 export function LyricsPage() {
   const { videoId } = useParams<{ videoId: string }>()
@@ -94,46 +84,6 @@ export function LyricsPage() {
     [seekTo, play],
   )
 
-  const [copyState, setCopyState] = useState<CopyState>("idle")
-  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const isMountedRef = useRef(true)
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      if (copyResetTimerRef.current !== null) {
-        clearTimeout(copyResetTimerRef.current)
-        copyResetTimerRef.current = null
-      }
-    }
-  }, [])
-
-  const scheduleCopyReset = useCallback((state: Exclude<CopyState, "idle">) => {
-    if (copyResetTimerRef.current !== null) clearTimeout(copyResetTimerRef.current)
-    copyResetTimerRef.current = setTimeout(() => {
-      copyResetTimerRef.current = null
-      if (isMountedRef.current) setCopyState("idle")
-    }, COPY_RESET_MS[state])
-  }, [])
-
-  const handleCopy = useCallback(() => {
-    const body = variantQuery.data?.variant.lyrics
-    if (!body) return
-    if (!navigator.clipboard) return
-    navigator.clipboard.writeText(body).then(
-      () => {
-        if (!isMountedRef.current) return
-        setCopyState("copied")
-        scheduleCopyReset("copied")
-      },
-      () => {
-        if (!isMountedRef.current) return
-        setCopyState("failed")
-        scheduleCopyReset("failed")
-      },
-    )
-  }, [variantQuery.data, scheduleCopyReset])
-
   const handleDownload = useCallback(() => {
     const v = variantQuery.data?.variant
     if (!v) return
@@ -152,7 +102,6 @@ export function LyricsPage() {
   }
 
   const variant = variantQuery.data?.variant
-  const canCopy = typeof navigator !== "undefined" && !!navigator.clipboard
 
   return (
     <div className="space-y-6">
@@ -175,52 +124,15 @@ export function LyricsPage() {
       <div className="grid gap-6 sm:grid-cols-[minmax(0,384px)_minmax(0,1fr)]">
         <div className="space-y-4">
           <YouTubeEmbed playerRef={ref} />
-          <div className="flex items-center gap-2">
-            <a
-              href={`https://music.youtube.com/watch?v=${safeVideoId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Open on YouTube Music"
-              title="Open on YouTube Music"
-              className={ICON_BUTTON_CLASS}
-            >
-              <IconBrandYoutube className="size-4" stroke={1.75} />
-            </a>
-            <button
-              type="button"
-              onClick={handleDownload}
-              disabled={!variant}
-              aria-label="Download lyrics file"
-              title="Download lyrics"
-              className={cn(ICON_BUTTON_CLASS, "disabled:cursor-not-allowed disabled:opacity-60")}
-            >
-              <IconDownload className="size-4" stroke={1.75} />
-            </button>
-            <button
-              type="button"
-              onClick={handleCopy}
-              disabled={!variant || !canCopy}
-              aria-label="Copy lyrics body to clipboard"
-              aria-live="polite"
-              title="Copy lyrics"
-              className={cn(
-                ICON_BUTTON_CLASS,
-                "disabled:cursor-not-allowed disabled:opacity-60",
-                copyState === "idle" && "text-unison-text-secondary",
-                copyState === "copied" && "text-green-500",
-                copyState === "failed" && "text-amber-500",
-              )}
-            >
-              {copyState === "copied" ? (
-                <IconCheck className="size-4" stroke={1.75} />
-              ) : copyState === "failed" ? (
-                <IconX className="size-4" stroke={1.75} />
-              ) : (
-                <IconCopy className="size-4" stroke={1.75} />
-              )}
-              <span className="sr-only">{COPY_LABEL[copyState]}</span>
-            </button>
-          </div>
+          <a
+            href={`https://music.youtube.com/watch?v=${safeVideoId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 rounded-md border border-unison-border bg-unison-bg-elevated py-2 pr-4 pl-3 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
+          >
+            <IconBrandYoutube className="size-4" stroke={1.75} />
+            Open on YouTube Music
+          </a>
           {variant ? <VariantMetadata variant={variant} /> : null}
         </div>
         <div className="space-y-4">
@@ -253,6 +165,17 @@ export function LyricsPage() {
                   Raw
                 </button>
               </fieldset>
+              {variant ? (
+                <div className="flex items-center gap-2">
+                  <DownloadButton
+                    onClick={handleDownload}
+                    className={HEADER_ACTION_CLASS}
+                    iconClassName="size-3.5"
+                    withText
+                  />
+                  <CopyButton text={variant.lyrics} className={HEADER_ACTION_CLASS} iconClassName="size-3.5" withText />
+                </div>
+              ) : null}
             </div>
             <div className="p-4">
               {variantQuery.isLoading || !variant ? (

--- a/web/src/pages/LyricsPage.tsx
+++ b/web/src/pages/LyricsPage.tsx
@@ -1,4 +1,4 @@
-import { IconBrandYoutube, IconDownload } from "@tabler/icons-react"
+import { IconBrandYoutube, IconCheck, IconCopy, IconDownload, IconX } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom"
@@ -14,7 +14,7 @@ import { useYouTubePlayer } from "@/hooks/useYouTubePlayer"
 import { cn } from "@/lib/cn"
 import { fetchLyricsVariant, fetchLyricsVariants } from "@/lib/api"
 import { downloadTextFile } from "@/lib/download"
-import { EXTENSION_BY_FORMAT, lyricsFilename, MIME_BY_FORMAT } from "@/lib/lyrics-download"
+import { lyricsFilename, MIME_BY_FORMAT } from "@/lib/lyrics-download"
 
 type Mode = "synced" | "raw"
 type CopyState = "idle" | "copied" | "failed"
@@ -29,6 +29,9 @@ const COPY_LABEL: Record<CopyState, string> = {
   copied: "Copied!",
   failed: "Copy failed",
 }
+
+const ICON_BUTTON_CLASS =
+  "flex items-center justify-center rounded-md border border-unison-border bg-unison-bg-elevated p-2 text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
 
 export function LyricsPage() {
   const { videoId } = useParams<{ videoId: string }>()
@@ -172,25 +175,52 @@ export function LyricsPage() {
       <div className="grid gap-6 sm:grid-cols-[minmax(0,384px)_minmax(0,1fr)]">
         <div className="space-y-4">
           <YouTubeEmbed playerRef={ref} />
-          <a
-            href={`https://music.youtube.com/watch?v=${safeVideoId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 rounded-md border border-unison-border bg-unison-bg-elevated py-2 pr-4 pl-3 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text"
-          >
-            <IconBrandYoutube className="size-4" stroke={1.75} />
-            Open on YouTube Music
-          </a>
-          <button
-            type="button"
-            onClick={handleDownload}
-            disabled={!variant}
-            aria-label="Download lyrics file"
-            className="flex items-center justify-center gap-2 rounded-md border border-unison-border bg-unison-bg-elevated py-2 pr-4 pl-3 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:bg-unison-bg-hover hover:text-unison-text disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <IconDownload className="size-4" stroke={1.75} />
-            Download {variant ? EXTENSION_BY_FORMAT[variant.format].toUpperCase() : "lyrics"}
-          </button>
+          <div className="flex items-center gap-2">
+            <a
+              href={`https://music.youtube.com/watch?v=${safeVideoId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open on YouTube Music"
+              title="Open on YouTube Music"
+              className={ICON_BUTTON_CLASS}
+            >
+              <IconBrandYoutube className="size-4" stroke={1.75} />
+            </a>
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={!variant}
+              aria-label="Download lyrics file"
+              title="Download lyrics"
+              className={cn(ICON_BUTTON_CLASS, "disabled:cursor-not-allowed disabled:opacity-60")}
+            >
+              <IconDownload className="size-4" stroke={1.75} />
+            </button>
+            <button
+              type="button"
+              onClick={handleCopy}
+              disabled={!variant || !canCopy}
+              aria-label="Copy lyrics body to clipboard"
+              aria-live="polite"
+              title="Copy lyrics"
+              className={cn(
+                ICON_BUTTON_CLASS,
+                "disabled:cursor-not-allowed disabled:opacity-60",
+                copyState === "idle" && "text-unison-text-secondary",
+                copyState === "copied" && "text-green-500",
+                copyState === "failed" && "text-amber-500",
+              )}
+            >
+              {copyState === "copied" ? (
+                <IconCheck className="size-4" stroke={1.75} />
+              ) : copyState === "failed" ? (
+                <IconX className="size-4" stroke={1.75} />
+              ) : (
+                <IconCopy className="size-4" stroke={1.75} />
+              )}
+              <span className="sr-only">{COPY_LABEL[copyState]}</span>
+            </button>
+          </div>
           {variant ? <VariantMetadata variant={variant} /> : null}
         </div>
         <div className="space-y-4">
@@ -223,38 +253,6 @@ export function LyricsPage() {
                   Raw
                 </button>
               </fieldset>
-              <div className="flex items-center gap-2">
-                {variant ? (
-                  <button
-                    type="button"
-                    onClick={handleDownload}
-                    aria-label="Download lyrics file"
-                    className="rounded border border-unison-border px-2 py-1 text-xs text-unison-text-secondary transition-colors hover:border-unison-border-strong hover:text-unison-text"
-                  >
-                    Download
-                  </button>
-                ) : null}
-                {mode === "raw" && variant ? (
-                  <button
-                    type="button"
-                    onClick={handleCopy}
-                    disabled={!canCopy}
-                    aria-label="Copy lyrics body to clipboard"
-                    aria-live="polite"
-                    className={cn(
-                      "rounded border border-unison-border px-2 py-1 text-xs transition-colors",
-                      canCopy
-                        ? "hover:border-unison-border-strong"
-                        : "cursor-not-allowed text-unison-text-muted opacity-60",
-                      canCopy && copyState === "idle" && "text-unison-text-secondary hover:text-unison-text",
-                      canCopy && copyState === "copied" && "text-green-500",
-                      canCopy && copyState === "failed" && "text-amber-500",
-                    )}
-                  >
-                    {COPY_LABEL[copyState]}
-                  </button>
-                ) : null}
-              </div>
             </div>
             <div className="p-4">
               {variantQuery.isLoading || !variant ? (


### PR DESCRIPTION
## Overview

Add Download and Copy buttons to the lyrics panel header on the song page. Download saves the selected variant's stored body exactly as-is in its native format (.ttml, .lrc, or .txt), named after the song and artist, so nothing gets re-encoded or lost. Both controls are now small reusable components, which keeps the copy state logic in one place. Also bumped the braccato lyrics packages to the latest: a clean upgrade with no breaking changes to how we render or parse.
