### PR TITLE
feat(badges): preload badge artwork across the app

### DIFF
--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -1,13 +1,17 @@
 import { AuthProvider } from "@/auth/AuthProvider"
+import type { BadgeImage } from "@/lib/types"
 import { Outlet } from "react-router-dom"
 import { AppHeader } from "./AppHeader"
 import { BadgeAssetPreloader } from "./BadgeAssetPreloader"
 import { ToastViewport } from "./ToastViewport"
 
+// Stable reference so the preloader effect does not re-run on every render.
+const COLOR_VARIANTS: (keyof BadgeImage)[] = ["color"]
+
 export function AppLayout() {
 	return (
 		<AuthProvider>
-			<BadgeAssetPreloader variants={["color"]} fetchPriority="high" />
+			<BadgeAssetPreloader variants={COLOR_VARIANTS} fetchPriority="high" />
 			<div className="min-h-full">
 				<AppHeader />
 				<main className="mx-auto max-w-5xl px-6 py-8">

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -1,11 +1,13 @@
 import { AuthProvider } from "@/auth/AuthProvider"
 import { Outlet } from "react-router-dom"
 import { AppHeader } from "./AppHeader"
+import { BadgeAssetPreloader } from "./BadgeAssetPreloader"
 import { ToastViewport } from "./ToastViewport"
 
 export function AppLayout() {
 	return (
 		<AuthProvider>
+			<BadgeAssetPreloader variants={["color"]} fetchPriority="high" />
 			<div className="min-h-full">
 				<AppHeader />
 				<main className="mx-auto max-w-5xl px-6 py-8">

--- a/web/src/components/BadgeAssetPreloader.test.tsx
+++ b/web/src/components/BadgeAssetPreloader.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, waitFor } from "@testing-library/react"
+import { preload } from "react-dom"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { clearAsyncDataCache } from "@/hooks/useAsyncData"
+import { fetchBadgeCatalogue } from "@/lib/api"
+import type { BadgeCatalogue } from "@/lib/types"
+import { BadgeAssetPreloader } from "./BadgeAssetPreloader"
+
+vi.mock("react-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-dom")>()),
+  preload: vi.fn(),
+}))
+
+vi.mock("@/lib/api", () => ({
+  fetchBadgeCatalogue: vi.fn(),
+}))
+
+const catalogue: BadgeCatalogue = {
+  badges: [
+    {
+      key: "a",
+      name: "A",
+      description: "A",
+      category: "output",
+      kind: "medal",
+      image: { color: "/a-color.svg", mono: "/a-mono.svg", silhouette: "/a-sil.svg" },
+    },
+  ],
+  display: { inlineGlyphs: 3, featuredMax: 3, rarityThreshold: 0.1, categoryOrder: [] },
+}
+
+beforeEach(() => {
+  clearAsyncDataCache()
+  vi.mocked(preload).mockClear()
+  vi.mocked(fetchBadgeCatalogue).mockResolvedValue(catalogue)
+})
+
+afterEach(() => cleanup())
+
+describe("BadgeAssetPreloader", () => {
+  it("preloads the requested variants at the given priority once the catalogue loads", async () => {
+    render(<BadgeAssetPreloader variants={["color"]} fetchPriority="high" />)
+    await waitFor(() => expect(preload).toHaveBeenCalledWith("/a-color.svg", { as: "image", fetchPriority: "high" }))
+    expect(preload).not.toHaveBeenCalledWith("/a-mono.svg", expect.anything())
+    expect(preload).not.toHaveBeenCalledWith("/a-sil.svg", expect.anything())
+  })
+
+  it("renders nothing", () => {
+    const { container } = render(<BadgeAssetPreloader variants={["color"]} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/web/src/components/BadgeAssetPreloader.tsx
+++ b/web/src/components/BadgeAssetPreloader.tsx
@@ -1,0 +1,15 @@
+import { useAsyncData } from "@/hooks/useAsyncData"
+import { usePreloadBadgeAssets } from "@/hooks/usePreloadBadgeAssets"
+import { fetchBadgeCatalogue } from "@/lib/api"
+import type { BadgeImage } from "@/lib/types"
+
+interface BadgeAssetPreloaderProps {
+  variants: (keyof BadgeImage)[]
+  fetchPriority?: "high" | "low" | "auto"
+}
+
+export function BadgeAssetPreloader({ variants, fetchPriority = "high" }: BadgeAssetPreloaderProps) {
+  const state = useAsyncData(fetchBadgeCatalogue, "badges:catalogue")
+  usePreloadBadgeAssets(state.status === "success" ? state.data : undefined, variants, fetchPriority)
+  return null
+}

--- a/web/src/components/BadgeCatalogueContext.tsx
+++ b/web/src/components/BadgeCatalogueContext.tsx
@@ -1,17 +1,22 @@
 import { createContext, type ReactNode, useContext } from "react"
 import { useAsyncData } from "@/hooks/useAsyncData"
+import { usePreloadBadgeAssets } from "@/hooks/usePreloadBadgeAssets"
 import { fetchBadgeCatalogue } from "@/lib/api"
-import type { BadgeCatalogue } from "@/lib/types"
+import type { BadgeCatalogue, BadgeImage } from "@/lib/types"
 
 type CatalogueState =
   | { status: "loading"; data: undefined; error: undefined }
   | { status: "success"; data: BadgeCatalogue; error: undefined }
   | { status: "error"; data: undefined; error: Error }
 
+// Color is preloaded app-wide; these glyphs only appear on badge pages, so they load lazily here.
+const GLYPH_VARIANTS: (keyof BadgeImage)[] = ["mono", "silhouette"]
+
 const BadgeCatalogueContext = createContext<CatalogueState | null>(null)
 
 export function BadgeCatalogueProvider({ children }: { children: ReactNode }) {
   const state = useAsyncData<BadgeCatalogue>(fetchBadgeCatalogue, "badges:catalogue")
+  usePreloadBadgeAssets(state.status === "success" ? state.data : undefined, GLYPH_VARIANTS, "low")
   return <BadgeCatalogueContext.Provider value={state}>{children}</BadgeCatalogueContext.Provider>
 }
 

--- a/web/src/hooks/usePreloadBadgeAssets.test.tsx
+++ b/web/src/hooks/usePreloadBadgeAssets.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react"
+import { preload } from "react-dom"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { BadgeCatalogue } from "@/lib/types"
+import { usePreloadBadgeAssets } from "./usePreloadBadgeAssets"
+
+vi.mock("react-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-dom")>()),
+  preload: vi.fn(),
+}))
+
+const catalogue: BadgeCatalogue = {
+  badges: [
+    {
+      key: "a",
+      name: "A",
+      description: "A",
+      category: "output",
+      kind: "medal",
+      image: { color: "/a-color.svg", mono: "/a-mono.svg", silhouette: "/a-sil.svg" },
+    },
+  ],
+  display: { inlineGlyphs: 3, featuredMax: 3, rarityThreshold: 0.1, categoryOrder: [] },
+}
+
+beforeEach(() => vi.mocked(preload).mockClear())
+afterEach(() => vi.clearAllMocks())
+
+describe("usePreloadBadgeAssets", () => {
+  it("preloads only the requested variants at the given priority", () => {
+    renderHook(() => usePreloadBadgeAssets(catalogue, ["color"], "high"))
+    expect(preload).toHaveBeenCalledWith("/a-color.svg", { as: "image", fetchPriority: "high" })
+    expect(preload).not.toHaveBeenCalledWith("/a-mono.svg", expect.anything())
+    expect(preload).not.toHaveBeenCalledWith("/a-sil.svg", expect.anything())
+  })
+
+  it("preloads the glyph variants at low priority", () => {
+    renderHook(() => usePreloadBadgeAssets(catalogue, ["mono", "silhouette"], "low"))
+    expect(preload).toHaveBeenCalledWith("/a-mono.svg", { as: "image", fetchPriority: "low" })
+    expect(preload).toHaveBeenCalledWith("/a-sil.svg", { as: "image", fetchPriority: "low" })
+    expect(preload).not.toHaveBeenCalledWith("/a-color.svg", expect.anything())
+  })
+
+  it("does nothing until the catalogue is available", () => {
+    renderHook(() => usePreloadBadgeAssets(undefined, ["color"], "high"))
+    expect(preload).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/hooks/usePreloadBadgeAssets.ts
+++ b/web/src/hooks/usePreloadBadgeAssets.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react"
+import { preload } from "react-dom"
+import { collectBadgeAssetUrls } from "@/lib/badge-view"
+import type { BadgeCatalogue, BadgeImage } from "@/lib/types"
+
+export function usePreloadBadgeAssets(
+  catalogue: BadgeCatalogue | undefined,
+  variants: (keyof BadgeImage)[],
+  fetchPriority: "high" | "low" | "auto",
+): void {
+  useEffect(() => {
+    if (!catalogue) return
+    for (const url of collectBadgeAssetUrls(catalogue, variants)) {
+      preload(url, { as: "image", fetchPriority })
+    }
+  }, [catalogue, variants, fetchPriority])
+}

--- a/web/src/lib/badge-view.test.ts
+++ b/web/src/lib/badge-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { groupBadgesByCategory, isRareBadge, resolveBadgeImage } from "./badge-view"
-import type { BadgeDef } from "./types"
+import { collectBadgeAssetUrls, groupBadgesByCategory, isRareBadge, resolveBadgeImage } from "./badge-view"
+import type { BadgeCatalogue, BadgeDef } from "./types"
 
 function def(key: string, category: string, extra: Partial<BadgeDef> = {}): BadgeDef {
   return {
@@ -69,6 +69,56 @@ describe("resolveBadgeImage", () => {
       expect(resolveBadgeImage(def("committee", "special"), 2, "color")).toBe(
         "/badges/committee/image.svg?variant=color",
       )
+    })
+  })
+})
+
+describe("collectBadgeAssetUrls", () => {
+  const catalogue: BadgeCatalogue = {
+    badges: [def("a", "output"), tiered],
+    display: { inlineGlyphs: 3, featuredMax: 3, rarityThreshold: 0.1, categoryOrder: [] },
+  }
+
+  it("collects every image variant for each badge", () => {
+    const urls = collectBadgeAssetUrls(catalogue)
+    expect(urls).toContain("/badges/a/image.svg?variant=color")
+    expect(urls).toContain("/badges/a/image.svg?variant=mono")
+    expect(urls).toContain("/badges/a/image.svg?variant=silhouette")
+  })
+
+  it("includes per-tier images", () => {
+    const urls = collectBadgeAssetUrls(catalogue)
+    expect(urls).toContain("/t1-color")
+    expect(urls).toContain("/t2-color")
+  })
+
+  it("collects only the requested variants when given a subset", () => {
+    const urls = collectBadgeAssetUrls(catalogue, ["color"])
+    expect(urls).toContain("/badges/a/image.svg?variant=color")
+    expect(urls).toContain("/t1-color")
+    expect(urls).not.toContain("/badges/a/image.svg?variant=mono")
+    expect(urls).not.toContain("/badges/a/image.svg?variant=silhouette")
+  })
+
+  describe("edge cases", () => {
+    it("dedupes urls shared across tiers", () => {
+      const urls = collectBadgeAssetUrls(catalogue)
+      expect(urls.filter((u) => u === "/mono")).toHaveLength(1)
+      expect(urls.filter((u) => u === "/sil")).toHaveLength(1)
+    })
+
+    it("skips tiers with no image and never emits an empty url", () => {
+      const urls = collectBadgeAssetUrls(catalogue)
+      expect(urls.every((u) => u.length > 0)).toBe(true)
+    })
+
+    it("returns an empty list for an empty catalogue", () => {
+      expect(
+        collectBadgeAssetUrls({
+          badges: [],
+          display: { inlineGlyphs: 3, featuredMax: 3, rarityThreshold: 0.1, categoryOrder: [] },
+        }),
+      ).toEqual([])
     })
   })
 })

--- a/web/src/lib/badge-view.ts
+++ b/web/src/lib/badge-view.ts
@@ -1,4 +1,25 @@
-import type { BadgeDef, BadgeImage } from "./types"
+import type { BadgeCatalogue, BadgeDef, BadgeImage } from "./types"
+
+const IMAGE_VARIANTS: (keyof BadgeImage)[] = ["color", "mono", "silhouette"]
+
+export function collectBadgeAssetUrls(
+  catalogue: BadgeCatalogue,
+  variants: (keyof BadgeImage)[] = IMAGE_VARIANTS,
+): string[] {
+  const urls = new Set<string>()
+  for (const badge of catalogue.badges) {
+    for (const variant of variants) {
+      if (badge.image[variant]) urls.add(badge.image[variant])
+    }
+    for (const tier of badge.tiers ?? []) {
+      if (!tier.image) continue
+      for (const variant of variants) {
+        if (tier.image[variant]) urls.add(tier.image[variant])
+      }
+    }
+  }
+  return [...urls]
+}
 
 export interface BadgeGroup {
   category: string


### PR DESCRIPTION
## Overview

Preload badge artwork so it's cached before a badge ever renders. The color variants fetch app-wide at high priority on first load, so wherever a badge shows up it's already there. The mono and silhouette glyphs only appear on the badge pages, so they load lazily at low priority once one of those pages mounts, reusing the catalogue that page already fetches. Color art is about 36 KB gzipped; the glyphs only download when you land somewhere that uses them.
